### PR TITLE
Feature/improve parsing

### DIFF
--- a/metadata_backend/api/parser.py
+++ b/metadata_backend/api/parser.py
@@ -20,19 +20,34 @@ class SubmissionXMLToJSONParser:
     def parse(self, xml_type: str, content: str) -> Dict:
         """Parse necessary data from XML to make it queryable later.
 
-        All submitted objects first are ran through generic parser,
-        formatted and then passed to specific parser based on objects schema.
+        All submitted objects are first parsed on generic level, then formatted
+        formatted and finally passed to schema-specific parser.
 
         :param xml_type: Submission type (schema) to be used
         :param content: XML content to be parsed
         :returns: XML parsed to JSON
         """
+        # Validate
         schema = self._load_schema(xml_type)
         self._validate(content, schema)
+
+        # Parse json from XML
         content_json_raw = schema.to_dict(content, converter=AbderaConverter,
-                                          decimal_type=float, dict_class=dict)
-        content_json_formatted = self._to_lowercase(content_json_raw)
+                                          decimal_type=float,
+                                          dict_class=dict)[xml_type.upper()]
+
+        # Elevate content from ['children'][0] to top level
+        to_be_elevated = content_json_raw['children'][0]
+        del content_json_raw['children']
+        content_json_elevated = {**content_json_raw, **to_be_elevated}
+
+        # Format content to json-style formatting
+        content_json_formatted = self._to_lowercase(content_json_elevated)
+
+        # Add accessionId
         content_json_formatted["accessionId"] = self._generate_accessionId()
+
+        # Run through schema-specific parser and return the result
         return getattr(self, f"_parse_{xml_type}")(content_json_formatted)
 
     def _load_schema(self, xml_type: str) -> XMLSchema:

--- a/metadata_backend/api/parser.py
+++ b/metadata_backend/api/parser.py
@@ -41,8 +41,11 @@ class SubmissionXMLToJSONParser:
         del content_json_raw['children']
         content_json_elevated = {**content_json_raw, **to_be_elevated}
 
+        # Clear empty lists
+        content_json_cleared = self._remove_empty_lists(content_json_elevated)
+
         # Format content to json-style formatting
-        content_json_formatted = self._to_lowercase(content_json_elevated)
+        content_json_formatted = self._to_lowercase(content_json_cleared)
 
         # Add accessionId
         content_json_formatted["accessionId"] = self._generate_accessionId()
@@ -264,3 +267,9 @@ class SubmissionXMLToJSONParser:
             return _to_camel(obj)
         else:
             return obj
+
+    def _remove_empty_lists(self, obj: Dict) -> Dict:
+        """Parse away empty lists created in xml-json conversion."""
+        return {k: (v if not isinstance(v, dict) else
+                    self._remove_empty_lists(v)) for k, v in
+                obj.items() if v}

--- a/metadata_backend/api/parser.py
+++ b/metadata_backend/api/parser.py
@@ -41,11 +41,8 @@ class SubmissionXMLToJSONParser:
         del content_json_raw['children']
         content_json_elevated = {**content_json_raw, **to_be_elevated}
 
-        # Clear empty lists
-        content_json_cleared = self._remove_empty_lists(content_json_elevated)
-
         # Format content to json-style formatting
-        content_json_formatted = self._to_lowercase(content_json_cleared)
+        content_json_formatted = self._to_lowercase(content_json_elevated)
 
         # Add accessionId
         content_json_formatted["accessionId"] = self._generate_accessionId()
@@ -250,8 +247,11 @@ class SubmissionXMLToJSONParser:
         return sorted(data, key=lambda x: order[x["schema"]])
 
     def _to_lowercase(self, obj: Dict) -> Dict:
-        """Make dictionary lowercase and convert to CamelCase."""
+        """Make dictionary lowercase and convert keys to CamelCase.
 
+        Also clears away any empty elements that xml-json -conversion
+        caused.
+        """
         def _to_camel(name: str) -> str:
             """Convert underscore char notation to CamelCase."""
             _under_regex = re.compile(r'_([a-z])')
@@ -259,17 +259,11 @@ class SubmissionXMLToJSONParser:
 
         if isinstance(obj, dict):
             return {_to_camel(k.lower()): self._to_lowercase(v)
-                    for k, v in obj.items()}
+                    for k, v in obj.items() if v}
         elif isinstance(obj, (list, set, tuple)):
             t = type(obj)
-            return t(self._to_lowercase(o) for o in obj)
+            return t(self._to_lowercase(o) for o in obj if o)
         elif isinstance(obj, str):
             return _to_camel(obj)
         else:
             return obj
-
-    def _remove_empty_lists(self, obj: Dict) -> Dict:
-        """Parse away empty lists created in xml-json conversion."""
-        return {k: (v if not isinstance(v, dict) else
-                    self._remove_empty_lists(v)) for k, v in
-                obj.items() if v}

--- a/tests/api/test_parser.py
+++ b/tests/api/test_parser.py
@@ -1,5 +1,4 @@
 """Test api endpoints from views module."""
-
 from pathlib import Path
 
 from metadata_backend.api.parser import SubmissionXMLToJSONParser
@@ -151,6 +150,6 @@ class ParserTestCase(unittest.TestCase):
                             'submitterId': {
                                 'attributes': {'namespace': 'BGI'},
                                 'children': ['BGI-FC304RWAAXX']}}}
-
-        self.assertTrue("children" not in data['file']['attributes'])
-        self.assertTrue("children" in data['identifiers']['submitterId'])
+        cleaned = self.parser._to_lowercase(data)
+        self.assertTrue("children" not in cleaned['file']['attributes'])
+        self.assertTrue("children" in cleaned['identifiers']['submitterid'])

--- a/tests/api/test_parser.py
+++ b/tests/api/test_parser.py
@@ -55,11 +55,9 @@ class ParserTestCase(unittest.TestCase):
         self.assertEqual(datetime.datetime(2020, 6, 14, 0, 0),
                          study_json['publishDate'])
         self.assertIn("Highly integrated epigenome maps in Arabidopsis",
-                      study_json['study']['children'][0]['descriptor'][
-                          'studyTitle'])
-        self.assertIn("18423832",
-                      study_json['study']['children'][0]['studyLinks'][
-                          'studyLink']['xrefLink']['id'])
+                      study_json['descriptor']['studyTitle'])
+        self.assertIn("18423832", study_json['studyLinks']['studyLink'][
+            'xrefLink']['id'])
 
     def test_sample_is_parsed(self):
         """Test that sample is parsed correctly and accessionId is set.
@@ -70,10 +68,9 @@ class ParserTestCase(unittest.TestCase):
         sample_json = self.parser.parse("sample", sample_xml)
         self.assertEqual(self.mock_accessionId, sample_json['accessionId'])
         self.assertIn("Human HapMap individual NA18758",
-                      sample_json['sample']['children'][0]['description'])
+                      sample_json['description'])
         self.assertIn("Homo sapiens",
-                      sample_json['sample']['children'][0]['sampleName'][
-                          'scientificName'])
+                      sample_json['sampleName']['scientificName'])
 
     def test_experiment_is_parsed(self):
         """Test that experiment is parsed correctly and accessionId is set.
