### PR TITLE
Fix error: xml validation error details

### DIFF
--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -253,8 +253,8 @@ class SubmissionAPIHandler:
 
         except ParseError as error:
             reason = str(error).split(':')[0]
-            location = (str(error).split(':')[1])[1:]
-            full_reason = f"Faulty XML file was given, {reason} at {location}"
+            position = (str(error).split(':')[1])[1:]
+            full_reason = f"Faulty XML file was given, {reason} at {position}"
             # Manually find instance element
             lines = StringIO(xml_content).readlines()
             line = lines[error.position[0] - 1]  # line of instance
@@ -267,13 +267,14 @@ class SubmissionAPIHandler:
                                 content_type="application/json")
 
         except XMLSchemaValidationError as error:
-            # Parsing reason and instance from the validation error message
+            # Parse reason and instance from the validation error message
             reason = error.reason
+            # TODO: Find position (line no.) of error and add to end of reason
             instance = ElementTree.tostring(error.elem, encoding="unicode")
             # Replace element address in reason with instance element
             if '<' and '>' in reason:
-                instance = ''.join((instance.split('>')[0], '>'))
-                reason = re.sub("<[^>]*>", instance + ' ', reason)
+                instance_parent = ''.join((instance.split('>')[0], '>'))
+                reason = re.sub("<[^>]*>", instance_parent + ' ', reason)
 
             body = json.dumps({"isValid": False, "detail":
                               {"reason": reason, "instance": instance}})

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -269,7 +269,6 @@ class SubmissionAPIHandler:
         except XMLSchemaValidationError as error:
             # Parse reason and instance from the validation error message
             reason = error.reason
-            # TODO: Find position (line no.) of error and add to end of reason
             instance = ElementTree.tostring(error.elem, encoding="unicode")
             # Replace element address in reason with instance element
             if '<' and '>' in reason:

--- a/tests/test_files/study/SRP000539_copy.xml
+++ b/tests/test_files/study/SRP000539_copy.xml
@@ -1,0 +1,34 @@
+<STUDY_SET>
+    <STUDY center_name="GEO" alias="GSE10966" accession="SRP000539">
+        <IDENTIFIERS>
+            <PRIMARY_ID>SRP000539</PRIMARY_ID>
+            <EXTERNAL_ID namespace="BioProject" label="primary">PRJNA108793</EXTERNAL_ID>
+            <EXTERNAL_ID namespace="GEO">GSE10966</EXTERNAL_ID>
+        </IDENTIFIERS>
+        <DESCRIPTOR>
+            <STUDY_TITLE>Highly integrated epigenome maps in Arabidopsis - whole genome shotgun bisulfite sequencing
+            </STUDY_TITLE>
+            <STUDY_TYPE existing_study_type="Other"/>
+            <STUDY_ABSTRACT>Part of a set of highly integrated epigenome maps for Arabidopsis thaliana. Keywords:
+                Illumina high-throughput bisulfite sequencing Overall design: Whole genome shotgun bisulfite sequencing
+                of wildtype Arabidopsis plants (Columbia-0), and met1, drm1 drm2 cmt3, and ros1 dml2 dml3 null mutants
+                using the Illumina Genetic Analyzer.
+            </STUDY_ABSTRACT>
+            <CENTER_PROJECT_NAME>GSE10966</CENTER_PROJECT_NAME>
+        </DESCRIPTOR>
+        <STUDY_LINKS>
+            <STUDY_LINK>
+                <XREF_LINK>
+                    <DB>pubmed</DB>
+                    <ID>18423832</ID>
+                </XREF_LINK>
+            </STUDY_LINK>
+        </STUDY_LINKS>
+        <STUDY_ATTRIBUTES>
+            <STUDY_ATTRIBUTE>
+                <TAG>parent_bioproject</TAG>
+                <VALUE>PRJNA107265</VALUE>
+            </STUDY_ATTRIBUTE>
+        </STUDY_ATTRIBUTES>
+    </STUDY>
+</STUDY_SET>

