### PR TITLE
Feature/modify tox and gh action configs for better local usage

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -8,7 +8,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.6, 3.7]
+        python-version: [3.7]
       
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -27,8 +27,10 @@ jobs:
         python -m pip install --upgrade pip
         pip install tox tox-gh-actions
     - name: Run unit tests for python 3.6
+      if: ${{ matrix.python-version == '3.6' }}
       run: tox -e py36
     - name: Run unit tests for python 3.7
+      if: ${{ matrix.python-version == '3.7' }}
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
       run: tox -e py37

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -26,7 +26,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install tox tox-gh-actions
-    - name: Run unit tests
+    - name: Run unit tests for python 3.6
+      run: tox -e py36
+    - name: Run unit tests for python 3.7
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-      run: tox -e unit_tests
+      run: tox -e py37

--- a/docs/specification.yml
+++ b/docs/specification.yml
@@ -321,9 +321,9 @@ paths:
         description: filter objects in schema using accession ID
         schema:
           type: string
+        required: true
       - name: format
         in: query
-        name: page
         schema:
           type: string
         description: Set response content-type. Will be JSON by default, use XML if you want originally submitted XML file.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8, isort, mypy, docs, unit_tests
+envlist = py36, py37, flake8, isort, mypy, docs
 skipsdist = True
 
 [flake8]
@@ -42,7 +42,7 @@ deps =
 # could be done at some point.
 commands = mypy --ignore-missing-imports metadata_backend/
 
-[testenv:unit_tests]
+[testenv]
 passenv = COVERALLS_REPO_TOKEN
 deps =
     .[test]
@@ -53,5 +53,5 @@ commands = py.test -x --cov=metadata_backend tests/
 
 [gh-actions]
 python =
-    3.6: flake8, unit_tests, docs, isort, mypy
-    3.7: flake8, unit_tests, docs, isort, mypy
+    3.6: py36
+    3.7: flake8, py37, docs, isort, mypy


### PR DESCRIPTION
### Description

This PR re-introduces possibility to use py36 and py37 envs locally.

Also fixes tiny typo in api specs, which caused swagger to fail rendering.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made
- changed tox and gh actions configs

### Testing

- [x] Tests do not apply

@blankdots Merge #70 first