### PR TITLE
Fix server dropping request on autoreconnects

### DIFF
--- a/metadata_backend/conf/conf.py
+++ b/metadata_backend/conf/conf.py
@@ -45,8 +45,8 @@ mongo_user = os.getenv("MONGO_INITDB_ROOT_USERNAME", "admin")
 mongo_password = os.getenv("MONGO_INITDB_ROOT_PASSWORD", "admin")
 mongo_host = os.getenv("MONGODB_HOST", "localhost:27017")
 url = f"mongodb://{mongo_user}:{mongo_password}@{mongo_host}"
-serverTimeout = 10000
-connectTimeout = 10000
+serverTimeout = 15000
+connectTimeout = 15000
 
 
 def create_db_client() -> AsyncIOMotorClient:

--- a/metadata_backend/database/db_service.py
+++ b/metadata_backend/database/db_service.py
@@ -1,6 +1,4 @@
 """Services that handle database connections. Implemented with MongoDB."""
-
-import asyncio
 from functools import wraps
 from typing import Any, Callable, Dict
 
@@ -24,21 +22,18 @@ def auto_reconnect(db_func: Callable) -> Callable:
         :raises ConnectionFailure after preset amount of attempts
         """
         default_timeout = int(serverTimeout // 1000)
-        wait_time = default_timeout
-        max_attempts = 5
+        max_attempts = 6
         for attempt in range(1, max_attempts + 1):
             try:
                 return await db_func(*args, **kwargs)
             except AutoReconnect:
-                if attempt == 5:
+                if attempt == max_attempts:
                     message = (f"Connection to database failed after {attempt}"
                                "tries")
                     raise ConnectionFailure(message=message)
                 LOG.error("Connection not successful, trying to reconnect."
                           f"Reconnection attempt number {attempt}, waiting "
-                          f" for {default_timeout + wait_time} seconds.")
-                await asyncio.sleep(wait_time)
-                wait_time += default_timeout
+                          f" for {default_timeout} seconds.")
                 continue
     return retry
 

--- a/tests/test_db_service.py
+++ b/tests/test_db_service.py
@@ -122,4 +122,4 @@ class DatabaseTestCase(AsyncTestCase):
         with patch("metadata_backend.database.db_service.serverTimeout", 0):
             with self.assertRaises(ConnectionFailure):
                 await self.test_service.create("test", self.data_stub)
-        self.assertEqual(self.collection.insert_one.call_count, 5)
+        self.assertEqual(self.collection.insert_one.call_count, 6)


### PR DESCRIPTION
### Description

Our current implementation for autoreconnects causes frontend client to drop request too soon. I believe this is related to `asyncio.sleep` used here: https://github.com/CSCfi/metadata-submitter/blob/855ef63d794e21a0a2aed120a55ef61cf5de5179/metadata_backend/database/db_service.py#L40, since connection drops only if we're waiting in sleep, but not when Motor is doing autoreconnecting. 

Removing sleeping solves problem for now. Howerer, this results reconnect attempts to happen on same interval, so I'm suggesting that we raise interval to 15 secs and let it try connecting for 6 times so 1,5mins overall.


### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Testing

- [x] Unit Tests
