### PR TITLE
Refactor: Extract validation error handling to different module

### DIFF
--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Tuple, Union, cast
 
 from aiohttp import BodyPartReader, web
 from aiohttp.web import Request, Response
+from xmlschema import XMLSchemaException
 
 from ..conf.conf import schema_types
 from ..helpers.parser import XMLToJSONParser
@@ -240,9 +241,10 @@ class SubmissionAPIHandler:
 
         try:
             schema = SchemaLoader().get_schema(schema_type)
+            LOG.info(f"{schema_type} schema loaded.")
             validator = XMLValidator(schema, xml_content)
 
-        except SchemaNotFoundException as error:
+        except (SchemaNotFoundException, XMLSchemaException) as error:
             reason = f"{error} ({schema_type})"
             LOG.error(reason)
             raise web.HTTPBadRequest(reason=reason)

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -26,7 +26,7 @@ class RESTApiHandler:
 
         Basically returns which objects user can submit and query for.
         :param req: GET Request
-        :returns JSON list of schema types
+        :returns: JSON list of schema types
         """
         types_json = json.dumps([x["description"] for x in
                                  schema_types.values()])

--- a/metadata_backend/helpers/parser.py
+++ b/metadata_backend/helpers/parser.py
@@ -172,7 +172,7 @@ class XMLToJSONParser:
         schema = self._load_schema(schema_type)
         LOG.info(f"{schema_type} schema loaded.")
         validator = XMLValidator(schema, content)
-        if not validator.xmlIsValid:
+        if not validator.is_valid:
             reason = ("Current request could not be processed"
                       " as the submitted file was not valid")
             LOG.error(reason)

--- a/metadata_backend/helpers/parser.py
+++ b/metadata_backend/helpers/parser.py
@@ -170,6 +170,7 @@ class XMLToJSONParser:
         :raises: HTTPBadRequest if error was raised during validation
         """
         schema = self._load_schema(schema_type)
