### PR TITLE
Add authentication/authorization middleware

### DIFF
--- a/metadata_backend/api/middlewares.py
+++ b/metadata_backend/api/middlewares.py
@@ -75,7 +75,6 @@ def jwt_middleware() -> Callable:
             if not re.match('Bearer', scheme):
                 raise web.HTTPUnauthorized(reason="Invalid token scheme, "
                                                   "Bearer required.")
-
             if token is None:
                 raise web.HTTPUnauthorized(reason='Token cannot be empty.')
 

--- a/metadata_backend/api/middlewares.py
+++ b/metadata_backend/api/middlewares.py
@@ -73,15 +73,15 @@ async def jwt_authentication(req: Request, handler: Callable) -> Response:
 
         # JWK and JWTClaims parameters for decoding
         key = environ.get('PUBLIC_KEY', None)
-        # TODO: get Oauth2 public key
-        # TODO: verify audience claim
+
+        # Get Oauth2 public key and verify audience claim here
 
         # Include claims that are required to be present
         # in the payload of the token
         claims_options = {
             "iss": {
                 "essential": True,
-                # TODO: add the proper issuer URLs here
+                # Proper issuer URLs need to be added as the values
                 "values": ["haka_iss", "elixir_iss"]
             },
             "exp": {
@@ -95,7 +95,7 @@ async def jwt_authentication(req: Request, handler: Callable) -> Response:
             claims.validate()
             LOG.info('Auth token decoded and validated.')
 
-            # TODO: Retrieve GA4GH passports and process into permissions
+            # Retrieve GA4GH passports and process into permissions here
 
             req["token"] = {"authenticated": True}
             return await handler(req)

--- a/metadata_backend/api/middlewares.py
+++ b/metadata_backend/api/middlewares.py
@@ -67,7 +67,7 @@ def jwt_middleware() -> Callable:
             # Check token exists
             try:
                 scheme, token = req.headers.get('Authorization').split(' ')
-                LOG.info('Auth Token Received.')
+                LOG.info('Auth token received.')
             except Exception as err:
                 raise web.HTTPUnauthorized(reason=str(err))
 
@@ -96,7 +96,9 @@ def jwt_middleware() -> Callable:
                 claims = jwt.decode(token, key, claims_options=claims_options)
                 claims.validate()
                 LOG.info('Auth token decoded and validated.')
+
                 # TODO: Retrieve GA4GH passports and process into permissions
+
                 req["token"] = {"authenticated": True}
                 return await handler(req)
             except errors.MissingClaimError as err:

--- a/metadata_backend/api/middlewares.py
+++ b/metadata_backend/api/middlewares.py
@@ -46,6 +46,7 @@ async def http_error_handler(req: Request, handler: Callable) -> Response:
 
     return http_error_handler
 
+
 @middleware
 async def jwt_authentication(req: Request, handler: Callable) -> Response:
     """Middleware for validating and authenticating JSON web token.
@@ -60,8 +61,8 @@ async def jwt_authentication(req: Request, handler: Callable) -> Response:
         try:
             scheme, token = req.headers.get('Authorization').split(' ')
             LOG.info('Auth token received.')
-        except Exception as err:
-            raise web.HTTPUnauthorized(reason=str(err))
+        except ValueError as err:
+            raise web.HTTPUnauthorized(reason=f"Failure to read token: {err}")
 
         # Check token has proper scheme and was provided.
         if not re.match('Bearer', scheme):
@@ -113,7 +114,6 @@ async def jwt_authentication(req: Request, handler: Callable) -> Response:
     else:
         req["token"] = {"authenticated": False}
         return await handler(req)
-
 
 
 def _json_exception(status: int, exception: web.HTTPException,

--- a/metadata_backend/api/middlewares.py
+++ b/metadata_backend/api/middlewares.py
@@ -13,47 +13,41 @@ from yarl import URL
 from ..helpers.logger import LOG
 
 
-def error_middleware() -> Callable:
+@middleware
+async def http_error_handler(req: Request, handler: Callable) -> Response:
     """Middleware for handling exceptions recieved from the API methods.
 
-    :returns: Handled response
+    :param req: A request instance
+    :param handler: A request handler
+    :raises: Reformatted HTTP Exceptions
+    :returns: Successful requests unaffected
     """
-
-    @middleware
-    async def http_error_handler(req: Request, handler: Callable) -> Response:
-        """Handle HTTP errors.
-
-        :param req: A request instance
-        :param handler: A request handler
-        :raises: Reformatted HTTP Exceptions
-        :returns: Successful requests unaffected
-        """
-        try:
-            response = await handler(req)
-            return response
-        except web.HTTPError as error:
-            details = _json_exception(error.status, error, req.url)
-            LOG.error(details)
-            c_type = 'application/problem+json'
-            if error.status == 400:
-                raise web.HTTPBadRequest(text=details,
-                                         content_type=c_type)
-            elif error.status == 401:
-                raise web.HTTPUnauthorized(text=details,
-                                           content_type=c_type)
-            elif error.status == 403:
-                raise web.HTTPForbidden(text=details,
-                                        content_type=c_type)
-            elif error.status == 404:
-                raise web.HTTPNotFound(text=details,
+    try:
+        response = await handler(req)
+        return response
+    except web.HTTPError as error:
+        details = _json_exception(error.status, error, req.url)
+        LOG.error(details)
+        c_type = 'application/problem+json'
+        if error.status == 400:
+            raise web.HTTPBadRequest(text=details,
+                                     content_type=c_type)
+        elif error.status == 401:
+            raise web.HTTPUnauthorized(text=details,
                                        content_type=c_type)
-            else:
-                raise web.HTTPServerError()
+        elif error.status == 403:
+            raise web.HTTPForbidden(text=details,
+                                    content_type=c_type)
+        elif error.status == 404:
+            raise web.HTTPNotFound(text=details,
+                                   content_type=c_type)
+        else:
+            raise web.HTTPServerError()
 
     return http_error_handler
 
-
-def jwt_middleware() -> Callable:
+@middleware
+async def jwt_authentication(req: Request, handler: Callable) -> Response:
     """Middleware for validating and authenticating JSON web token.
 
     :param req: A request instance
@@ -61,68 +55,65 @@ def jwt_middleware() -> Callable:
     :raises: HTTP Exception with status code 401 or 403
     :returns: Successful requests unaffected
     """
-    @middleware
-    async def jwt_authentication(req: Request, handler: Callable) -> Response:
-        if 'Authorization' in req.headers:
-            # Check token exists
-            try:
-                scheme, token = req.headers.get('Authorization').split(' ')
-                LOG.info('Auth token received.')
-            except Exception as err:
-                raise web.HTTPUnauthorized(reason=str(err))
+    if 'Authorization' in req.headers:
+        # Check token exists
+        try:
+            scheme, token = req.headers.get('Authorization').split(' ')
+            LOG.info('Auth token received.')
+        except Exception as err:
+            raise web.HTTPUnauthorized(reason=str(err))
 
-            # Check token has proper scheme and was provided.
-            if not re.match('Bearer', scheme):
-                raise web.HTTPUnauthorized(reason="Invalid token scheme, "
-                                                  "Bearer required.")
-            if token is None:
-                raise web.HTTPUnauthorized(reason='Token cannot be empty.')
+        # Check token has proper scheme and was provided.
+        if not re.match('Bearer', scheme):
+            raise web.HTTPUnauthorized(reason="Invalid token scheme, "
+                                              "Bearer required.")
+        if token is None:
+            raise web.HTTPUnauthorized(reason='Token cannot be empty.')
 
-            # JWK and JWTClaims parameters for decoding
-            key = environ.get('PUBLIC_KEY', None)
-            # TODO: get Oauth2 public key
-            # TODO: verify audience claim
+        # JWK and JWTClaims parameters for decoding
+        key = environ.get('PUBLIC_KEY', None)
+        # TODO: get Oauth2 public key
+        # TODO: verify audience claim
 
-            # Include claims that are required to be present
-            # in the payload of the token
-            claims_options = {
-                "iss": {
-                    "essential": True,
-                    # TODO: add the proper issuer URLs here
-                    "values": ["haka_iss", "elixir_iss"]
-                },
-                "exp": {
-                    "essential": True
-                }
+        # Include claims that are required to be present
+        # in the payload of the token
+        claims_options = {
+            "iss": {
+                "essential": True,
+                # TODO: add the proper issuer URLs here
+                "values": ["haka_iss", "elixir_iss"]
+            },
+            "exp": {
+                "essential": True
             }
+        }
 
-            # Decode and validate token
-            try:
-                claims = jwt.decode(token, key, claims_options=claims_options)
-                claims.validate()
-                LOG.info('Auth token decoded and validated.')
+        # Decode and validate token
+        try:
+            claims = jwt.decode(token, key, claims_options=claims_options)
+            claims.validate()
+            LOG.info('Auth token decoded and validated.')
 
-                # TODO: Retrieve GA4GH passports and process into permissions
+            # TODO: Retrieve GA4GH passports and process into permissions
 
-                req["token"] = {"authenticated": True}
-                return await handler(req)
-            except errors.MissingClaimError as err:
-                raise web.HTTPUnauthorized(reason=f"{err}")
-            except errors.ExpiredTokenError as err:
-                raise web.HTTPUnauthorized(reason=f"{err}")
-            except errors.InvalidClaimError as err:
-                raise web.HTTPForbidden(reason=f"Token contains {err}")
-            except errors.BadSignatureError as err:
-                raise web.HTTPUnauthorized(reason="Token signature is invalid"
-                                                  f", {err}")
-            except errors.InvalidTokenError as err:
-                raise web.HTTPUnauthorized(reason="Invalid authorization token"
-                                                  f": {err}")
-        else:
-            req["token"] = {"authenticated": False}
+            req["token"] = {"authenticated": True}
             return await handler(req)
+        except errors.MissingClaimError as err:
+            raise web.HTTPUnauthorized(reason=f"{err}")
+        except errors.ExpiredTokenError as err:
+            raise web.HTTPUnauthorized(reason=f"{err}")
+        except errors.InvalidClaimError as err:
+            raise web.HTTPForbidden(reason=f"Token contains {err}")
+        except errors.BadSignatureError as err:
+            raise web.HTTPUnauthorized(reason="Token signature is invalid"
+                                              f", {err}")
+        except errors.InvalidTokenError as err:
+            raise web.HTTPUnauthorized(reason="Invalid authorization token"
+                                              f": {err}")
+    else:
+        req["token"] = {"authenticated": False}
+        return await handler(req)
 
-    return jwt_authentication
 
 
 def _json_exception(status: int, exception: web.HTTPException,

--- a/metadata_backend/api/middlewares.py
+++ b/metadata_backend/api/middlewares.py
@@ -74,14 +74,11 @@ async def jwt_authentication(req: Request, handler: Callable) -> Response:
         # JWK and JWTClaims parameters for decoding
         key = environ.get('PUBLIC_KEY', None)
 
-        # Get Oauth2 public key and verify audience claim here
-
         # Include claims that are required to be present
         # in the payload of the token
         claims_options = {
             "iss": {
                 "essential": True,
-                # Proper issuer URLs need to be added as the values
                 "values": ["haka_iss", "elixir_iss"]
             },
             "exp": {
@@ -94,9 +91,6 @@ async def jwt_authentication(req: Request, handler: Callable) -> Response:
             claims = jwt.decode(token, key, claims_options=claims_options)
             claims.validate()
             LOG.info('Auth token decoded and validated.')
-
-            # Retrieve GA4GH passports and process into permissions here
-
             req["token"] = {"authenticated": True}
             return await handler(req)
         except errors.MissingClaimError as err:

--- a/metadata_backend/api/middlewares.py
+++ b/metadata_backend/api/middlewares.py
@@ -80,7 +80,8 @@ def jwt_middleware() -> Callable:
 
             # JWK and JWTClaims parameters for decoding
             key = environ.get('PUBLIC_KEY', None)
-            # TODO more elaborate key get method
+            # TODO: get Oauth2 public key
+            # TODO: verify audience claim.
 
             # Include claims that are required to be present
             # in the payload of the token
@@ -94,7 +95,8 @@ def jwt_middleware() -> Callable:
             try:
                 claims = jwt.decode(token, key, claims_options=claims_options)
                 claims.validate()
-                LOG.info('Auth Token Decoded and Validated.')
+                LOG.info('Auth token decoded and validated.')
+                # TODO: Retrieve GA4GH passports and process into permissions
                 req["token"] = {"authenticated": True}
                 return await handler(req)
             except errors.MissingClaimError as err:

--- a/metadata_backend/server.py
+++ b/metadata_backend/server.py
@@ -6,7 +6,7 @@ import uvloop
 from aiohttp import web
 
 from .api.handlers import RESTApiHandler, StaticHandler, SubmissionAPIHandler
-from .api.middlewares import error_middleware
+from .api.middlewares import error_middleware, jwt_middleware
 from .conf.conf import create_db_client, frontend_static_files
 from .helpers.logger import LOG
 
@@ -23,7 +23,8 @@ async def init() -> web.Application:
     Note:: if using variable resources (such as {schema}), add
     specific ones on top of more generic ones.
     """
-    server = web.Application(middlewares=[error_middleware()])
+    server = web.Application(middlewares=[error_middleware(),
+                                          jwt_middleware()])
     rest_handler = RESTApiHandler()
     submission_handler = SubmissionAPIHandler()
     api_routes = [

--- a/metadata_backend/server.py
+++ b/metadata_backend/server.py
@@ -6,7 +6,7 @@ import uvloop
 from aiohttp import web
 
 from .api.handlers import RESTApiHandler, StaticHandler, SubmissionAPIHandler
-from .api.middlewares import error_middleware, jwt_middleware
+from .api.middlewares import http_error_handler, jwt_authentication
 from .conf.conf import create_db_client, frontend_static_files
 from .helpers.logger import LOG
 
@@ -23,8 +23,8 @@ async def init() -> web.Application:
     Note:: if using variable resources (such as {schema}), add
     specific ones on top of more generic ones.
     """
-    server = web.Application(middlewares=[error_middleware(),
-                                          jwt_middleware()])
+    server = web.Application(middlewares=[http_error_handler,
+                                          jwt_authentication])
     rest_handler = RESTApiHandler()
     submission_handler = SubmissionAPIHandler()
     api_routes = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aiohttp
+Authlib
 gunicorn
 motor
 python-dateutil

--- a/tests/test_middlewares.py
+++ b/tests/test_middlewares.py
@@ -9,8 +9,38 @@ from authlib.jose import jwt
 from metadata_backend.server import init
 
 
-class MiddlewaresTestCase(AioHTTPTestCase):
-    """Api middlewares test cases."""
+class ErrorMiddlewareTestCase(AioHTTPTestCase):
+    """Error handling middleware test cases."""
+
+    async def get_application(self):
+        """Retrieve web Application for test."""
+        return await init()
+
+    @unittest_run_loop
+    async def test_bad_HTTP_request_converts_into_json_response(self):
+        """Test that middleware reformats 400 error with problem details."""
+        data = _create_improper_data()
+        response = await self.client.post("/submit", data=data)
+        self.assertEqual(response.status, 400)
+        self.assertEqual(response.content_type, "application/problem+json")
+        resp_dict = await response.json()
+        self.assertIn("Bad Request", resp_dict['title'])
+        self.assertIn("There must be a submission.xml file in submission.",
+                      resp_dict['detail'])
+        self.assertIn("/submit", resp_dict['instance'])
+
+    @unittest_run_loop
+    async def test_bad_url_returns_json_response(self):
+        """Test that unrouted api url returns a 404 in JSON format."""
+        response = await self.client.get("/objects/swagadagamaster")
+        self.assertEqual(response.status, 404)
+        self.assertEqual(response.content_type, "application/problem+json")
+        resp_dict = await response.json()
+        self.assertIn("Not Found", resp_dict['title'])
+
+
+class AuthMiddlewareTestCase(AioHTTPTestCase):
+    """Authentication middleware test cases."""
 
     async def get_application(self):
         """Retrieve web Application for test."""
@@ -39,45 +69,12 @@ class MiddlewaresTestCase(AioHTTPTestCase):
         """Unset the public key."""
         os.unsetenv('PUBLIC_KEY')
 
-    def create_improper_data(self):
-        """Create request data that produces a 404 error.
-
-        Submission method in API handlers raises Bad Request (400) error
-        if 'submission' is not included on the first field of request
-        """
-        data = FormData()
-        data.add_field("study", "content of a file",
-                       filename='file', content_type='text/xml')
-        return data
-
-    @unittest_run_loop
-    async def test_bad_HTTP_request_converts_into_json_response(self):
-        """Test that middleware reformats 400 error with problem details."""
-        data = self.create_improper_data()
-        response = await self.client.post("/submit", data=data)
-        self.assertEqual(response.status, 400)
-        self.assertEqual(response.content_type, "application/problem+json")
-        resp_dict = await response.json()
-        self.assertIn("Bad Request", resp_dict['title'])
-        self.assertIn("There must be a submission.xml file in submission.",
-                      resp_dict['detail'])
-        self.assertIn("/submit", resp_dict['instance'])
-
-    @unittest_run_loop
-    async def test_bad_url_returns_json_response(self):
-        """Test that unrouted api url returns a 404 in JSON format."""
-        response = await self.client.get("/objects/swagadagamaster")
-        self.assertEqual(response.status, 404)
-        self.assertEqual(response.content_type, "application/problem+json")
-        resp_dict = await response.json()
-        self.assertIn("Not Found", resp_dict['title'])
-
     @unittest_run_loop
     async def test_authentication_passes(self):
         """Test that JWT authenticates."""
         # Add claims to mocked token
         token = jwt.encode(self.header, self.payload, self.pem).decode('utf-8')
-        data = self.create_improper_data()
+        data = _create_improper_data()
         response = await self.client.post("/submit", data=data,
                                           headers={'Authorization':
                                                    f"Bearer {token}"})
@@ -96,7 +93,7 @@ class MiddlewaresTestCase(AioHTTPTestCase):
         payload = self.payload
         payload['exp'] = 0
         token = jwt.encode(self.header, payload, self.pem).decode('utf-8')
-        data = self.create_improper_data()
+        data = _create_improper_data()
         response = await self.client.post("/submit", data=data,
                                           headers={'Authorization':
                                                    f"Bearer {token}"})
@@ -114,7 +111,7 @@ class MiddlewaresTestCase(AioHTTPTestCase):
         payload = self.payload
         del payload['iss']
         token = jwt.encode(self.header, self.payload, self.pem).decode('utf-8')
-        data = self.create_improper_data()
+        data = _create_improper_data()
         response = await self.client.post("/submit", data=data,
                                           headers={'Authorization':
                                                    f"Bearer {token}"})
@@ -133,7 +130,7 @@ class MiddlewaresTestCase(AioHTTPTestCase):
         payload = self.payload
         payload['iss'] = "wrong_iss"
         token = jwt.encode(self.header, payload, self.pem).decode('utf-8')
-        data = self.create_improper_data()
+        data = _create_improper_data()
         response = await self.client.post("/submit", data=data,
                                           headers={'Authorization':
                                                    f"Bearer {token}"})
@@ -154,7 +151,7 @@ class MiddlewaresTestCase(AioHTTPTestCase):
             'k': "hJtXIZ2uSN5kbQfbtTNWbpdmhkV8FJG"
         }
         token = jwt.encode(self.header, self.payload, otherkey).decode('utf-8')
-        data = self.create_improper_data()
+        data = _create_improper_data()
         response = await self.client.post("/submit", data=data,
                                           headers={'Authorization':
                                                    f"Bearer {token}"})
@@ -165,3 +162,15 @@ class MiddlewaresTestCase(AioHTTPTestCase):
         resp_dict = await response.json()
         self.assertIn('Token signature is invalid, bad_signature:',
                       resp_dict['detail'])
+
+
+def _create_improper_data():
+    """Create request data that produces a 404 error.
+
+    Submission method in API handlers raises Bad Request (400) error
+    if 'submission' is not included on the first field of request
+    """
+    data = FormData()
+    data.add_field("study", "content of a file",
+                   filename='file', content_type='text/xml')
+    return data

--- a/tests/test_middlewares.py
+++ b/tests/test_middlewares.py
@@ -43,8 +43,8 @@ class MiddlewaresTestCase(AioHTTPTestCase):
         self.assertIn("Not Found", resp_dict['title'])
 
     @unittest_run_loop
-    async def test_bad_jwt(self):
-        """Test bad jwt (expired)."""
+    async def test_authentication_fails_with_expired_jwt(self):
+        """Test that JWT does not authenticate if token has expired."""
         # Mock token
         header = {'alg': "HS256", 'type': "JWT"}
         payload = {'sub': "test", 'name': "tester", 'exp': 0}
@@ -54,7 +54,7 @@ class MiddlewaresTestCase(AioHTTPTestCase):
             "k": "GawgguFyGrWKav7AX4VKUg"
         }
         token = jwt.encode(header, payload, pem).decode('utf-8')
-        # Set pem as environment variable for the sake of the test
+        # Set pem as environment variable for the duration of the test
         os.environ['PUBLIC_KEY'] = json.dumps(pem)
         data = FormData()
         # This data would otherwise cause 400 error if authentication passed


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
PR includes a middleware for validating and authenticating a JWT included in the request headers, similar in structure to the one found in [Beacon API Server](https://github.com/CSCfi/beacon-python/blob/dev/beacon_api/utils/validate_jwt.py). Things will still need to be added on to this middleware, for example #96.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
Fixes #44 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)


### Changes Made

<!-- List changes made. -->
- added authentication middleware implementation 
- adds unit tests and includes helper methods in `test_middleware.py`

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests
