### PR TITLE
Feature/add validation endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ venv.bak/
 ### Editor conficuration files ###
 .vim/
 .idea/
+
+# Mac OS store
+.DS_Store

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -157,8 +157,8 @@ class SubmissionAPIHandler:
         """Validate xml file sent to endpoint.
 
         :param req: Multipart POST request with submission.xml and files
-        :raises: HTTP Exception with status code 400
-        :returns: Text indicating success
+        :raises: HTTP Exception with status code 400 if schema load fails
+        :returns: Json response indicating if validation was successful or not
         """
         files = await _extract_xml_upload(req)
 
@@ -177,12 +177,17 @@ class SubmissionAPIHandler:
             # Error with validating XML syntax
             except ParseError as error:
                 reason = f"Faulty XML file was given. Details: {error}"
-                raise web.HTTPBadRequest(reason=reason)
+                body = json.dumps({"isValid": False, "reason": reason})
+                return web.Response(body=body,
+                                    content_type="application/json")
             # Error with validating XML against schema
             except XMLSchemaValidationError as error:
                 reason = f"XML file is not valid. Details: {error}"
-                raise web.HTTPBadRequest(reason=reason)
-        return web.Response(text="XML file is valid!")
+                body = json.dumps({"isValid": False, "reason": reason})
+                return web.Response(body=body,
+                                    content_type="application/json")
+        body = json.dumps({"isValid": True})
+        return web.Response(body=body, content_type="application/json")
 
     @staticmethod
     def generate_receipt(actions: Dict) -> str:

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -170,12 +170,15 @@ class SubmissionAPIHandler:
                 schema = SchemaLoader().get_schema(xml_type)
                 # Validating requested XML file against the schema
                 schema.validate(xml_content)
+            # Error with loading schema
             except SchemaNotFoundException as error:
                 reason = f"{error} ({xml_type})"
                 raise web.HTTPBadRequest(reason=reason)
+            # Error with validating XML syntax
             except ParseError as error:
                 reason = f"Faulty XML file was given. Details: {error}"
                 raise web.HTTPBadRequest(reason=reason)
+            # Error with validating XML against schema
             except XMLSchemaValidationError as error:
                 reason = f"XML file is not valid. Details: {error}"
                 raise web.HTTPBadRequest(reason=reason)

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -151,8 +151,25 @@ class SubmissionAPIHandler:
         return web.Response(body=receipt, status=201, content_type="text/xml")
 
     async def validate(self, req: Request) -> Response:
-        """Validate xml file sent to endpoint."""
-        return web.Response(text="Validated!")
+        """Validate xml file sent to endpoint.
+
+        :param req: Multipart POST request with submission.xml and files
+        :raises: HTTP Exception with status code 400
+        :returns: Text indicating success
+        """
+        files = await _extract_xml_upload(req)
+
+        # FIX: No errors get raised and method always returns valid
+        for file in files:
+            # Loading schema
+            xml_type = file[1]
+            schema = XMLToJSONParser._load_schema(xml_type)
+
+            # Validating requested XML file against the schema
+            xml_content = file[0]
+            XMLToJSONParser._validate(xml_content, schema)
+
+        return web.Response(text="The file is valid!")
 
     @staticmethod
     def generate_receipt(actions: Dict) -> str:

--- a/tests/test_files/study/SRP000539_invalid2.xml
+++ b/tests/test_files/study/SRP000539_invalid2.xml
@@ -1,0 +1,34 @@
+<STUDY_SET>
+    <STUDY center_name="GEO" alias="GSE10966" accession="SRP000539">
+        <IDENTIFIERS>
+            <PRIMARY_ID>SRP000539</PRIMARY_ID>
+            <EXTERNAL_ID namespace="BioProject" label="primary">PRJNA108793</EXTERNAL_ID>
+            <EXTERNAL_ID namespace="GEO">GSE10966</EXTERNAL_ID>
+        </IDENTIFIERS>
+        <DESCRIPTOR>
+            <STUDY_TITLE>Highly integrated epigenome maps in Arabidopsis - whole genome shotgun bisulfite sequencing
+            </STUDY_TITLE>
+            <STUDY_TYPE existing_study_type="Something wrong"/>
+            <STUDY_ABSTRACT>Part of a set of highly integrated epigenome maps for Arabidopsis thaliana. Keywords:
+                Illumina high-throughput bisulfite sequencing Overall design: Whole genome shotgun bisulfite sequencing
+                of wildtype Arabidopsis plants (Columbia-0), and met1, drm1 drm2 cmt3, and ros1 dml2 dml3 null mutants
+                using the Illumina Genetic Analyzer.
+            </STUDY_ABSTRACT>
+            <CENTER_PROJECT_NAME>GSE10966</CENTER_PROJECT_NAME>
+        </DESCRIPTOR>
+        <STUDY_LINKS>
+            <STUDY_LINK>
+                <XREF_LINK>
+                    <DB>pubmed</DB>
+                    <ID>18423832</ID>
+                </XREF_LINK>
+            </STUDY_LINK>
+        </STUDY_LINKS>
+        <STUDY_ATTRIBUTES>
+            <STUDY_ATTRIBUTE>
+                <TAG>parent_bioproject</TAG>
+                <VALUE>PRJNA107265</VALUE>
+            </STUDY_ATTRIBUTE>
+        </STUDY_ATTRIBUTES>
+    </STUDY>
+</STUDY_SET>

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -54,8 +54,6 @@ class HandlersTestCase(AioHTTPTestCase):
             return_value=self.accession_id,
             autospec=True)
 