--- a/tests/test_files/study/SRP000539_invalid3.xml
+++ b/tests/test_files/study/SRP000539_invalid3.xml
@@ -1,0 +1,34 @@
+<STUDY_SET>
+    <STUDY center_name="GEO" alias="GSE10966" accession="SRP000539">
+        <IDENTIFIERS>
+            <PRIMARY_ID>SRP000539</PRIMARY_ID>
+            <EXTERNAL_ID namespace="BioProject" label="primary">PRJNA108793</EXTERNAL_ID>
+            <EXTERNAL_ID namespace="GEO">GSE10966</EXTERNAL_ID>
+        </IDENTIFIERS>
+        <STUDY_LINKS>
+            <STUDY_LINK>
+                <XREF_LINK>
+                    <DB>pubmed</DB>
+                    <ID>18423832</ID>
+                </XREF_LINK>
+            </STUDY_LINK>
+        </STUDY_LINKS>
+        <STUDY_ATTRIBUTES>
+            <STUDY_ATTRIBUTE>
+                <TAG>parent_bioproject</TAG>
+                <VALUE>PRJNA107265</VALUE>
+            </STUDY_ATTRIBUTE>
+        </STUDY_ATTRIBUTES>
+        <DESCRIPTOR>
+            <STUDY_TITLE>Highly integrated epigenome maps in Arabidopsis - whole genome shotgun bisulfite sequencing
+            </STUDY_TITLE>
+            <STUDY_TYPE existing_study_type="Other"/>
+            <STUDY_ABSTRACT>Part of a set of highly integrated epigenome maps for Arabidopsis thaliana. Keywords:
+                Illumina high-throughput bisulfite sequencing Overall design: Whole genome shotgun bisulfite sequencing
+                of wildtype Arabidopsis plants (Columbia-0), and met1, drm1 drm2 cmt3, and ros1 dml2 dml3 null mutants
+                using the Illumina Genetic Analyzer.
+            </STUDY_ABSTRACT>
+            <CENTER_PROJECT_NAME>GSE10966</CENTER_PROJECT_NAME>
+        </DESCRIPTOR>
+    </STUDY>
+</STUDY_SET>

--- a/tests/test_files/study/SRP000539_invalid4.xml
+++ b/tests/test_files/study/SRP000539_invalid4.xml
@@ -1,0 +1,34 @@
+<STUDY_SET>
+    <STUDY center_name="GEO" alias="GSE10966" accession="SRP000539">
+        <IDENTIFIERS>
+            <PRIMARY_ID>SRP000539&</PRIMARY_ID>
+            <EXTERNAL_ID namespace="BioProject" label="primary">PRJNA108793</EXTERNAL_ID>
+            <EXTERNAL_ID namespace="GEO">GSE10966</EXTERNAL_ID>
+        </IDENTIFIERS>
+        <DESCRIPTOR>
+            <STUDY_TITLE>Highly integrated epigenome maps in Arabidopsis - whole genome shotgun bisulfite sequencing
+            </STUDY_TITLE>
+            <STUDY_TYPE existing_study_type="Other"/>
+            <STUDY_ABSTRACT>Part of a set of highly integrated epigenome maps for Arabidopsis thaliana. Keywords:
+                Illumina high-throughput bisulfite sequencing Overall design: Whole genome shotgun bisulfite sequencing
+                of wildtype Arabidopsis plants (Columbia-0), and met1, drm1 drm2 cmt3, and ros1 dml2 dml3 null mutants
+                using the Illumina Genetic Analyzer.
+            </STUDY_ABSTRACT>
+            <CENTER_PROJECT_NAME>GSE10966</CENTER_PROJECT_NAME>
+        </DESCRIPTOR>
+        <STUDY_LINKS>
+            <STUDY_LINK>
+                <XREF_LINK>
+                    <DB>pubmed</DB>
+                    <ID>18423832</ID>
+                </XREF_LINK>
+            </STUDY_LINK>
+        </STUDY_LINKS>
+        <STUDY_ATTRIBUTES>
+            <STUDY_ATTRIBUTE>
+                <TAG>parent_bioproject</TAG>
+                <VALUE>PRJNA107265</VALUE>
+            </STUDY_ATTRIBUTE>
+        </STUDY_ATTRIBUTES>
+    </STUDY>
+</STUDY_SET>

