### PR TITLE
Feature/change from pymongo to motor

### DIFF
--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -47,8 +47,8 @@ class RESTApiHandler:
             raise web.HTTPNotFound(reason=reason)
         format = req.query.get("format", "json").lower()
         operator = XMLOperator() if format == "xml" else Operator()
-        data, content_type = operator.read_metadata_object(schema_type,
-                                                           accession_id)
+        data, content_type = await operator.read_metadata_object(schema_type,
+                                                                 accession_id)
         return web.Response(body=data, status=200, content_type=content_type)
 
     async def post_object(self, req: Request) -> Response:
@@ -69,7 +69,8 @@ class RESTApiHandler:
         else:
             content = await req.json()
             operator = Operator()
-        accession_id = operator.create_metadata_object(schema_type, content)
+        accession_id = await operator.create_metadata_object(schema_type,
+                                                             content)
         body = json.dumps({"accessionId": accession_id})
         return web.Response(body=body, status=201,
                             content_type="application/json")

--- a/metadata_backend/api/operators.py
+++ b/metadata_backend/api/operators.py
@@ -9,8 +9,8 @@ from typing import Any, Dict, List, Tuple, Union
 from aiohttp import web
 from bson import json_util
 from dateutil.relativedelta import relativedelta
+from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorCursor
 from multidict import MultiDictProxy
-from motor.motor_asyncio import AsyncIOMotorCursor, AsyncIOMotorClient
 from pymongo.errors import ConnectionFailure, OperationFailure
 
 from ..conf.conf import query_map
@@ -153,7 +153,7 @@ class Operator(BaseOperator):
     Operations are implemented with JSON format.
     """
 
-    def __init__(self, db_client) -> None:
+    def __init__(self, db_client: AsyncIOMotorClient) -> None:
         """Initialize database and content-type.
 
         :param db_client: Motor client used for database connections. Should be
@@ -277,7 +277,7 @@ class XMLOperator(BaseOperator):
     Operations are implemented with XML format.
     """
 
-    def __init__(self, db_client) -> None:
+    def __init__(self, db_client: AsyncIOMotorClient) -> None:
         """Initialize database and content-type.
 
         :param db_client: Motor client used for database connections. Should be

--- a/metadata_backend/api/operators.py
+++ b/metadata_backend/api/operators.py
@@ -52,8 +52,8 @@ class BaseOperator(ABC):
         accession_id = (await self.
                         _format_data_to_create_and_add_to_db(schema_type,
                                                              data))
