### PR TITLE
Feature/add more endpoints and queryable submissions

### DIFF
--- a/metadata_backend/api/parser.py
+++ b/metadata_backend/api/parser.py
@@ -38,8 +38,8 @@ class SubmissionXMLToJSONParser:
         self._validate(content, schema)
         content_json_raw = schema.to_dict(content, converter=AbderaConverter,
                                           decimal_type=float, dict_class=dict)
-        content_json_raw["accession"] = self._generate_accession()
         content_json_formatted = self._to_lowercase(content_json_raw)
+        content_json_formatted["accessionId"] = self._generate_accessionId()
         return getattr(self, f"_parse_{xml_type}")(content_json_formatted)
 
     def _load_schema(self, xml_type: str) -> XMLSchema:
@@ -72,7 +72,7 @@ class SubmissionXMLToJSONParser:
             raise web.HTTPBadRequest(reason=reason)
 
     @staticmethod
-    def _generate_accession() -> str:
+    def _generate_accessionId() -> str:
         """Generate accession number.
 
         returns: generated accession number

--- a/metadata_backend/api/translator.py
+++ b/metadata_backend/api/translator.py
@@ -3,6 +3,7 @@
 from typing import Dict
 
 from aiohttp import web
+from bson import json_util
 from pymongo import errors
 
 from ..database.db_services import CRUDService, DBService
@@ -25,9 +26,9 @@ class ActionToCRUDTranslator:
         self.submissions = submissions
 
     def add(self, target: Dict) -> None:
-        """Submit new metadata object with ADD action.
+        """Submit new metadata object (ADD action in submission.xml).
 
-        :param target: Attributes for add action, e.g. information on which
+        :param target: Attributes for add action, e.g. information about which
         file to save to database
         :raises: HTTP error when inserting file to database fails
         """
@@ -53,3 +54,23 @@ class ActionToCRUDTranslator:
             reason = f"Error happened when backing up {source} to database."
             raise web.HTTPBadRequest(reason=reason)
         LOG.info(f"Inserting file {source} to database succeeded")
+
+    def get_all(self) -> Dict:
+        """Get all objects from the database.
+
+        Objects are grabbed from all collections with empty query,
+        which in MongoDB returns everything from that collection.
+
+        This will load all the objects into program memory and should
+        since be refactored at some point.
+
+        returns: JSON containing all objects.
+        """
+        schemas = ["study", "sample", "experiment", "run",
+                   "analysis", "dac", "policy", "dataset", "project"]
+
+        objects = []
+        for schema in schemas:
+            objects.extend(list(CRUDService.read(self.submission_db_service,
+                                                 schema, {})))
+        return json_util.dumps(objects)

--- a/metadata_backend/api/translator.py
+++ b/metadata_backend/api/translator.py
@@ -13,29 +13,26 @@ from .parser import SubmissionXMLToJSONParser
 class ActionToCRUDTranslator:
     """Wrapper that turns submission actions to CRUD operations."""
 
-    def __init__(self, submissions: Dict) -> None:
-        """Create needed services for connecting to database.
-
-        :param submissions: Original XML types and contents for each submitted
-        file
-        """
+    def __init__(self) -> None:
+        """Create needed services for connecting to database."""
         self.submission_db_service = DBService("submissions")
         self.backup_db_service = DBService("backups")
         self.parser = SubmissionXMLToJSONParser()
-        self.submissions = submissions
 
-    def add(self, target: Dict) -> Dict:
+    def add(self, target: Dict, submissions: Dict) -> Dict:
         """Submit new metadata object (ADD action in submission.xml).
 
         :param target: Attributes for add action, e.g. information about which
         file to save to database
+        :param submissions: Submission xml data grouped by schemas and
+        filenames
         :raises: HTTP error when inserting file to database fails
         :returns Json containing accession id for object that has been
         inserted to database
         """
         xml_type = target["schema"]
         source = target["source"]
-        content_xml = self.submissions[xml_type][source]
+        content_xml = submissions[xml_type][source]
         content_json = self.parser.parse(xml_type, content_xml)
         backup_json = {"accessionId": content_json["accessionId"],
                        "content": content_xml}

