### PR TITLE
Feature/add pagination

### DIFF
--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -93,10 +93,22 @@ class RESTApiHandler:
         if format == "xml":
             reason = "xml-formatted query results are not supported"
             raise web.HTTPBadRequest(reason=reason)
+        try:
+            page_num = int(req.query.get("page", 1))
+        except ValueError:
+            reason = f"page must a number, now it was {req.query.get('page')}"
+            raise web.HTTPBadRequest(reason=reason)
+        try:
+            page_size = int(req.query.get("per_page", 10))
+        except ValueError:
+            reason = ("per_page must a number, but it was "
+                      f"{req.query.get('per_page')}")
+            raise web.HTTPBadRequest(reason=reason)
         db_client = req.app['db_client']
         data, page_num, page_size = await (Operator(db_client)
                                            .query_metadata_database(
-                                           schema_type, req.query))
+                                           schema_type, req.query, page_num,
+                                           page_size))
         result = json.dumps({
             "page": {
                 "page": page_num,

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -135,7 +135,7 @@ class RESTApiHandler:
         schema_type = req.match_info['schema']
         if schema_type not in schema_types.keys():
             reason = f"Theres no schema {schema_type}"
-            raise web.HTTPBadRequest(reason=reason)
+            raise web.HTTPNotFound(reason=reason)
         accession_id = req.match_info['accessionId']
         db_client = req.app['db_client']
         await Operator(db_client).delete_metadata_object(schema_type,

--- a/metadata_backend/api/operators.py
+++ b/metadata_backend/api/operators.py
@@ -196,7 +196,6 @@ class Operator(BaseOperator):
                     mongo_query = {query_map[query]: regx}
         try:
             cursor = self.db_service.query(schema_type, mongo_query)
-            LOG.info(cursor)
         except (ConnectionFailure, OperationFailure) as error:
             reason = f"Error happened while getting file: {error}"
             raise web.HTTPBadRequest(reason=reason)

--- a/metadata_backend/api/operators.py
+++ b/metadata_backend/api/operators.py
@@ -164,9 +164,8 @@ class Operator(BaseOperator):
 
     async def query_metadata_database(self, schema_type: str,
                                       que: MultiDictProxy,
-                                      page_size: int = 10,
-                                      page_num: int = 1) -> Tuple[Dict, int,
-                                                                  int]:
+                                      page_num: int, page_size: int
+                                      ) -> Tuple[Dict, int, int]:
         """Query database based on url query parameters.
 
         Url queries are mapped to mongodb queries based on query_map in
@@ -205,6 +204,7 @@ class Operator(BaseOperator):
         data = await self._format_read_data(schema_type, cursor)
         if not data:
             raise web.HTTPNotFound
+        page_size = len(data) if len(data) != page_size else page_size
         return data, page_num, page_size
 
     async def _format_data_to_create_and_add_to_db(self, schema_type: str,

--- a/metadata_backend/api/operators.py
+++ b/metadata_backend/api/operators.py
@@ -165,7 +165,7 @@ class Operator(BaseOperator):
     async def query_metadata_database(self, schema_type: str,
                                       que: MultiDictProxy,
                                       page_num: int, page_size: int
-                                      ) -> Tuple[Dict, int, int]:
+                                      ) -> Tuple[Dict, int, int, int]:
         """Query database based on url query parameters.
 
         Url queries are mapped to mongodb queries based on query_map in
@@ -177,6 +177,7 @@ class Operator(BaseOperator):
         :param page_num: Page number
         :raises: HTTPBadRequest if error happened when connection to database
         and HTTPNotFound error if file with given accession id is not found.
+        :returns: Query result with pagination numbers
         """
         # Generate mongodb query from query parameters
         mongo_query: Dict = {}
@@ -205,7 +206,9 @@ class Operator(BaseOperator):
         if not data:
             raise web.HTTPNotFound
         page_size = len(data) if len(data) != page_size else page_size
-        return data, page_num, page_size
+        total_objects = await self.db_service.get_count(schema_type,
+                                                        mongo_query)
+        return data, page_num, page_size, total_objects
 
     async def _format_data_to_create_and_add_to_db(self, schema_type: str,
                                                    data: Dict) -> str:

--- a/metadata_backend/database/db_service.py
+++ b/metadata_backend/database/db_service.py
@@ -5,7 +5,7 @@ from functools import wraps
 from typing import Any, Callable, Dict
 
 from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorCursor
-from pymongo.errors import AutoReconnect, ConnectionFailure, OperationFailure
+from pymongo.errors import AutoReconnect, ConnectionFailure
 
 from ..conf.conf import serverTimeout
 from ..helpers.logger import LOG
@@ -34,9 +34,9 @@ def auto_reconnect(db_func: Callable) -> Callable:
                     message = (f"Connection to database failed after {attempt}"
                                "tries")
                     raise ConnectionFailure(message=message)
-                LOG.info("Connection not successful, trying to reconnect."
-                         f"Reconnection attempt number {attempt}, waiting for "
-                         f"{default_timeout + wait_time} seconds")
+                LOG.error("Connection not successful, trying to reconnect."
+                          f"Reconnection attempt number {attempt}, waiting "
+                          f" for {default_timeout + wait_time} seconds.")
                 await asyncio.sleep(wait_time)
                 wait_time += default_timeout
                 continue
@@ -143,7 +143,4 @@ class DBService:
         :returns: Async cursor instance which should be awaited when iterating
         :raises: Error when read fails for any Mongodb related reason
         """
-        try:
-            return self.database[collection].find(query)
-        except (ConnectionFailure, OperationFailure):
-            raise
+        return self.database[collection].find(query)

--- a/metadata_backend/database/db_service.py
+++ b/metadata_backend/database/db_service.py
@@ -141,6 +141,15 @@ class DBService:
         :param collection: Collection where document should be searched from
         :param query: query to be used
         :returns: Async cursor instance which should be awaited when iterating
-        :raises: Error when read fails for any Mongodb related reason
         """
         return self.database[collection].find(query)
+
+    @auto_reconnect
+    async def get_count(self, collection: str, query: Dict) -> int:
+        """Get (estimated) count of documents matching given query.
+
+        :param collection: Collection where document should be searched from
+        :param query: query to be used
+        :returns: Estimate of the number of documents
+        """
+        return await self.database[collection].count_documents(query)

--- a/tests/test_db_service.py
+++ b/tests/test_db_service.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 from pymongo.results import InsertOneResult, UpdateResult, DeleteResult
 from pymongo.errors import AutoReconnect, ConnectionFailure
 from bson import ObjectId
+from motor.motor_asyncio import AsyncIOMotorCursor
 
 from metadata_backend.database.db_service import DBService
 
@@ -100,6 +101,13 @@ class DatabaseTestCase(AsyncTestCase):
         self.collection.delete_one.assert_called_once_with({"accessionId":
                                                            self.id_stub})
         assert success
+
+    def test_query_executes_find(self):
+        """Test that find is executed, so cursor is returned."""
+        self.collection.find.return_value = AsyncIOMotorCursor(None, None)
+        cursor = self.test_service.query("test", {})
+        assert type(cursor) == AsyncIOMotorCursor
+        self.collection.find.assert_called_once_with({})
 
     async def test_db_operation_is_retried_with_increasing_interval(self):
         """Patch timeout to be 0 sec instead of default, test autoreconnect."""

--- a/tests/test_db_service.py
+++ b/tests/test_db_service.py
@@ -39,7 +39,7 @@ class DatabaseTestCase(AsyncTestCase):
         """Test client is shared across different db_service_objects."""
         foo = DBService("foo", self.client)
         bar = DBService("bar", self.client)
-        self.assertEqual(foo.db_client, bar.db_client)
+        self.assertIs(foo.db_client, bar.db_client)
 
     async def test_create_inserts_data(self):
         """Test that create method works and returns success."""

--- a/tests/test_db_service.py
+++ b/tests/test_db_service.py
@@ -97,7 +97,7 @@ class DatabaseTestCase(AsyncTestCase):
         self.collection.delete_one.return_value = futurized(
             DeleteResult({}, True)
         )
-        success = await self.test_service.delete("yolo", self.id_stub)
+        success = await self.test_service.delete("test", self.id_stub)
         self.collection.delete_one.assert_called_once_with({"accessionId":
                                                            self.id_stub})
         assert success
@@ -108,6 +108,13 @@ class DatabaseTestCase(AsyncTestCase):
         cursor = self.test_service.query("test", {})
         assert type(cursor) == AsyncIOMotorCursor
         self.collection.find.assert_called_once_with({})
+
+    async def test_count_returns_amount(self):
+        """Test that get_count method works and returns amount."""
+        self.collection.count_documents.return_value = futurized(100)
+        count = await self.test_service.get_count("test", {})
+        self.collection.count_documents.assert_called_once_with({})
+        assert count == 100
 
     async def test_db_operation_is_retried_with_increasing_interval(self):
         """Patch timeout to be 0 sec instead of default, test autoreconnect."""

--- a/tests/test_db_service.py
+++ b/tests/test_db_service.py
@@ -39,7 +39,7 @@ class DatabaseTestCase(AsyncTestCase):
         """Test client is shared across different db_service_objects."""
         foo = DBService("foo", self.client)
         bar = DBService("bar", self.client)
-        assert foo.db_client is bar.db_client
+        self.assertEqual(foo.db_client, bar.db_client)
 
     async def test_create_inserts_data(self):
         """Test that create method works and returns success."""
@@ -48,7 +48,7 @@ class DatabaseTestCase(AsyncTestCase):
         )
         success = await self.test_service.create("test", self.data_stub)
         self.collection.insert_one.assert_called_once_with(self.data_stub)
-        assert success
+        self.assertTrue(success)
 
     async def test_create_reports_fail_correctly(self):
         """Test that failure is reported, when write not acknowledged."""
@@ -57,13 +57,13 @@ class DatabaseTestCase(AsyncTestCase):
         )
         success = await self.test_service.create("test", self.data_stub)
         self.collection.insert_one.assert_called_once_with(self.data_stub)
-        assert not success
+        self.assertFalse(success)
 
     async def test_read_returns_data(self):
         """Test that read method works and returns data."""
         self.collection.find_one.return_value = futurized(self.data_stub)
         found_doc = await self.test_service.read("test", self.id_stub)
-        assert found_doc == self.data_stub
+        self.assertEqual(found_doc, self.data_stub)
         self.collection.find_one.assert_called_once_with({"accessionId":
                                                           self.id_stub})
 
@@ -78,7 +78,7 @@ class DatabaseTestCase(AsyncTestCase):
                                                             self.id_stub},
                                                            {"$set":
                                                             self.data_stub})
-        assert success
+        self.assertTrue(success)
 
     async def test_replace_replaces_data(self):
         """Test that replace method works and returns success."""
@@ -90,7 +90,7 @@ class DatabaseTestCase(AsyncTestCase):
         self.collection.replace_one.assert_called_once_with({"accessionId":
                                                             self.id_stub},
                                                             self.data_stub)
-        assert success
+        self.assertTrue(success)
 
     async def test_delete_deletes_data(self):
         """Test that delete method works and returns success."""
@@ -100,13 +100,13 @@ class DatabaseTestCase(AsyncTestCase):
         success = await self.test_service.delete("test", self.id_stub)
         self.collection.delete_one.assert_called_once_with({"accessionId":
                                                            self.id_stub})
-        assert success
+        self.assertTrue(success)
 
     def test_query_executes_find(self):
         """Test that find is executed, so cursor is returned."""
         self.collection.find.return_value = AsyncIOMotorCursor(None, None)
         cursor = self.test_service.query("test", {})
-        assert type(cursor) == AsyncIOMotorCursor
+        self.assertEqual(type(cursor), AsyncIOMotorCursor)
         self.collection.find.assert_called_once_with({})
 
     async def test_count_returns_amount(self):
@@ -114,7 +114,7 @@ class DatabaseTestCase(AsyncTestCase):
         self.collection.count_documents.return_value = futurized(100)
         count = await self.test_service.get_count("test", {})
         self.collection.count_documents.assert_called_once_with({})
-        assert count == 100
+        self.assertEqual(count, 100)
 
     async def test_db_operation_is_retried_with_increasing_interval(self):
         """Patch timeout to be 0 sec instead of default, test autoreconnect."""
@@ -122,4 +122,4 @@ class DatabaseTestCase(AsyncTestCase):
         with patch("metadata_backend.database.db_service.serverTimeout", 0):
             with self.assertRaises(ConnectionFailure):
                 await self.test_service.create("test", self.data_stub)
-        assert self.collection.insert_one.call_count == 5
+        self.assertEqual(self.collection.insert_one.call_count, 5)

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -122,8 +122,8 @@ class HandlersTestCase(AioHTTPTestCase):
         files = [("submission", "ERA521986_valid.xml")]
         data = self.create_submission_data(files)
         response = await self.client.post("/submit", data=data)
-        assert response.status == 201
-        assert response.content_type == "application/json"
+        self.assertEqual(response.status, 201)
+        self.assertEqual(response.content_type, "application/json")
 
     @unittest_run_loop
     async def test_submit_endpoint_fails_without_submission_xml(self):
@@ -135,7 +135,7 @@ class HandlersTestCase(AioHTTPTestCase):
         data = self.create_submission_data(files)
         response = await self.client.post("/submit", data=data)
         failure_text = "There must be a submission.xml file in submission."
-        assert response.status == 400
+        self.assertEqual(response.status, 400)
         self.assertIn(failure_text, await response.text())
 
     @unittest_run_loop
@@ -149,7 +149,7 @@ class HandlersTestCase(AioHTTPTestCase):
         data = self.create_submission_data(files)
         response = await self.client.post("/submit", data=data)
         failure_text = "You should submit only one submission.xml file."
-        assert response.status == 400
+        self.assertEqual(response.status, 400)
         self.assertIn(failure_text, await response.text())
 
     @unittest_run_loop
@@ -168,7 +168,7 @@ class HandlersTestCase(AioHTTPTestCase):
         files = [("study", "SRP000539.xml")]
         data = self.create_submission_data(files)
         response = await self.client.post("/objects/study", data=data)
-        assert response.status == 201
+        self.assertEqual(response.status, 201)
         self.assertIn(self.test_ega_string, await response.text())
         self.MockedXMLOperator().create_metadata_object.assert_called_once()
 
@@ -178,7 +178,7 @@ class HandlersTestCase(AioHTTPTestCase):
         json_req = {"centerName": "GEO",
                     "alias": "GSE10966"}
         response = await self.client.post("/objects/study", json=json_req)
-        assert response.status == 201
+        self.assertEqual(response.status, 201)
         self.assertIn(self.test_ega_string, await response.text())
         self.MockedOperator().create_metadata_object.assert_called_once()
 
@@ -198,8 +198,8 @@ class HandlersTestCase(AioHTTPTestCase):
         """Test that accessionId returns correct json object."""
         url = f"/objects/study/{self.query_accessionId}"
         response = await self.client.get(url)
-        assert response.status == 200
-        assert response.content_type == "application/json"
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.content_type, "application/json")
         self.assertEqual(self.metadata_json, await response.json())
 
     @unittest_run_loop
@@ -207,8 +207,8 @@ class HandlersTestCase(AioHTTPTestCase):
         """Test that accessionId  with xml query returns xml object."""
         url = f"/objects/study/{self.query_accessionId}"
         response = await self.client.get(f"{url}?format=xml")
-        assert response.status == 200
-        assert response.content_type == "text/xml"
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.content_type, "text/xml")
         self.assertEqual(self.metadata_xml, await response.text())
 
     @unittest_run_loop
@@ -217,28 +217,28 @@ class HandlersTestCase(AioHTTPTestCase):
         url = (f"/objects/study?studyType=foo&name=bar&page={self.page_num}"
                f"&per_page={self.page_size}")
         response = await self.client.get(url)
-        assert response.status == 200
-        assert response.content_type == "application/json"
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.content_type, "application/json")
         json_resp = await response.json()
-        assert json_resp["page"]["page"] == self.page_num
-        assert json_resp["page"]["size"] == self.page_size
-        assert json_resp["page"]["totalPages"] == (self.total_objects
-                                                   / self.page_size)
-        assert json_resp["page"]["totalObjects"] == self.total_objects
-        assert json_resp["objects"][0] == self.metadata_json
+        self.assertEqual(json_resp["page"]["page"], self.page_num)
+        self.assertEqual(json_resp["page"]["size"], self.page_size)
+        self.assertEqual(json_resp["page"]["totalPages"], (self.total_objects
+                                                           / self.page_size))
+        self.assertEqual(json_resp["page"]["totalObjects"], self.total_objects)
+        self.assertEqual(json_resp["objects"][0], self.metadata_json)
         self.MockedOperator().query_metadata_database.assert_called_once()
         args = self.MockedOperator().query_metadata_database.call_args[0]
-        assert "study" == args[0]
-        assert "studyType': 'foo', 'name': 'bar'" in str(args[1])
-        assert self.page_num == args[2]
-        assert self.page_size == args[3]
+        self.assertEqual("study", args[0])
+        self.assertIn("studyType': 'foo', 'name': 'bar'", str(args[1]))
+        self.assertEqual(self.page_num, args[2])
+        self.assertEqual(self.page_size, args[3])
 
     @unittest_run_loop
     async def test_delete_is_called(self):
         """Test query method calls operator and returns status correctly."""
         url = "/objects/study/EGA123456"
         response = await self.client.delete(url)
-        assert response.status == 204
+        self.assertEqual(response.status, 204)
         self.MockedOperator().delete_metadata_object.assert_called_once()
 
     @unittest_run_loop
@@ -246,8 +246,8 @@ class HandlersTestCase(AioHTTPTestCase):
         """Test query method calls operator and returns status correctly."""
         url = "/objects/study?studyType=foo&name=bar&format=xml"
         response = await self.client.get(url)
-        assert response.status == 400
         json_resp = await response.json()
+        self.assertEqual(response.status, 400)
         self.assertIn("xml-formatted query results are not supported",
                       json_resp["detail"])
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -90,7 +90,8 @@ class HandlersTestCase(AioHTTPTestCase):
         """Fake read operation to return mocked json."""
         return await futurized((self.metadata_json, "application/json"))
 
-    async def fake_operator_query_metadata_object(self, schema_type, query):
+    async def fake_operator_query_metadata_object(self, schema_type, query,
+                                                  page_num, page_size):
         """Fake query operation to return list containing mocked json."""
         return await futurized(([self.metadata_json], self.page_num,
                                self.page_size))

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -292,13 +292,34 @@ class HandlersTestCase(AioHTTPTestCase):
         self.assertIn(reason, await response.text())
 
     @unittest_run_loop
-    async def test_post_and_get_fail_for_wrong_schema_type(self):
+    async def test_operations_fail_for_wrong_schema_type(self):
         """Test 404 error is raised if incorrect schema name is given."""
         get_resp = await self.client.get("/objects/bad_scehma_name/some_id")
         self.assertEqual(get_resp.status, 404)
         json_get_resp = await get_resp.json()
         self.assertIn("Theres no schema", json_get_resp['detail'])
+
         post_rep = await self.client.post("/objects/bad_scehma_name")
         self.assertEqual(post_rep.status, 404)
         post_json_rep = await post_rep.json()
         self.assertIn("Theres no schema", post_json_rep['detail'])
+
+        get_resp = await self.client.get("/objects/bad_scehma_name")
+        self.assertEqual(get_resp.status, 404)
+        json_get_resp = await get_resp.json()
+        self.assertIn("Theres no schema", json_get_resp['detail'])
+
+        get_resp = await self.client.delete("/objects/bad_scehma_name/some_id")
+        self.assertEqual(get_resp.status, 404)
+        json_get_resp = await get_resp.json()
+        self.assertIn("Theres no schema", json_get_resp['detail'])
+
+    @unittest_run_loop
+    async def test_query_with_invalid_pagination_params(self):
+        """Test that 400s are raised correctly with pagination."""
+        get_resp = await self.client.get("/objects/study?page=2?title=joo")
+        self.assertEqual(get_resp.status, 400)
+        get_resp = await self.client.get("/objects/study?page=0")
+        self.assertEqual(get_resp.status, 400)
+        get_resp = await self.client.get("/objects/study?per_page=0")
+        self.assertEqual(get_resp.status, 400)

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -81,11 +81,11 @@ class TestOperators(AsyncTestCase):
         read_data, c_type = await operator.read_metadata_object("sample",
                                                                 "EGA123456")
         operator.db_service.read.assert_called_once_with("sample", "EGA123456")
-        assert c_type == "application/json"
-        assert read_data == {"dateCreated": "2020-06-14T00:00:00",
-                             "dateModified": "2020-06-14T00:00:00",
-                             "accessionId": "EGA123456",
-                             "foo": "bar"}
+        self.assertEqual(c_type, "application/json")
+        self.assertEqual(read_data, {"dateCreated": "2020-06-14T00:00:00",
+                                     "dateModified": "2020-06-14T00:00:00",
+                                     "accessionId": "EGA123456",
+                                     "foo": "bar"})
 
     async def test_reading_metadata_works_with_xml(self):
         """Test xml is read from db correctly."""
@@ -98,8 +98,8 @@ class TestOperators(AsyncTestCase):
         r_data, c_type = await operator.read_metadata_object("sample",
                                                              "EGA123456")
         operator.db_service.read.assert_called_once_with("sample", "EGA123456")
-        assert c_type == "text/xml"
-        assert r_data == data["content"]
+        self.assertEqual(c_type, "text/xml")
+        self.assertEqual(r_data, data["content"])
 
     async def test_reading_with_non_valid_id_raises_error(self):
         """Test HTTPNotFound is raised."""
@@ -127,9 +127,9 @@ class TestOperators(AsyncTestCase):
             "dateModified": datetime.datetime(2020, 6, 14, 0, 0)
         }
         result = Operator(self.client)._format_single_dict("study", study_test)
-        assert result["publishDate"] == "2020-06-14T00:00:00"
-        assert result["dateCreated"] == "2020-06-14T00:00:00"
-        assert result["dateModified"] == "2020-06-14T00:00:00"
+        self.assertEqual(result["publishDate"], "2020-06-14T00:00:00")
+        self.assertEqual(result["dateCreated"], "2020-06-14T00:00:00")
+        self.assertEqual(result["dateModified"], "2020-06-14T00:00:00")
         with self.assertRaises(KeyError):
             result["_Id"]
 
@@ -139,7 +139,7 @@ class TestOperators(AsyncTestCase):
         operator.db_service.create.return_value = futurized(True)
         accession = await operator.create_metadata_object("study", {})
         operator.db_service.create.assert_called_once()
-        assert accession == self.accession_id
+        self.assertEqual(accession, self.accession_id)
 
     async def test_xml_create_passes_and_returns_accessionId(self):
         """Test create method for xml works. Patch json related calls."""
@@ -153,7 +153,7 @@ class TestOperators(AsyncTestCase):
                 accession = await operator.create_metadata_object(
                     "study", "<TEST></TEST>")
         operator.db_service.create.assert_called_once()
-        assert accession == self.accession_id
+        self.assertEqual(accession, self.accession_id)
 
     async def test_correct_data_is_set_to_json_when_creating(self):
         """Test operator creates object and adds necessary info."""
@@ -170,7 +170,7 @@ class TestOperators(AsyncTestCase):
                               "dateCreated": datetime.datetime(2020, 4, 14),
                               "dateModified": datetime.datetime(2020, 4, 14),
                               "publishDate": datetime.datetime(2020, 6, 14)})
-            assert acc == self.accession_id
+            self.assertEqual(acc, self.accession_id)
 
     async def test_correct_data_is_set_to_xml_when_creating(self):
         """Test XMLoperator creates object and adds necessary info."""
@@ -191,7 +191,7 @@ class TestOperators(AsyncTestCase):
                     m_insert.assert_called_once_with("study", {
                         "accessionId": self.accession_id,
                         "content": xml_data})
-                    assert acc == self.accession_id
+                    self.assertEqual(acc, self.accession_id)
 
     async def test_deleting_metadata_deletes_json_and_xml(self):
         """Test xml is read from db correctly."""
@@ -199,7 +199,7 @@ class TestOperators(AsyncTestCase):
         operator.db_service.db_client = self.client
         operator.db_service.delete.return_value = futurized(True)
         await operator.delete_metadata_object("sample", "EGA123456")
-        assert operator.db_service.delete.call_count == 2
+        self.assertEqual(operator.db_service.delete.call_count, 2)
         operator.db_service.delete.assert_called_with("sample", "EGA123456")
 
     async def test_working_query_params_are_passed_to_db_query(self):
@@ -273,12 +273,12 @@ class TestOperators(AsyncTestCase):
         parsed, page_num, page_size, total_objects = (
             await operator.query_metadata_database("sample", query, 1, 10))
         for doc in parsed:
-            assert doc["dateCreated"] == "2020-06-14T00:00:00"
-            assert doc["dateModified"] == "2020-06-14T00:00:00"
-            assert doc["accessionId"] == "EGA123456"
-        assert page_num == 1
-        assert page_size == 2
-        assert total_objects == 100
+            self.assertEqual(doc["dateCreated"], "2020-06-14T00:00:00")
+            self.assertEqual(doc["dateModified"], "2020-06-14T00:00:00")
+            self.assertEqual(doc["accessionId"], "EGA123456")
+        self.assertEqual(page_num, 1)
+        self.assertEqual(page_size, 2)
+        self.assertEqual(total_objects, 100)
 
     async def test_non_empty_query_result_raises_notfound(self):
         """Test that 404 is raised with empty query result."""
@@ -299,8 +299,8 @@ class TestOperators(AsyncTestCase):
         with patch("metadata_backend.api.operators.Operator._format_read_data",
                    return_value=futurized(data)):
             await operator.query_metadata_database("sample", {}, 3, 50)
-            assert cursor._skip == 100
-            assert cursor._limit == 50
+            self.assertEqual(cursor._skip, 100)
+            self.assertEqual(cursor._limit, 50)
 
 
 if __name__ == '__main__':

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -216,7 +216,7 @@ class TestOperators(AsyncTestCase):
         }]
         operator.db_service.query.return_value = MockCursor(study_test)
         query = MultiDictProxy(MultiDict([("studyAttributes", "foo")]))
-        await operator.query_metadata_database("study", query)
+        await operator.query_metadata_database("study", query, 1, 10)
         operator.db_service.query.assert_called_once_with(
             'study', {'$or': [
                 {'studyAttributes.tag':
@@ -242,7 +242,7 @@ class TestOperators(AsyncTestCase):
         query = MultiDictProxy(MultiDict([("swag", "littinen")]))
         with patch("metadata_backend.api.operators.Operator._format_read_data",
                    return_value=futurized(study_test)):
-            await operator.query_metadata_database("study", query)
+            await operator.query_metadata_database("study", query, 1, 10)
         operator.db_service.query.assert_called_once_with('study', {})
 
     async def test_multiple_document_result_is_parsed_correctly(self):
@@ -269,7 +269,8 @@ class TestOperators(AsyncTestCase):
         ]
         operator.db_service.query.return_value = MockCursor(multiple_result)
         query = MultiDictProxy(MultiDict([]))
-        parsed, _, _ = await operator.query_metadata_database("sample", query)
+        parsed, _, _ = await operator.query_metadata_database("sample", query,
+                                                              1, 10)
         for doc in parsed:
             assert doc["dateCreated"] == "2020-06-14T00:00:00"
             assert doc["dateModified"] == "2020-06-14T00:00:00"
@@ -283,7 +284,7 @@ class TestOperators(AsyncTestCase):
         with patch("metadata_backend.api.operators.Operator._format_read_data",
                    return_value=futurized([])):
             with self.assertRaises(HTTPNotFound):
-                await operator.query_metadata_database("study", query)
+                await operator.query_metadata_database("study", query, 1, 10)
 
     async def test_query_skip_and_limit_are_set_correctly(self):
         """Test custom skip and limits."""
@@ -293,7 +294,7 @@ class TestOperators(AsyncTestCase):
         operator.db_service.query.return_value = cursor
         with patch("metadata_backend.api.operators.Operator._format_read_data",
                    return_value=futurized(data)):
-            await operator.query_metadata_database("sample", {}, 50, 3)
+            await operator.query_metadata_database("sample", {}, 3, 50)
             assert cursor._skip == 100
             assert cursor._limit == 50
 

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -286,6 +286,17 @@ class TestOperators(AsyncTestCase):
             with self.assertRaises(HTTPNotFound):
                 await operator.query_metadata_database("study", query)
 
+    async def test_query_skip_and_limit_are_set_correctly(self):
+        """Test custom skip and limits."""
+        operator = Operator(self.client)
+        cursor = MockCursor([])
+        operator.db_service.query.return_value = cursor
+        with patch("metadata_backend.api.operators.Operator._format_read_data",
+                   return_value=MagicMock()):
+            await operator.query_metadata_database("sample", {}, 50, 3)
+            assert cursor._skip == 100
+            assert cursor._limit == 50
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Description

This PR adds pagination to query responses, following our api specs.

### Related issues
Fixes #54 

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Changes Made
- Added pagination parameter checks and pagination response to handlers module
- Added pagination logic to operators module
- Added db operations for size of query results (yepp, this can't be done directly with cursor...) 
- Moved away json dumps from operators module --> now operators are only returning strings, lists or dicts, which can then be dumped to json / xml in handlers module. Makes program logic clearer imo.

+ added some tiny fixes I noticed to handlers errors 

### Testing
- [x] Unit Tests
- [x] Integration Tests

### Mentions
Are we ok with this or do we wan't to include for example link headers (see https://stackoverflow.com/questions/12168624/pagination-response-payload-from-a-restful-api)? 