-        LOG.info(f"""Inserting file to database succeeded: {schema_type}
-                 {accession_id}""")
+        LOG.info(f"Inserting file with schema {schema_type} to database "
+                 f"succeeded with accession id: {accession_id}")
         return accession_id
 
     async def read_metadata_object(self, schema_type: str, accession_id:

--- a/metadata_backend/conf/conf.py
+++ b/metadata_backend/conf/conf.py
@@ -36,17 +36,23 @@ from pathlib import Path
 
 from motor.motor_asyncio import AsyncIOMotorClient
 
+# 1) Set up database client and custom timeouts for spesific parameters.
+# Set custom timeouts and other parameters here so they can be imported to
+# other modules if needed.
 
-# 1) Set up database client and custom timeouts for spesific parameters
+mongo_user = os.getenv("MONGO_INITDB_ROOT_USERNAME", "admin")
+mongo_password = os.getenv("MONGO_INITDB_ROOT_PASSWORD", "admin")
+mongo_host = os.getenv("MONGODB_HOST", "localhost:27017")
+url = f"mongodb://{mongo_user}:{mongo_password}@{mongo_host}"
 serverTimeout = 10000
 connectTimeout = 10000
 
 
-def create_db_client():
-    mongo_user = os.getenv("MONGO_INITDB_ROOT_USERNAME", "admin")
-    mongo_password = os.getenv("MONGO_INITDB_ROOT_PASSWORD", "admin")
-    mongo_host = os.getenv("MONGODB_HOST", "localhost:27017")
-    url = f"mongodb://{mongo_user}:{mongo_password}@{mongo_host}"
+def create_db_client() -> AsyncIOMotorClient:
+    """Initialize database client for AioHTTP App.
+
+    :returns: Coroutine-based Motor client for Mongo operations
+    """
     return AsyncIOMotorClient(url,
                               connectTimeoutMS=connectTimeout,
                               serverSelectionTimeoutMS=serverTimeout)

--- a/metadata_backend/conf/conf.py
+++ b/metadata_backend/conf/conf.py
@@ -37,13 +37,19 @@ from pathlib import Path
 from motor.motor_asyncio import AsyncIOMotorClient
 
 
-# 1) Set up database client
+# 1) Set up database client and custom timeouts for spesific parameters
+serverTimeout = 10000
+connectTimeout = 10000
+
+
 def create_db_client():
     mongo_user = os.getenv("MONGO_INITDB_ROOT_USERNAME", "admin")
     mongo_password = os.getenv("MONGO_INITDB_ROOT_PASSWORD", "admin")
     mongo_host = os.getenv("MONGODB_HOST", "localhost:27017")
     url = f"mongodb://{mongo_user}:{mongo_password}@{mongo_host}"
-    return AsyncIOMotorClient(url)
+    return AsyncIOMotorClient(url,
+                              connectTimeoutMS=connectTimeout,
+                              serverSelectionTimeoutMS=serverTimeout)
 
 
 # 2) Load schema types and descriptions from json

--- a/metadata_backend/conf/conf.py
+++ b/metadata_backend/conf/conf.py
@@ -8,11 +8,14 @@ Currently in use:
 - MONGO_INITDB_ROOT_PASSWORD - Admin password for mongodb
 - MONGODB_HOST - Mongodb server hostname, with port spesified if needed
 
-MongoDB client should be shared across the whole application and always
-imported from this module.
 Admin access is needed in order to create new databases during runtime.
 Default values are the same that are used in docker-compose file
 found from deploy/mongodb.
+
+MongoDB client should be shared across the whole application. Since aiohttp
+discourages usage of singletons, recommended way is to initialize database
+when setting up server and store db to application instance in server.py
+module.
 
 2) Metadata schema types
 Schema types (such as "submission", "study", "sample") are needed in
@@ -33,17 +36,21 @@ from pathlib import Path
 
 from motor.motor_asyncio import AsyncIOMotorClient
 
+
 # 1) Set up database client
-mongo_user = os.getenv("MONGO_INITDB_ROOT_USERNAME", "admin")
-mongo_password = os.getenv("MONGO_INITDB_ROOT_PASSWORD", "admin")
-mongo_host = os.getenv("MONGODB_HOST", "localhost:27017")
-url = f"mongodb://{mongo_user}:{mongo_password}@{mongo_host}"
-db_client = AsyncIOMotorClient(url)
+def create_db_client():
+    mongo_user = os.getenv("MONGO_INITDB_ROOT_USERNAME", "admin")
+    mongo_password = os.getenv("MONGO_INITDB_ROOT_PASSWORD", "admin")
+    mongo_host = os.getenv("MONGODB_HOST", "localhost:27017")
+    url = f"mongodb://{mongo_user}:{mongo_password}@{mongo_host}"
+    return AsyncIOMotorClient(url)
+
 
 # 2) Load schema types and descriptions from json
 path_to_schema_file = Path(__file__).parent / "schemas.json"
 with open(path_to_schema_file) as schema_file:
     schema_types = json.load(schema_file)
+
 
 # 3) Define mapping between url query parameters and mongodb queries
 query_map = {
@@ -75,6 +82,7 @@ query_map = {
                           "keys": ["accessionId", "refname",
                                    "refcenter"]},
 }
+
 
 # 4) Set frontend folder to be inside metadata_backend modules root
 frontend_static_files = Path(__file__).parent.parent / "frontend"

--- a/metadata_backend/conf/conf.py
+++ b/metadata_backend/conf/conf.py
@@ -31,14 +31,14 @@ import json
 import os
 from pathlib import Path
 
-from pymongo import MongoClient
+from motor.motor_asyncio import AsyncIOMotorClient
 
 # 1) Set up database client
 mongo_user = os.getenv("MONGO_INITDB_ROOT_USERNAME", "admin")
 mongo_password = os.getenv("MONGO_INITDB_ROOT_PASSWORD", "admin")
 mongo_host = os.getenv("MONGODB_HOST", "localhost:27017")
 url = f"mongodb://{mongo_user}:{mongo_password}@{mongo_host}"
-db_client = MongoClient(url)
+db_client = AsyncIOMotorClient(url)
 
 # 2) Load schema types and descriptions from json
 path_to_schema_file = Path(__file__).parent / "schemas.json"

--- a/metadata_backend/database/db_service.py
+++ b/metadata_backend/database/db_service.py
@@ -1,9 +1,41 @@
 """Services that handle database connections. Implemented with MongoDB."""
 
-from typing import Dict
+from typing import Dict, Callable, Any
 
 from motor.motor_asyncio import AsyncIOMotorCursor
-from pymongo.errors import ConnectionFailure, OperationFailure
+from pymongo.errors import ConnectionFailure, OperationFailure, AutoReconnect
+from ..helpers.logger import LOG
+import asyncio
+from functools import wraps
+from ..conf.conf import serverTimeout
+
+
+def auto_reconnect(db_func: Callable):
+    """Auto reconnection decorator."""
+    @wraps(db_func)
+    async def retry(*args: Any, **kwargs: Any) -> Any:
+        """Retry given function for many times with increasing interval.
+
+        By default increases interval by clients default timeout for five
+        times and then stops.
+        :returns Async mongodb function passed to decorator
+        :raises ConnectionFailure after 5 retries
+        """
+        interval = serverTimeout
+        for wait_time in range(interval, 5 * interval, interval):
+            try:
+                return await db_func(*args, **kwargs)
+            except AutoReconnect:
+                i = int(wait_time / 10)
+                if i == 5:
+                    message = f"Connection to database failed after {i} tries"
+                    raise ConnectionFailure(message=message)
+                LOG.info("Connection not successful, trying to reconnect."
+                         f"Reconnection attempt number {i}, waiting for "
+                         f"{serverTimeout/1000 + wait_time} seconds")
+                await asyncio.sleep(wait_time)
+                continue
+    return retry
 
 
 class DBService:
@@ -27,83 +59,72 @@ class DBService:
         self.db_client = db_client
         self.database = db_client[database_name]
 
+    @auto_reconnect
     async def create(self, collection: str, document: Dict) -> bool:
         """Insert document to collection in database.
 
         :param collection: Collection where document should be inserted
         :param document: Document to be inserted
-        :raises: Error when write fails for any Mongodb related reason
         :returns: True if operation was successful
         """
-        try:
-            result = await self.database[collection].insert_one(document)
-            return result.acknowledged
-        except (ConnectionFailure, OperationFailure):
-            raise
+        result = await self.database[collection].insert_one(document)
+        return result.acknowledged
 
+    @auto_reconnect
     async def read(self, collection: str, accession_id: str) -> Dict:
         """Find object by its accessionId.
 
         :param collection: Collection where document should be searched from
         :param accession_id: Accession id of the document to be searched
-        :returns: First document matching the query
-        :raises: Error when read fails for any Mongodb related reason
+        :returns: First document matching the accession_id
         """
-        try:
-            find_by_id_query = {"accessionId": accession_id}
-            return await self.database[collection].find_one(find_by_id_query)
-        except (ConnectionFailure, OperationFailure):
-            raise
+        find_by_id_query = {"accessionId": accession_id}
+        return await self.database[collection].find_one(find_by_id_query)
 
+    @auto_reconnect
     async def update(self, collection: str, accession_id: str,
-                     data_to_be_updated: Dict) -> None:
+                     data_to_be_updated: Dict) -> bool:
         """Update some elements of object by its accessionId.
 
         :param collection: Collection where document should be searched from
         :param accession_id: Accession id for object to be updated
         :param data_to_be_updated: JSON representing the data that should be
         updated to object, can replace previous fields and add new ones.
-        :raises: Error when read fails for any Mongodb related reason
+        :returns: True if operation was successful
         """
-        try:
-            find_by_id_query = {"accessionId": accession_id}
-            update_operation = {"$set": data_to_be_updated}
-            await self.database[collection].update_one(find_by_id_query,
-                                                       update_operation)
-        except (ConnectionFailure, OperationFailure):
-            raise
+        find_by_id_query = {"accessionId": accession_id}
+        update_operation = {"$set": data_to_be_updated}
+        result = await self.database[collection].update_one(find_by_id_query,
+                                                            update_operation)
+        return result.acknowledged
 
+    @auto_reconnect
     async def replace(self, collection: str, accession_id: str,
-                      data_to_be_updated: Dict) -> None:
+                      new_data: Dict) -> None:
         """Replace whole object by its accessionId.
 
         :param collection: Collection where document should be searched from
         :param accession_id: Accession id for object to be updated
-        :param data_to_be_updated: JSON representing the data that replaces
+        :param new_data: JSON representing the data that replaces
         old data
-        :raises: Error when read fails for any Mongodb related reason
+        :returns: True if operation was successful
         """
-        try:
-            find_by_id_query = {"accessionId": accession_id}
-            await self.database[collection].replace_one(find_by_id_query,
-                                                        data_to_be_updated)
-        except (ConnectionFailure, OperationFailure):
-            raise
+        find_by_id_query = {"accessionId": accession_id}
+        result = await self.database[collection].replace_one(find_by_id_query,
+                                                             new_data)
+        return result.acknowledged
 
+    @auto_reconnect
     async def delete(self, collection: str, accession_id: str) -> None:
         """Delete object by its accessionId.
 
         :param collection: Collection where document should be searched from
         :param accession_id: Accession id for object to be updated
-        :raises: Error when read fails for any Mongodb related reason
+        :returns: True if operation was successful
         """
-        try:
-            find_by_id_query = {"accessionId": accession_id}
-            result = (await self.database[collection].
-                      delete_one(find_by_id_query))
-            return result.acknowledged
-        except (ConnectionFailure, OperationFailure):
-            raise
+        find_by_id_query = {"accessionId": accession_id}
+        result = await self.database[collection].delete_one(find_by_id_query)
+        return result.acknowledged
 
     def query(self, collection: str, query: Dict) -> AsyncIOMotorCursor:
         """Query database with given query.

--- a/metadata_backend/database/db_service.py
+++ b/metadata_backend/database/db_service.py
@@ -21,7 +21,7 @@ def auto_reconnect(db_func: Callable):
         :returns Async mongodb function passed to decorator
         :raises ConnectionFailure after 5 retries
         """
-        interval = serverTimeout
+        interval = serverTimeout // 1000
         for wait_time in range(interval, 5 * interval, interval):
             try:
                 return await db_func(*args, **kwargs)

--- a/metadata_backend/database/db_service.py
+++ b/metadata_backend/database/db_service.py
@@ -1,16 +1,17 @@
 """Services that handle database connections. Implemented with MongoDB."""
 
-from typing import Dict, Callable, Any
-
-from motor.motor_asyncio import AsyncIOMotorCursor
-from pymongo.errors import ConnectionFailure, OperationFailure, AutoReconnect
-from ..helpers.logger import LOG
 import asyncio
 from functools import wraps
+from typing import Any, Callable, Dict
+
+from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorCursor
+from pymongo.errors import AutoReconnect, ConnectionFailure, OperationFailure
+
 from ..conf.conf import serverTimeout
+from ..helpers.logger import LOG
 
 
-def auto_reconnect(db_func: Callable):
+def auto_reconnect(db_func: Callable) -> Callable:
     """Auto reconnection decorator."""
     @wraps(db_func)
     async def retry(*args: Any, **kwargs: Any) -> Any:
@@ -53,7 +54,8 @@ class DBService:
     automatically.
     """
 
-    def __init__(self, database_name: str, db_client) -> None:
+    def __init__(self, database_name: str,
+                 db_client: AsyncIOMotorClient) -> None:
         """Create service for given database.
 
         Service will have read-write access to given database. Database will be