--- a/tests/test_files/study/SRP000539_invalid5.xml
+++ b/tests/test_files/study/SRP000539_invalid5.xml
@@ -1,0 +1,35 @@
+<STUDY_SET>
+    <STUDY center_name="GEO" alias="GSE10966" accession="SRP000539">
+        <IDENTIFIERS>
+            <PRIMARY_ID>SRP000539</PRIMARY_ID>
+            <EXTERNAL_ID namespace="BioProject" label="primary">PRJNA108793</EXTERNAL_ID>
+            <EXTERNAL_ID namespace="GEO">GSE10966</EXTERNAL_ID>
+        </IDENTIFIERS>
+        <DESCRIPTOR>
+            <STUDY_TITLE>Highly integrated epigenome maps in Arabidopsis - whole genome shotgun bisulfite sequencing
+            </STUDY_TITLE>
+            <STUDY_TYPE existing_study_type="Other"/>
+            <STUDY_ABSTRACT>Part of a set of highly integrated epigenome maps for Arabidopsis thaliana. Keywords:
+                Illumina high-throughput bisulfite sequencing Overall design: Whole genome shotgun bisulfite sequencing
+                of wildtype Arabidopsis plants (Columbia-0), and met1, drm1 drm2 cmt3, and ros1 dml2 dml3 null mutants
+                using the Illumina Genetic Analyzer.
+            </STUDY_ABSTRACT>
+            <CENTER_PROJECT_NAME>GSE10966</CENTER_PROJECT_NAME>
+        </DESCRIPTOR>
+        <STUDY_LINKS>
+            <STUDY_LINK>
+                <XREF_LINK>
+                    <DB>pubmed</DB>
+                    <ID>18423832</ID>
+                </XREF_LINK>
+            </STUDY_LINK>
+        </STUDY_LINKS>
+        <STUDY_ATTRIBUTES>
+            <STUDY_ATTRIBUTE>
+                <TAG>parent_bioproject</TAG>
+                <VALUE>PRJNA107265</VALUE>
+            </STUDY_ATTRIBUTE>
+        </STUDY_ATTRIBUTES>
+    </STUDY>
+</STUDY_SET>
+added junk

--- a/tests/test_files/study/SRP000539_invalid6.xml
+++ b/tests/test_files/study/SRP000539_invalid6.xml
@@ -31,4 +31,5 @@
             </STUDY_ATTRIBUTE>
         </STUDY_ATTRIBUTES>
     </STUDY>
+    <BAD_ELEMENT></BAD_ELEMENT>
 </STUDY_SET>

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -268,7 +268,8 @@ class HandlersTestCase(AioHTTPTestCase):
         response = await self.client.post("/validate", data=data)
         resp_dict = await response.json()
         self.assertEqual(response.status, 200)
-        self.assertIn("Faulty XML file was given", resp_dict['detail'])
+        self.assertIn("Faulty XML file was given.",
+                      resp_dict['detail']['reason'])
 
     @unittest_run_loop
     async def test_validation_fails_for_invalid_xml(self):

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -268,8 +268,8 @@ class HandlersTestCase(AioHTTPTestCase):
         response = await self.client.post("/validate", data=data)
         resp_dict = await response.json()
         self.assertEqual(response.status, 200)
-        self.assertIn("Faulty XML file was given.",
-                      resp_dict['detail']['reason'])
+        self.assertEqual("Faulty XML file was given, mismatched tag",
+                         resp_dict['detail']['reason'])
 
     @unittest_run_loop
     async def test_validation_fails_for_invalid_xml(self):

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -268,8 +268,8 @@ class HandlersTestCase(AioHTTPTestCase):
         response = await self.client.post("/validate", data=data)
         resp_dict = await response.json()
         self.assertEqual(response.status, 200)
-        self.assertEqual("Faulty XML file was given, mismatched tag",
-                         resp_dict['detail']['reason'])
+        self.assertIn("Faulty XML file was given, mismatched tag",
+                      resp_dict['detail']['reason'])
 
     @unittest_run_loop
     async def test_validation_fails_for_invalid_xml(self):


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->

Bugs described in #85 are technically fixed with this PR. 
1. Instead of `<Element 'SAMPLE_SET' at 0x7f4ec563a180> is not an element of the schema"`, the error will now be displayed as: `<SAMPLE_SET> is not an element of the schema."`
2. The same response structure has been utilized for parsing errors as well (errors caused by invalid xml syntax) so that error reason is included in `detail.reason`.

The `xmlschema.etree.ParseError` exceptions provide the position of the error, making it quite simple to include the line number in the reason. Thus, the output for `SRP000539_invalid.xml` test file would be: ` Faulty XML file was given, mismatched tag at line 7, column 10.` However, `xmlschema` library does not have a built-in method for getting the same numerical position so validation error outputs do not have the line number included yet.

I also tried to come up with some additional errors to test different error outputs, so there are some more test files included in this PR as well.


### Related issues
Fixes #85 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

<!-- List changes made. -->
- XML ElementTree parsing error output reformatted to return the same JSON-object as validation errors
- Parsing errors include better information 
- Validation error reason is altered if it contains element address.
- Logging spelling
- More test files with different errors for checking validation error outputs

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests (previous tests altered to work with fixes)