@@ -84,8 +81,7 @@ class ParserTestCase(unittest.TestCase):
         experiment_json = self.parser.parse("experiment", experiment_xml)
         self.assertEqual(self.mock_accessionId, experiment_json['accessionId'])
         self.assertIn("SOLiD sequencing of Human HapMap individual NA18504",
-                      experiment_json['experiment']['children'][0][
-                          'design']['designDescription'])
+                      experiment_json['design']['designDescription'])
 
     def test_run_is_parsed(self):
         """Test that run is parsed correctly and accessionId is set.
@@ -96,11 +92,10 @@ class ParserTestCase(unittest.TestCase):
         run_json = self.parser.parse("run", run_xml)
         self.assertEqual(self.mock_accessionId, run_json['accessionId'])
         self.assertIn("ERA000/ERA000014/srf/BGI-FC304RWAAXX_5.srf",
-                      run_json['run']['children'][0][
-                          'dataBlock']['files']['file']['attributes'][
+                      run_json['dataBlock']['files']['file']['attributes'][
                           'filename'])
-        self.assertIn("ERX000037", run_json['run']['children'][0][
-            'experimentRef']['attributes']['accession'])
+        self.assertIn("ERX000037", run_json['experimentRef']['attributes'][
+            'accession'])
 
     def test_analysis_is_parsed(self):
         """Test that run is parsed correctly and accessionId is set.
@@ -111,10 +106,9 @@ class ParserTestCase(unittest.TestCase):
         analysis_json = self.parser.parse("analysis", analysis_xml)
         pprint(analysis_json)
         self.assertEqual(self.mock_accessionId, analysis_json['accessionId'])
-        self.assertIn("GCA_000001405.1", analysis_json['analysis'][
-            'children'][0][
-            'analysisType']['processedReads']['assembly']['standard'][
-            'attributes']['accession'])
+        self.assertIn("GCA_000001405.1", analysis_json['analysisType'][
+            'processedReads']['assembly']['standard']['attributes'][
+            'accession'])
 
     def test_error_raised_when_schema_not_found(self):
         """Test 400 is returned when schema."""

--- a/tests/api/test_parser.py
+++ b/tests/api/test_parser.py
@@ -2,13 +2,11 @@
 
 from pathlib import Path
 
-
 from metadata_backend.api.parser import SubmissionXMLToJSONParser
 from aiohttp import web
 from metadata_backend.helpers.schema_load import SchemaLoader
 import unittest
 import datetime
-from pprint import pprint
 
 from unittest.mock import patch
 
@@ -104,7 +102,6 @@ class ParserTestCase(unittest.TestCase):
         """
         analysis_xml = self.load_xml_from_file("analysis", "ERZ266973.xml")
         analysis_json = self.parser.parse("analysis", analysis_xml)
-        pprint(analysis_json)
         self.assertEqual(self.mock_accessionId, analysis_json['accessionId'])
         self.assertIn("GCA_000001405.1", analysis_json['analysisType'][
             'processedReads']['assembly']['standard']['attributes'][
@@ -142,3 +139,18 @@ class ParserTestCase(unittest.TestCase):
                      {"schema": "dac", "content": "foo"}]
         sorted_list = self.parser._sort_actions_by_schemas(original_list)
         self.assertEqual(goal_list, sorted_list)
+
+    def test_empty_lists_are_removed_from_json(self):
+        """Check empty lists are removed and non-empty are retained."""
+        data = {'file': {'attributes': {
+            'checksum': '3dfebb4b30211523853805439fbd7cec',
+            'checksumMethod': 'MD5',
+            'filetype': 'srf'},
+            'children': []},
+            'identifiers': {'primaryId': 'ERR000076',
+                            'submitterId': {
+                                'attributes': {'namespace': 'BGI'},
+                                'children': ['BGI-FC304RWAAXX']}}}
+
+        self.assertTrue("children" not in data['file']['attributes'])
+        self.assertTrue("children" in data['identifiers']['submitterId'])


### PR DESCRIPTION
### Description

Adding small fixes to xml-json parsing, which will hopefully make json more readable and easibly queryable

### Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected

### Changes Made
- empty elements (such as key-value pairs where value is empty list) are now cleared from jsons
- there was non-necessary nesting in generated jsons, that is fixed. For example, now `['study']['children'][0]['descriptor']` is just `[descriptor]`, which is a lot easier to handle.

### Testing
- [x] Unit Tests included