--- a/metadata_backend/api/translator.py
+++ b/metadata_backend/api/translator.py
@@ -37,7 +37,6 @@ class ActionToCRUDTranslator:
         content_xml = self.submissions[xml_type][source]
         content_json = self.parser.parse(xml_type, content_xml)
         backup_json = {"accession": content_json["accession"],
-                       "alias": content_json["alias"],
                        "content": content_xml}
         try:
             CRUDService.create(self.submission_db_service, xml_type,

--- a/metadata_backend/api/translator.py
+++ b/metadata_backend/api/translator.py
@@ -1,5 +1,4 @@
 """Handle translating API endpoint functionalities to CRUD operations."""
-
 from typing import Dict
 
 from aiohttp import web
@@ -57,8 +56,8 @@ class ActionToCRUDTranslator:
         LOG.info(f"Inserting file {source} to database succeeded")
         return content_json["accessionId"]
 
-    def get_object_with_accessionId(self, schema: str,
-                                    accessionId: str) -> Dict:
+    def get_object_with_accessionId(self, schema: str, accessionId: str,
+                                    return_xml: bool) -> Dict:
         """Get object from database according to given accession id.
 
         param: accessionId: Accession id for object to be searched
@@ -67,10 +66,17 @@ class ActionToCRUDTranslator:
         returns: JSON containing all objects.
         """
         try:
-            data = CRUDService.read(self.submission_db_service, schema,
-                                    {"accessionId": accessionId})
+            if return_xml:
+                data_raw = CRUDService.read(self.backup_db_service, schema,
+                                            {"accessionId": accessionId})
+                data = list(data_raw)[0]["content"]
+            else:
+                data_raw = CRUDService.read(self.submission_db_service, schema,
+                                            {"accessionId": accessionId})
+                data = json_util.dumps(data_raw)
+
             if data is not None:
-                return json_util.dumps(data)
+                return data
 
         except errors.PyMongoError as error:
             LOG.info(f"error, reason: {error}")

--- a/metadata_backend/api/views.py
+++ b/metadata_backend/api/views.py
@@ -55,8 +55,21 @@ class SiteHandler:
             for filename in filenames.keys():
                 accessionId = translator.add({"schema": schema,
                                               "source": filename})
-
         return web.Response(body=accessionId)
+
+    async def get_object_from_alias_address(self, req: Request) -> Response:
+        """Redirect requests to /<schema> to /object/<schema>.
+
+        This implements restful way to serve content from canonical uri.
+
+        :param req: GET request
+        :raises: HTTPFound for redirection
+        """
+        accessionId = req.match_info['accessionId']
+        schema = req.match_info['schema']
+        uri = req.app.router['get_object'].url_for(schema=schema,
+                                                   accessionId=accessionId)
+        raise web.HTTPFound(location=uri)
 
     @staticmethod
     def generate_receipt(successful: List, unsuccessful: List) -> str:
@@ -64,8 +77,8 @@ class SiteHandler:
 
         Not currently valid receipt (against schema), will be changed later.
 
-        :param successful: Succesful submissions and their info
-        :param unsuccessful: Unuccesful submissions and their info
+        :param successful: Successful submissions and their info
+        :param unsuccessful: Unsuccessful submissions and their info
         :returns: XML-based receipt
         """
         date = datetime.now()

--- a/metadata_backend/api/views.py
+++ b/metadata_backend/api/views.py
@@ -1,4 +1,5 @@
 """Handle HTTP methods for server."""
+import json
 from datetime import datetime
 from typing import Dict, List, cast
 
@@ -11,6 +12,18 @@ from .translator import ActionToCRUDTranslator
 
 class SiteHandler:
     """Backend HTTP method handler."""
+
+    async def get_object_types(self, req: Request) -> Response:
+        """Get all possible object types from database.
+
+        Basically returns which objects user can submit and query for.
+        :param req: GET Request
+        :returns JSON list of object types
+        """
+        object_types = json.dumps(["submission", "study", "sample",
+                                  "experiment", "run", "analysis", "dac",
+                                   "policy", "dataset", "project"])
+        return web.Response(body=object_types)
 
     async def get_object(self, req: Request) -> Response:
         """Get one object by its accession id.

--- a/metadata_backend/server.py
+++ b/metadata_backend/server.py
@@ -15,7 +15,8 @@ async def init() -> web.Application:
     """Initialise server and setup routes."""
     server = web.Application()
     handler = SiteHandler()
-    routes = [web.get('/object/{schema}/{accessionId}', handler.get_object),
+    routes = [web.get('/objects', handler.get_object_types),
+              web.get('/object/{schema}/{accessionId}', handler.get_object),
               web.post('/object/{schema}', handler.submit_object),
               web.post('/submit', handler.submit)]
     server.router.add_routes(routes)

--- a/metadata_backend/server.py
+++ b/metadata_backend/server.py
@@ -15,7 +15,10 @@ async def init() -> web.Application:
     """Initialise server and setup routes."""
     server = web.Application()
     handler = SiteHandler()
-    server.router.add_post('/submit', handler.submit)
+    routes = [web.get('/objects', handler.get_all_objects),
+              web.post('/objects', handler.submit_object),
+              web.post('/submit', handler.submit)]
+    server.router.add_routes(routes)
     LOG.info("Server configurations and routes loaded")
     return server
 

--- a/metadata_backend/server.py
+++ b/metadata_backend/server.py
@@ -15,8 +15,8 @@ async def init() -> web.Application:
     """Initialise server and setup routes."""
     server = web.Application()
     handler = SiteHandler()
-    routes = [web.get('/objects', handler.get_all_objects),
-              web.post('/objects', handler.submit_object),
+    routes = [web.get('/object/{schema}/{accessionId}', handler.get_object),
+              web.post('/object/{schema}', handler.submit_object),
               web.post('/submit', handler.submit)]
     server.router.add_routes(routes)
     LOG.info("Server configurations and routes loaded")

--- a/metadata_backend/server.py
+++ b/metadata_backend/server.py
@@ -12,12 +12,22 @@ asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
 
 async def init() -> web.Application:
-    """Initialise server and setup routes."""
+    """Initialise server and setup routes.
+
+    Routes should be setup by adding similar paths one after the another. (i.e.
+    POST and GET for same path grouped together). Handler method names should
+    be used for route names, so they're easy to use in other parts of the
+    application.
+
+    """
     server = web.Application()
     handler = SiteHandler()
     routes = [web.get('/objects', handler.get_object_types),
-              web.get('/object/{schema}/{accessionId}', handler.get_object),
+              web.get('/object/{schema}/{accessionId}', handler.get_object,
+                      name='get_object'),
               web.post('/object/{schema}', handler.submit_object),
+              web.get('/{schema}/{accessionId}',
+                      handler.get_object_from_alias_address),
               web.post('/submit', handler.submit)]
     server.router.add_routes(routes)
     LOG.info("Server configurations and routes loaded")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 aiohttp
-gunicorn
 pymongo
 uvloop
 xmlschema

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aiohttp
 pymongo
+python-dateutil
 uvloop
 xmlschema

--- a/tests/api/test_views.py
+++ b/tests/api/test_views.py
@@ -22,8 +22,9 @@ class SiteHandlerTestCase(AioHTTPTestCase):
         """Patch api classes that have been imported to views.py module."""
         class_parser = "metadata_backend.api.views.SubmissionXMLToJSONParser"
         class_translator = "metadata_backend.api.views.ActionToCRUDTranslator"
-        patch_parser = patch(class_parser)
-        patch_translator = patch(class_translator)
+        patch_parser = patch(class_parser, autospec=True)
+        patch_translator = patch(class_translator, autospec=True)
+
         self.MockedParser = patch_parser.start()
         self.MockedTranslator = patch_translator.start()
         self.addCleanup(patch_parser.stop)

--- a/tests/api/test_views.py
+++ b/tests/api/test_views.py
@@ -78,8 +78,3 @@ class SiteHandlerTestCase(AioHTTPTestCase):
         failure_text = "You should submit only one submission.xml file."
         assert response.status == 400
         self.assertIn(failure_text, await response.text())
-
-    # TODO: write following tests: receipt contains fails and messages,
-    # failures in validation with wrong schema etc or with invalid stuff
-    # (especially test response statuses with blackbox testing)
-    # TODO: test receipt does not contain extra messages


### PR DESCRIPTION
### Description

This PR adds some new enpoints and makes submission now more easily queryable from db. Querying enpoint is still under construction. 

There are also little tweaks here and there (try-except checks etc.).

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Changes Made

Folowing endpoints are added:
```
- /objects/
    - GET: Fetches all objects available (study, sample, analysis... etc)
- /objects/<schema>/
    - POST: Adds this type of object to database
- /objects/<schema>/<accessionId>
    - GET: Fetches a single object with its accessionId
        - If extended with ?format=xml, returns originally submitted xml file corresponding this accessionId
- /<schema>/<accessionId>
   - GET: Alias for /objects/<schema>/<accessionId>
```
### Testing
- [x] Needs testing (start an issue or do a follow up PR about it)