--- a/metadata_backend/database/db_service.py
+++ b/metadata_backend/database/db_service.py
@@ -67,6 +67,9 @@ class DBService:
         :param document: Document to be inserted
         :returns: True if operation was successful
         """
+        LOG.info(self.database)
+        collection = self.database[collection]
+        LOG.info(collection)
         result = await self.database[collection].insert_one(document)
         return result.acknowledged
 

--- a/metadata_backend/database/db_service.py
+++ b/metadata_backend/database/db_service.py
@@ -4,7 +4,6 @@ from typing import Dict
 
 from motor.motor_asyncio import AsyncIOMotorCursor
 from pymongo.errors import ConnectionFailure, OperationFailure
-from ..helpers.logger import LOG
 
 
 class DBService:
@@ -100,7 +99,9 @@ class DBService:
         """
         try:
             find_by_id_query = {"accessionId": accession_id}
-            await self.database[collection].delete_one(find_by_id_query)
+            result = (await self.database[collection].
+                      delete_one(find_by_id_query))
+            return result.acknowledged
         except (ConnectionFailure, OperationFailure):
             raise
 

--- a/metadata_backend/database/db_service.py
+++ b/metadata_backend/database/db_service.py
@@ -67,9 +67,6 @@ class DBService:
         :param document: Document to be inserted
         :returns: True if operation was successful
         """
-        LOG.info(self.database)
-        collection = self.database[collection]
-        LOG.info(collection)
         result = await self.database[collection].insert_one(document)
         return result.acknowledged
 

--- a/metadata_backend/server.py
+++ b/metadata_backend/server.py
@@ -7,7 +7,7 @@ from aiohttp import web
 
 from .api.handlers import RESTApiHandler, StaticHandler, SubmissionAPIHandler
 from .api.middlewares import error_middleware
-from .conf.conf import frontend_static_files, create_db_client
+from .conf.conf import create_db_client, frontend_static_files
 from .helpers.logger import LOG
 
 asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())

--- a/metadata_backend/server.py
+++ b/metadata_backend/server.py
@@ -7,7 +7,7 @@ from aiohttp import web
 
 from .api.handlers import RESTApiHandler, StaticHandler, SubmissionAPIHandler
 from .api.middlewares import error_middleware
-from .conf.conf import frontend_static_files
+from .conf.conf import frontend_static_files, create_db_client
 from .helpers.logger import LOG
 
 asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())

--- a/metadata_backend/server.py
+++ b/metadata_backend/server.py
@@ -46,6 +46,8 @@ async def init() -> web.Application:
         ]
         server.router.add_routes(frontend_routes)
         LOG.info("Frontend routes loaded")
+    server['db_client'] = create_db_client()
+    LOG.info("Database client loaded")
     return server
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 aiohttp
 gunicorn
 pymongo
+motor
 python-dateutil
 uvloop
 xmlschema>=1.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 aiohttp
 gunicorn
-pymongo
 motor
 python-dateutil
 uvloop

--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,7 @@ setup(
     install_requires=requirements,
 
     extras_require={
-        'test': ['coverage', 'pytest', 'pytest-cov', 'coveralls', 'tox',
-                 'mongomock'],
+        'test': ['coverage', 'pytest', 'pytest-cov', 'coveralls', 'tox'],
         'docs': ['sphinx >= 1.4', 'sphinx_rtd_theme'],
     },
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,8 @@ setup(
     install_requires=requirements,
 
     extras_require={
-        'test': ['coverage', 'pytest', 'pytest-cov', 'coveralls', 'tox'],
+        'test': ['aiounittest', 'coverage', 'coveralls', 'pytest',
+                 'pytest-cov', 'tox'],
         'docs': ['sphinx >= 1.4', 'sphinx_rtd_theme'],
     },
 

--- a/tests/coveralls.py
+++ b/tests/coveralls.py
@@ -9,7 +9,7 @@ from subprocess import call
 if __name__ == '__main__':
     if 'COVERALLS_REPO_TOKEN' in os.environ:
         rc = call('coveralls')
-        sys.stdout.write("Coveralls report from TRAVIS CI.\n")
+        sys.stdout.write("Coveralls report from Github Actions.\n")
         raise SystemExit(rc)
     else:
-        sys.stdout.write("Not on TRAVIS CI.\n")
+        sys.stdout.write("Not on Github Actions.\n")

--- a/tests/test_db_service.py
+++ b/tests/test_db_service.py
@@ -1,87 +1,49 @@
 """Test db_services."""
 import copy
-import unittest
-import mongomock
+from mongomock import MongoClient
+from aiounittest import AsyncTestCase, futurized
+from mock import MagicMock, Mock
+from pymongo.results import InsertOneResult
 
 from metadata_backend.database.db_service import DBService
 
 
-class DatabaseTestCase(unittest.TestCase):
+class DatabaseTestCase(AsyncTestCase):
     """Test different database operations."""
 
     def setUp(self):
-        """Setup test service with mongomock client."""
-        self.test_service = DBService("test", mongomock.MongoClient())
+        """Setup test service with mock client.
+
+        Monkey patches MagicMock to work with async / await, then adds
+        return values for used pymongo methods.
+
+        Tests should be using collection "test" inside database "test" to
+        ensure they work with correct mocked values.
+        """
+        async def async_patch():
+            pass
+        MagicMock.__await__ = lambda x: async_patch().__await__()
+
+        self.client = MagicMock()
+        self.database = MagicMock()
+        self.collection = MagicMock()
+        self.client.__getitem__.return_value = self.database
+        self.database.__getitem__.return_value = self.collection
+        self.test_service = DBService("test", self.client)
 
     def test_db_services_share_mongodb_client(self):
         """Test client is shared across different db_service_objects."""
-        foo = DBService("foo", mongomock.MongoClient())
-        bar = DBService("bar", mongomock.MongoClient())
-        assert foo.database.client == bar.database.client
+        foo = DBService("foo", self.client)
+        bar = DBService("bar", self.client)
+        assert foo.db_client is bar.db_client
 
-    async def test_crud_create_and_read_works(self):
+    async def test_create_works(self):
         """Test that basic crud stuff works as expected."""
+        self.collection.insert_one.return_value = futurized(
+            InsertOneResult("EGA123456", True)
+        )
         data = {"accessionId": "EGA123456",
-                'identifiers': {'primaryId': 'ERR000076',
-                                'submitterId': {
-                                    'attributes': {'namespace': 'BGI'},
-                                    'children': ['BGI-FC304RWAAXX']}}}
-        # Since mongomock is essentially in-memory mongodb, we want to use
-        # copies to avoid side effects
-        await self.test_service.create("test", copy.deepcopy(data))
-        # Read
-        results = self.test_service.read("test", "EGA123456")
-        del results["_id"]
-        assert results == data
-
-    def test_crud_update_works(self):
-        """Test that update operation works as expected."""
-        data = {"accessionId": "EGA123456",
-                'identifiers': {'primaryId': 'ERR000076',
-                                'submitterId': {
-                                    'attributes': {'namespace': 'BGI'},
-                                    'children': ['BGI-FC304RWAAXX']}}}
-        self.test_service.create("test", copy.deepcopy(data))
-        # Update
-        update_data = {"identifiers.submitterId.attributes.namespace": "ABC"}
-        self.test_service.update("test", "EGA123456", update_data)
-        # Read
-        results = self.test_service.read("test", "EGA123456")
-        del results["_id"]
-        goal_data = {"accessionId": "EGA123456",
-                     'identifiers': {'primaryId': 'ERR000076',
-                                     'submitterId': {
-                                         'attributes': {'namespace': 'ABC'},
-                                         'children': ['BGI-FC304RWAAXX']}}}
-        assert results == goal_data
-
-    def test_crud_replace_works(self):
-        """Test that replace operation works as expected."""
-        data = {"accessionId": "EGA123456",
-                'identifiers': {'primaryId': 'ERR000076',
-                                'submitterId': {
-                                    'attributes': {'namespace': 'BGI'},
-                                    'children': ['BGI-FC304RWAAXX']}}}
-        self.test_service.create("test", copy.deepcopy(data))
-        # Update
-        new_data = {"accessionId": "EGA123456",
-                    'identifiers': {'primaryId': 'ERNMAGE111',
-                                    'foo': 'bar'}}
-        self.test_service.replace("test", "EGA123456", copy.deepcopy(new_data))
-        # Read
-        results = self.test_service.read("test", "EGA123456")
-        del results["_id"]
-        assert results == new_data
-
-    def test_crud_delete_works(self):
-        """Test that replace operation works as expected."""
-        data = {"accessionId": "EGA123456",
-                'identifiers': {'primaryId': 'ERR000076',
-                                'submitterId': {
-                                    'attributes': {'namespace': 'BGI'},
-                                    'children': ['BGI-FC304RWAAXX']}}}
-        self.test_service.create("test", copy.deepcopy(data))
-        self.test_service.delete("test", "EGA123456")
-        # Read
-        results = self.test_service.read("test", "EGA123456")
-        assert results is None
+                'identifiers': ["foo", "bar"]
+                }
+        success = await self.test_service.create("test", data)
+        assert success

--- a/tests/test_db_service.py
+++ b/tests/test_db_service.py
@@ -20,7 +20,6 @@ class DatabaseTestCase(AsyncTestCase):
         async def async_patch():
             pass
         MagicMock.__await__ = lambda x: async_patch().__await__()
-
         self.client = MagicMock()
         self.database = MagicMock()
         self.collection = MagicMock()

--- a/tests/test_db_service.py
+++ b/tests/test_db_service.py
@@ -1,6 +1,6 @@
 """Test db_services."""
 from aiounittest import AsyncTestCase, futurized
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 from pymongo.results import InsertOneResult, UpdateResult, DeleteResult
 from pymongo.errors import AutoReconnect, ConnectionFailure
 from bson import ObjectId

--- a/tests/test_db_service.py
+++ b/tests/test_db_service.py
@@ -12,10 +12,13 @@ class DatabaseTestCase(AsyncTestCase):
     """Test different database operations."""
 
     def setUp(self):
-        """Setup test service with mock client.
+        """Initialize test service with mock client.
 
         Monkey patches MagicMock to work with async / await, then sets up
         client->database->collection -structure pymongo uses.
+
+        Monkey patching can probably be removed when upgrading requirements to
+        python 3.8+ since Mock 4.0+ library has async version of MagicMock.
         """
         async def async_patch():
             pass

--- a/tests/test_db_service.py
+++ b/tests/test_db_service.py
@@ -101,10 +101,10 @@ class DatabaseTestCase(AsyncTestCase):
                                                            self.id_stub})
         assert success
 
-    @patch("metadata_backend.database.db_service.serverTimeout", 0)
     async def test_db_operation_is_retried_with_increasing_interval(self):
         """Patch timeout to be 0 sec instead of default, test autoreconnect."""
         self.collection.insert_one.side_effect = AutoReconnect
-        with self.assertRaises(ConnectionFailure):
-            await self.test_service.create("test", self.data_stub)
+        with patch("metadata_backend.database.db_service.serverTimeout", 0):
+            with self.assertRaises(ConnectionFailure):
+                await self.test_service.create("test", self.data_stub)
         assert self.collection.insert_one.call_count == 5

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37},flake8,isort,mypy,docs, unit_tests
+envlist = flake8, isort, mypy, docs, unit_tests
 skipsdist = True
 
 [flake8]


### PR DESCRIPTION
### Description

This PR changes underlying database operations to be coroutine-based (by replacing Pymongo with Motor) and adds retryable database operations. 

### Related issues
Fixes #32 

### Type of change
- [x] Refactor

### Changes Made
- Change operations in db_services module to be async
- Change operations in operators module to be async
- Change calls for operators in handlers module to be async
- Fix database client sharing to work through aiohttp app, recommended by aiohttp docs, see: https://docs.aiohttp.org/en/stable/web_advanced.html#data-sharing-aka-no-singletons-please (otherwise motor is not always using the same loop than aiohttp which creates problems)
- Refactor away some shared code in methods in operators module
- Fix tests for db, operators and handlers, remove mongomock library since it supports only blocking operations. 

### Testing

- [x] Unit Tests