+        LOG.info(f"{schema_type} schema loaded.")
         validator = XMLValidator(schema, content)
         if not validator.xmlIsValid:
             reason = ("Current request could not be processed"

--- a/metadata_backend/helpers/validator.py
+++ b/metadata_backend/helpers/validator.py
@@ -1,0 +1,61 @@
+"""Utility class for validating XML files."""
+
+import re
+import json
+from io import StringIO
+from urllib.error import URLError
+
+from aiohttp import web
+from xmlschema import XMLSchema, XMLSchemaValidationError
+from xmlschema.etree import ElementTree, ParseError
+
+from ..helpers.logger import LOG
+
+
+class XMLValidator:
+    """Validator implementation."""
+
+    def __init__(self, schema: XMLSchema, xml: str) -> None:
+        """Variables."""
+        self.schema = schema
+        self.xml_content = xml
+        self.resp_body = self.get_validation()
+
+    def get_validation(self) -> str:
+        """Where validation happens."""
+        try:
+            self.schema.validate(self.xml_content)
+            # LOG.info(f"Submitted file is valid against {schema_type} schema."
+            return json.dumps({"isValid": True})
+
+        except ParseError as error:
+            reason = str(error).split(':')[0]
+            position = (str(error).split(':')[1])[1:]
+            full_reason = f"Faulty XML file was given, {reason} at {position}"
+            # Manually find instance element
+            lines = StringIO(self.xml_content).readlines()
+            line = lines[error.position[0] - 1]  # line of instance
+            instance = re.sub(r'^.*?<', '<', line)  # strip whitespaces
+
+            LOG.info("Submitted file does not not contain valid XML syntax.")
+            return json.dumps({"isValid": False, "detail":
+                              {"reason": full_reason, "instance": instance}})
+
+        except XMLSchemaValidationError as error:
+            # Parse reason and instance from the validation error message
+            reason = error.reason
+            instance = ElementTree.tostring(error.elem, encoding="unicode")
+            # Replace element address in reason with instance element
+            if '<' and '>' in reason:
+                instance_parent = ''.join((instance.split('>')[0], '>'))
+                reason = re.sub("<[^>]*>", instance_parent + ' ', reason)
+
+            # LOG.info(f"Submitted file is not valid against {schema_type} "
+            #          "schema.")
+            return json.dumps({"isValid": False, "detail":
+                              {"reason": reason, "instance": instance}})
+
+        except URLError as error:
+            reason = f"Faulty file was provided. {error.reason}."
+            LOG.error(reason)
+            raise web.HTTPBadRequest(reason=reason)

--- a/metadata_backend/helpers/validator.py
+++ b/metadata_backend/helpers/validator.py
@@ -16,13 +16,22 @@ class XMLValidator:
     """Validator implementation."""
 
     def __init__(self, schema: XMLSchema, xml: str) -> None:
-        """Variables."""
+        """Set Variables and initiate validation.
+
+        :param schema: Schema to be used
+        :param content: Content of XML file to be validated
+        """
         self.schema = schema
         self.xml_content = xml
         self.resp_body = self.get_validation()
+        self.xmlIsValid = self.isValid()
 
     def get_validation(self) -> str:
-        """Where validation happens."""
+        """Check validation and organize.
+
+        :returns: JSON formatted string that provides details of validation
+        :raises: HTTPBadRequest if URLError was raised during validation
+        """
         try:
             self.schema.validate(self.xml_content)
             # LOG.info(f"Submitted file is valid against {schema_type} schema."
@@ -59,3 +68,8 @@ class XMLValidator:
             reason = f"Faulty file was provided. {error.reason}."
             LOG.error(reason)
             raise web.HTTPBadRequest(reason=reason)
+
+    def isValid(self) -> bool:
+        """Quick method for checking validation result."""
+        resp = json.loads(self.resp_body)
+        return resp['isValid']

--- a/metadata_backend/helpers/validator.py
+++ b/metadata_backend/helpers/validator.py
@@ -34,7 +34,7 @@ class XMLValidator:
         """
         try:
             self.schema.validate(self.xml_content)
-            # LOG.info(f"Submitted file is valid against {schema_type} schema."
+            LOG.info("Submitted file is totally valid.")
             return json.dumps({"isValid": True})
 
         except ParseError as error:
@@ -59,8 +59,7 @@ class XMLValidator:
                 instance_parent = ''.join((instance.split('>')[0], '>'))
                 reason = re.sub("<[^>]*>", instance_parent + ' ', reason)
 
-            # LOG.info(f"Submitted file is not valid against {schema_type} "
-            #          "schema.")
+            LOG.info("Submitted file is not valid against schema.")
             return json.dumps({"isValid": False, "detail":
                               {"reason": reason, "instance": instance}})
 

--- a/metadata_backend/helpers/validator.py
+++ b/metadata_backend/helpers/validator.py
@@ -69,6 +69,9 @@ class XMLValidator:
             raise web.HTTPBadRequest(reason=reason)
 
     def isValid(self) -> bool:
-        """Quick method for checking validation result."""
+        """Quick method for checking validation result.
+
+        :returns: the value of isValid key in the validation detail JSON object
+        """
         resp = json.loads(self.resp_body)
         return resp['isValid']

--- a/metadata_backend/helpers/validator.py
+++ b/metadata_backend/helpers/validator.py
@@ -38,7 +38,7 @@ class XMLValidator:
             return json.dumps({"isValid": True})
 
         except ParseError as error:
-            reason = parse_error_reason(error)
+            reason = self.parse_error_reason(error)
             # Manually find instance element
             lines = StringIO(self.xml_content).readlines()
             line = lines[error.position[0] - 1]  # line of instance

--- a/metadata_backend/helpers/validator.py
+++ b/metadata_backend/helpers/validator.py
@@ -16,18 +16,17 @@ class XMLValidator:
     """Validator implementation."""
 
     def __init__(self, schema: XMLSchema, xml: str) -> None:
-        """Set Variables and initiate validation.
+        """Set variables.
 
         :param schema: Schema to be used
         :param content: Content of XML file to be validated
         """
         self.schema = schema
         self.xml_content = xml
-        self.resp_body = self.get_validation()
-        self.xmlIsValid = self.is_valid()
 
-    def get_validation(self) -> str:
-        """Check validation and organize.
+    @property
+    def resp_body(self) -> str:
+        """Check validation and organize validation error details.
 
         :returns: JSON formatted string that provides details of validation
         :raises: HTTPBadRequest if URLError was raised during validation
@@ -38,7 +37,7 @@ class XMLValidator:
             return json.dumps({"isValid": True})
 
         except ParseError as error:
-            reason = self.parse_error_reason(error)
+            reason = self._parse_error_reason(error)
             # Manually find instance element
             lines = StringIO(self.xml_content).readlines()
             line = lines[error.position[0] - 1]  # line of instance
@@ -66,20 +65,14 @@ class XMLValidator:
             LOG.error(reason)
             raise web.HTTPBadRequest(reason=reason)
 
-    def parse_error_reason(self, error: ParseError) -> str:
-        """Generate better error reason.
-
-        :param error: The ParseError exception that was raised
-        :returns: String with better error reason
-        """
+    def _parse_error_reason(self, error: ParseError) -> str:
+        """Generate better error reason."""
         reason = str(error).split(':')[0]
         position = (str(error).split(':')[1])[1:]
         return f"Faulty XML file was given, {reason} at {position}"
 
+    @property
     def is_valid(self) -> bool:
-        """Quick method for checking validation result.
-
-        :returns: the value of isValid key in the validation detail JSON object
-        """
+        """Quick method for checking validation result."""
         resp = json.loads(self.resp_body)
         return resp['isValid']

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -79,3 +79,9 @@ class ParserTestCase(unittest.TestCase):
         """Test 400 is returned when schema."""
         with self.assertRaises(web.HTTPBadRequest):
             self.parser._load_schema("None")
+
+    def test_error_raised_when_input_xml_not_valid_xml(self):
+        """Give parser xml with broken syntax, should fail."""
+        study_xml = self.load_xml_from_file("study", "SRP000539_invalid.xml")
+        with self.assertRaises(web.HTTPBadRequest):
+            self.parser.parse("study", study_xml)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 from metadata_backend.helpers.parser import XMLToJSONParser
 from aiohttp import web
-from metadata_backend.helpers.schema_loader import SchemaLoader
 import unittest
 
 
@@ -80,18 +79,3 @@ class ParserTestCase(unittest.TestCase):
         """Test 400 is returned when schema."""
         with self.assertRaises(web.HTTPBadRequest):
             self.parser._load_schema("None")
-
-    def test_error_raised_when_validate_fails_against_schema(self):
-        """Create sample validator, which should fail to validate study."""
-        loader = SchemaLoader()
-        schema = loader.get_schema("sample")
-        with self.assertRaises(web.HTTPBadRequest):
-            self.parser._validate("<STUDY_SET></STUDY_SET>", schema)
-
-    def test_error_raised_when_input_xml_not_valid_xml(self):
-        """Give validator xml with broken syntax, should fail."""
-        loader = SchemaLoader()
-        schema = loader.get_schema("study")
-        study_xml = self.load_xml_from_file("study", "SRP000539_invalid.xml")
-        with self.assertRaises(web.HTTPBadRequest):
-            self.parser._validate(study_xml, schema)


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
PR adds a `validator.py` to helper tools and readjusts `/validate` endpoint and `parser.py` to call the new method instead. No new tests added yet because previous tests work fine. If this refactoring looks ok though, previous tests dealing with validation could be moved to a new test class.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
Fixes #66 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue) / refactoring


### Changes Made

<!-- List changes made. -->
- Adds helper tool for validating XMLs
- removes previous validation calls and redirects those calls to the new validation method
- edited 2 of the tests in `test_parser.py` that do not apply anymore
- edited some logging calls and fixed a typo I spotted

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Needs testing (?)