-        # Classes below no longer in /metadata_backend/api/handlers.py
-        # Should these be changed to metadata_backend.api.operators... instead?
         class_parser = "metadata_backend.api.handlers.XMLToJSONParser"
         class_operator = "metadata_backend.api.handlers.Operator"
         class_xmloperator = "metadata_backend.api.handlers.XMLOperator"
@@ -208,9 +206,8 @@ class HandlersTestCase(AioHTTPTestCase):
     @unittest_run_loop
     async def test_validation_fails_for_invalid_xml(self):
         """Test that an invalid xml does not validate against its schema."""
-        # FIX: The below should return with a raised error
         files = [("study", "SRP000539_invalid.xml")]
         data = self.create_submission_data(files)
         response = await self.client.post("/validate", data=data)
         self.assertEqual(response.status, 400)
-        self.assertIn("Error", await response.text())
+        self.assertIn("Validation error happened", await response.text())

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -201,7 +201,7 @@ class HandlersTestCase(AioHTTPTestCase):
         data = self.create_submission_data(files)
         response = await self.client.post("/validate", data=data)
         self.assertEqual(response.status, 200)
-        self.assertIn("XML file is valid", await response.text())
+        self.assertIn('{"isValid": true}', await response.text())
 
     @unittest_run_loop
     async def test_validation_fails_for_invalid_xml_syntax(self):
@@ -209,7 +209,7 @@ class HandlersTestCase(AioHTTPTestCase):
         files = [("study", "SRP000539_invalid.xml")]
         data = self.create_submission_data(files)
         response = await self.client.post("/validate", data=data)
-        self.assertEqual(response.status, 400)
+        self.assertEqual(response.status, 200)
         self.assertIn("Faulty XML file was given", await response.text())
 
     @unittest_run_loop
@@ -218,5 +218,5 @@ class HandlersTestCase(AioHTTPTestCase):
         files = [("study", "SRP000539_invalid2.xml")]
         data = self.create_submission_data(files)
         response = await self.client.post("/validate", data=data)
-        self.assertEqual(response.status, 400)
+        self.assertEqual(response.status, 200)
         self.assertIn("XML file is not valid", await response.text())

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -196,18 +196,27 @@ class HandlersTestCase(AioHTTPTestCase):
 
     @unittest_run_loop
     async def test_validation_passes_for_valid_xml(self):
-        """Test that a valid xml validates against the correct schema."""
+        """Test validation endpoint for valid xml."""
         files = [("study", "SRP000539.xml")]
         data = self.create_submission_data(files)
         response = await self.client.post("/validate", data=data)
         self.assertEqual(response.status, 200)
-        self.assertIn("The file is valid!", await response.text())
+        self.assertIn("XML file is valid", await response.text())
 
     @unittest_run_loop
-    async def test_validation_fails_for_invalid_xml(self):
-        """Test that an invalid xml does not validate against its schema."""
+    async def test_validation_fails_for_invalid_xml_syntax(self):
+        """Test validation endpoint for xml with bad syntax."""
         files = [("study", "SRP000539_invalid.xml")]
         data = self.create_submission_data(files)
         response = await self.client.post("/validate", data=data)
         self.assertEqual(response.status, 400)
-        self.assertIn("Validation error happened", await response.text())
+        self.assertIn("Faulty XML file was given", await response.text())
+
+    @unittest_run_loop
+    async def test_validation_fails_for_invalid_xml(self):
+        """Test validation endpoint for invalid xml."""
+        files = [("study", "SRP000539_invalid2.xml")]
+        data = self.create_submission_data(files)
+        response = await self.client.post("/validate", data=data)
+        self.assertEqual(response.status, 400)
+        self.assertIn("XML file is not valid", await response.text())

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -54,6 +54,8 @@ class HandlersTestCase(AioHTTPTestCase):
             return_value=self.accession_id,
             autospec=True)
 
+        # Classes below no longer in /metadata_backend/api/handlers.py
+        # Should these be changed to metadata_backend.api.operators... instead?
         class_parser = "metadata_backend.api.handlers.XMLToJSONParser"
         class_operator = "metadata_backend.api.handlers.Operator"
         class_xmloperator = "metadata_backend.api.handlers.XMLOperator"
@@ -193,3 +195,22 @@ class HandlersTestCase(AioHTTPTestCase):
         args = self.MockedOperator().query_metadata_database.call_args[0]
         assert "study" in args[0]
         assert "studyType': 'foo', 'name': 'bar'" in str(args[1])
+
+    @unittest_run_loop
+    async def test_validation_passes_for_valid_xml(self):
+        """Test that a valid xml validates against the correct schema."""
+        files = [("study", "SRP000539.xml")]
+        data = self.create_submission_data(files)
+        response = await self.client.post("/validate", data=data)
+        self.assertEqual(response.status, 200)
+        self.assertIn("The file is valid!", await response.text())
+
+    @unittest_run_loop
+    async def test_validation_fails_for_invalid_xml(self):
+        """Test that an invalid xml does not validate against its schema."""
+        # FIX: The below should return with a raised error
+        files = [("study", "SRP000539_invalid.xml")]
+        data = self.create_submission_data(files)
+        response = await self.client.post("/validate", data=data)
+        self.assertEqual(response.status, 400)
+        self.assertIn("Error", await response.text())


### PR DESCRIPTION
### Description

PR includes an endpoint for XML validation that responds with a json object that includes boolean value for key "isValid" and a text string for the reason of failure if xml is invalid. Whether or not json response was required for this operation, I found responding with json to be substantially faster for whatever reason when xml was invalid against schema.

### Related issues

Fixes #22 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

- Completed HTTP method for xml validation

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests
