### PR TITLE
fix XML etree import warning for safer XML parsing

### DIFF
--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -5,12 +5,11 @@ from collections import Counter
 from math import ceil
 from pathlib import Path
 from typing import Dict, List, Tuple, Union, cast
-from xml.etree import ElementTree
-from xml.etree.ElementTree import ParseError
 
 from aiohttp import BodyPartReader, web
 from aiohttp.web import Request, Response
 from xmlschema import XMLSchemaValidationError
+from xmlschema.etree import ElementTree, ParseError
 
 from ..conf.conf import schema_types
 from ..helpers.parser import XMLToJSONParser

--- a/metadata_backend/helpers/parser.py
+++ b/metadata_backend/helpers/parser.py
@@ -2,7 +2,7 @@
 
 import re
 from typing import Any, Dict, List, Union
-from xml.etree.ElementTree import ParseError
+from xmlschema.etree import ParseError
 
 from aiohttp import web
 from xmlschema import (XMLSchema, XMLSchemaConverter, XMLSchemaException,


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
xmlschema addresses the safer XML parsing in https://github.com/sissaschool/xmlschema/blob/master/xmlschema/etree.py#L31-L35

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

Fixes #73 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

<!-- List changes made. -->

used built in `ElementTree` and and `ParseError` from xmlschema

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

but still need to pass

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
