### PR TITLE
Add draft submission feature

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,6 +6,7 @@ omit =
     # omit everything in /usr
     /usr/*
     metadata_backend/helpers/logger.py
+    */__init__.py
 
 [report]
 # Regexes for lines to exclude from consideration

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -199,6 +199,30 @@ class RESTApiHandler:
                  f"in schema {collection} was successful.")
         return web.Response(status=204)
 
+    async def put_object(self, req: Request) -> Response:
+        """Save metadata object to database.
+
+        :param req: PUT request
+        :returns: JSON response containing accessionId for submitted object
+        """
+        schema_type = req.match_info['schema']
+        accession_id = req.match_info['accessionId']
+        self._check_schema_exists(schema_type)
+        collection = (f"draft-{schema_type}" if req.path.startswith("/drafts")
+                      else schema_type)
+
+        db_client = req.app['db_client']
+        content = await req.json()
+        operator = Operator(db_client)
+        await operator.replace_metadata_object(collection,
+                                               accession_id,
+                                               content)
+        body = json.dumps({"accessionId": accession_id})
+        LOG.info(f"PUT object with accesssion ID {accession_id} "
+                 f"in schema {collection} was successful.")
+        return web.Response(body=body, status=201,
+                            content_type="application/json")
+
 
 class SubmissionAPIHandler:
     """Handler for non-rest API methods."""

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -39,10 +39,7 @@ class RESTApiHandler:
         :param req: GET request with query parameters
         :returns: JSON with query results
         """
-        schema_type = req.match_info['schema']
-        collection = (f"draft-{schema_type}" if req.path.startswith("/drafts")
-                      else schema_type)
-
+        collection = req.match_info['schema']
         format = req.query.get("format", "json").lower()
         if format == "xml":
             reason = "xml-formatted query results are not supported"

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -23,10 +23,10 @@ class RESTApiHandler:
     """Handler for REST API methods."""
 
     def _check_schema_exists(self, schema_type: str) -> None:
-        """Check is schema type exists.
+        """Check if schema type exists.
 
         :param schema_type: schema type.
-        :returns: None or HTTPNotFound if schema does not exist.
+        :raises: HTTPNotFound if schema does not exist.
         """
         if schema_type not in schema_types.keys():
             reason = f"Specified schema {schema_type} was not found."
@@ -34,7 +34,11 @@ class RESTApiHandler:
             raise web.HTTPNotFound(reason=reason)
 
     async def _handle_query(self, req: Request) -> Response:
-        """."""
+        """Handle query results.
+
+        :param req: GET request with query parameters
+        :returns: JSON with query results
+        """
         schema_type = req.match_info['schema']
         collection = (f"draft-{schema_type}" if req.path.startswith("/drafts")
                       else schema_type)

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -136,7 +136,8 @@ class RESTApiHandler:
                     else Operator(db_client))
         data, content_type = await operator.read_metadata_object(collection,
                                                                  accession_id)
-        data = data if format == "xml" else json.dumps(data)
+        data = (data if (format == "xml"
+                and not req.path.startswith("/drafts")) else json.dumps(data))
         LOG.info(f"GET object with accesssion ID {accession_id} "
                  f"from schema {collection}.")
         return web.Response(body=data, status=200, content_type=content_type)

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -22,6 +22,17 @@ from ..helpers.logger import LOG
 class RESTApiHandler:
     """Handler for REST API methods."""
 
+    def _check_schema_exists(self, schema_type: str) -> None:
+        """Check is schema type exists.
+
+        :param schema_type: schema type.
+        :returns: None or HTTPNotFound if schema does not exist.
+        """
+        if schema_type not in schema_types.keys():
+            reason = f"Specified schema {schema_type} was not found."
+            LOG.error(reason)
+            raise web.HTTPNotFound(reason=reason)
+
     async def get_schema_types(self, req: Request) -> Response:
         """Get all possible metadata schema types from database.
 
@@ -43,10 +54,8 @@ class RESTApiHandler:
         :returns: JSON list of schema types
         """
         schema_type = req.match_info['schema']
-        if schema_type not in schema_types.keys():
-            reason = f"Specified schema {schema_type} was not found."
-            LOG.error(reason)
-            raise web.HTTPNotFound(reason=reason)
+        self._check_schema_exists(schema_type)
+
         try:
             schema = JSONSchemaLoader().get_schema(schema_type)
             LOG.info(f"{schema_type} schema loaded.")
@@ -69,10 +78,8 @@ class RESTApiHandler:
         """
         accession_id = req.match_info['accessionId']
         schema_type = req.match_info['schema']
-        if schema_type not in schema_types.keys():
-            reason = f"Specified schema {schema_type} was not found."
-            LOG.error(reason)
-            raise web.HTTPNotFound(reason=reason)
+        self._check_schema_exists(schema_type)
+
         format = req.query.get("format", "json").lower()
         db_client = req.app['db_client']
         operator = (XMLOperator(db_client) if format == "xml"
@@ -91,10 +98,8 @@ class RESTApiHandler:
         :returns: JSON response containing accessionId for submitted object
         """
         schema_type = req.match_info['schema']
-        if schema_type not in schema_types.keys():
-            reason = f"Specified schema {schema_type} was not found."
-            LOG.error(reason)
-            raise web.HTTPNotFound(reason=reason)
+        self._check_schema_exists(schema_type)
+
         db_client = req.app['db_client']
         operator: Union[Operator, XMLOperator]
         if req.content_type == "multipart/form-data":
@@ -119,10 +124,8 @@ class RESTApiHandler:
         :returns: Query results as JSON
         """
         schema_type = req.match_info['schema']
-        if schema_type not in schema_types.keys():
-            reason = f"Specified schema {schema_type} was not found."
-            LOG.error(reason)
-            raise web.HTTPNotFound(reason=reason)
+        self._check_schema_exists(schema_type)
+
         format = req.query.get("format", "json").lower()
         if format == "xml":
             reason = "xml-formatted query results are not supported"
@@ -171,10 +174,8 @@ class RESTApiHandler:
         :returns: JSON response containing accessionId for submitted object
         """
         schema_type = req.match_info['schema']
-        if schema_type not in schema_types.keys():
-            reason = f"Specified schema {schema_type} was not found."
-            LOG.error(reason)
-            raise web.HTTPNotFound(reason=reason)
+        self._check_schema_exists(schema_type)
+
         accession_id = req.match_info['accessionId']
         db_client = req.app['db_client']
         await Operator(db_client).delete_metadata_object(schema_type,

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -131,8 +131,8 @@ class RESTApiHandler:
 
         format = req.query.get("format", "json").lower()
         db_client = req.app['db_client']
-        operator = (XMLOperator(db_client) if (format == "xml" and
-                    not req.path.startswith("/drafts"))
+        operator = (XMLOperator(db_client) if (format == "xml"
+                    and not req.path.startswith("/drafts"))
                     else Operator(db_client))
         data, content_type = await operator.read_metadata_object(collection,
                                                                  accession_id)
@@ -154,8 +154,8 @@ class RESTApiHandler:
 
         db_client = req.app['db_client']
         operator: Union[Operator, XMLOperator]
-        if (req.content_type == "multipart/form-data" and
-           not req.path.startswith("/drafts")):
+        if (req.content_type == "multipart/form-data"
+           and not req.path.startswith("/drafts")):
             files = await _extract_xml_upload(req, extract_one=True)
             content, _ = files[0]
             operator = XMLOperator(db_client)

--- a/metadata_backend/api/operators.py
+++ b/metadata_backend/api/operators.py
@@ -189,8 +189,8 @@ class BaseOperator(ABC):
         :returns: None
         """
         try:
-            check_exists = await self.db_service.exists(schema_type,
-                                                        accession_id)
+            check_exists = await operator.db_service.exists(schema_type,
+                                                            accession_id)
             if not check_exists:
                 reason = (f"Object with accession id {accession_id} "
                           "was not found.")

--- a/metadata_backend/api/operators.py
+++ b/metadata_backend/api/operators.py
@@ -128,6 +128,7 @@ class BaseOperator(ABC):
         :param schema_type: Schema type of the object to insert.
         :param data: Single document formatted as JSON
         :returns: Accession Id for object inserted to database
+        :raises: 400 if reading was not succesful
         """
         try:
             insert_success = (await self.db_service.create(schema_type, data))
@@ -145,11 +146,12 @@ class BaseOperator(ABC):
     async def _replace_object_from_db(self, schema_type: str,
                                       accession_id: str,
                                       data: Dict) -> str:
-        """Replace formatted metadata object to database.
+        """Replace formatted metadata object in database.
 
         :param schema_type: Schema type of the object to replace.
         :param accession_id: Identifier of object to replace.
         :param data: Single document formatted as JSON
+        :raises: 400 if reading was not succesful, 404 if no data found
         :returns: Accession Id for object inserted to database
         """
         try:
@@ -178,6 +180,14 @@ class BaseOperator(ABC):
                                      operator: Any,
                                      schema_type: str,
                                      accession_id: str) -> None:
+        """Delete object from database.
+
+        :param schema_type: Schema type of the object to delete.
+        :param accession_id: Identifier of object to delete.
+        :param data: Single document formatted as JSON
+        :raises: 400 if reading was not succesful, 404 if no data found
+        :returns: None
+        """
         try:
             check_exists = await self.db_service.exists(schema_type,
                                                         accession_id)

--- a/metadata_backend/api/operators.py
+++ b/metadata_backend/api/operators.py
@@ -114,9 +114,10 @@ class BaseOperator(ABC):
         await self._remove_object_from_db(Operator(db_client),
                                           schema_type,
                                           accession_id)
-        await self._remove_object_from_db(XMLOperator(db_client),
-                                          schema_type,
-                                          accession_id)
+        if not schema_type.startswith("draft"):
+            await self._remove_object_from_db(XMLOperator(db_client),
+                                              schema_type,
+                                              accession_id)
         LOG.info(f"removing object with schema {schema_type} from database "
                  f"and accession id: {accession_id}")
 

--- a/metadata_backend/api/operators.py
+++ b/metadata_backend/api/operators.py
@@ -320,7 +320,8 @@ class Operator(BaseOperator):
         """
         forbidden_keys = ['accessionId', 'publishDate', 'dateCreated']
         if any([i in data for i in forbidden_keys]):
-            reason = f"Some items (e.g: {forbidden_keys}) cannot be changed."
+            reason = (f"Some items (e.g: {', '.join(forbidden_keys)})"
+                      "cannot be changed.")
             LOG.error(reason)
             raise web.HTTPBadRequest(reason=reason)
         data["accessionId"] = accession_id

--- a/metadata_backend/api/operators.py
+++ b/metadata_backend/api/operators.py
@@ -153,6 +153,13 @@ class BaseOperator(ABC):
         :returns: Accession Id for object inserted to database
         """
         try:
+            check_exists = await self.db_service.exists(schema_type,
+                                                        accession_id)
+            if not check_exists:
+                reason = (f"Object with accession id {accession_id} "
+                          "was not found.")
+                LOG.error(reason)
+                raise web.HTTPNotFound(reason=reason)
             replace_success = (await self.db_service.replace(schema_type,
                                                              accession_id,
                                                              data))
@@ -172,6 +179,13 @@ class BaseOperator(ABC):
                                      schema_type: str,
                                      accession_id: str) -> None:
         try:
+            check_exists = await self.db_service.exists(schema_type,
+                                                        accession_id)
+            if not check_exists:
+                reason = (f"Object with accession id {accession_id} "
+                          "was not found.")
+                LOG.error(reason)
+                raise web.HTTPNotFound(reason=reason)
             delete_success = (await operator.db_service.delete(schema_type,
                                                                accession_id))
         except (ConnectionFailure, OperationFailure) as error:

--- a/metadata_backend/database/db_service.py
+++ b/metadata_backend/database/db_service.py
@@ -107,6 +107,8 @@ class DBService:
                       new_data: Dict) -> None:
         """Replace whole object by its accessionId.
 
+        We keep the dateCreated and publishDate dates as these
+        are connected with accession ID.
         :param collection: Collection where document should be searched from
         :param accession_id: Accession id for object to be updated
         :param new_data: JSON representing the data that replaces
@@ -114,6 +116,10 @@ class DBService:
         :returns: True if operation was successful
         """
         find_by_id_query = {"accessionId": accession_id}
+        old_data = await self.database[collection].find_one(find_by_id_query)
+        new_data['dateCreated'] = old_data['dateCreated']
+        if 'publishDate' in old_data:
+            new_data['publishDate'] = old_data['publishDate']
         result = await self.database[collection].replace_one(find_by_id_query,
                                                              new_data)
         LOG.debug(f"DB doc replaced for {accession_id}.")

--- a/metadata_backend/database/db_service.py
+++ b/metadata_backend/database/db_service.py
@@ -1,6 +1,6 @@
 """Services that handle database connections. Implemented with MongoDB."""
 from functools import wraps
-from typing import Any, Callable, Dict, Union
+from typing import Any, Callable, Dict
 
 from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorCursor
 from pymongo.errors import AutoReconnect, ConnectionFailure
@@ -117,7 +117,7 @@ class DBService:
 
     @auto_reconnect
     async def replace(self, collection: str, accession_id: str,
-                      new_data: Dict) -> Union[bool, str]:
+                      new_data: Dict) -> bool:
         """Replace whole object by its accessionId.
 
         We keep the dateCreated and publishDate dates as these

--- a/metadata_backend/database/db_service.py
+++ b/metadata_backend/database/db_service.py
@@ -74,6 +74,19 @@ class DBService:
         return result.acknowledged
 
     @auto_reconnect
+    async def exists(self, collection: str, accession_id: str) -> bool:
+        """Check object exists by its accessionId.
+
+        :param collection: Collection where document should be searched from
+        :param accession_id: Accession id of the document to be searched
+        :returns: True if exists and False if it does not
+        """
+        find_by_id = {"accessionId": accession_id}
+        LOG.debug(f"DB doc read for {accession_id}.")
+        exists = await self.database[collection].find_one(find_by_id)
+        return True if exists else False
+
+    @auto_reconnect
     async def read(self, collection: str, accession_id: str) -> Dict:
         """Find object by its accessionId.
 

--- a/metadata_backend/database/db_service.py
+++ b/metadata_backend/database/db_service.py
@@ -81,9 +81,9 @@ class DBService:
         :param accession_id: Accession id of the document to be searched
         :returns: First document matching the accession_id
         """
-        find_by_id_query = {"accessionId": accession_id}
+        find_by_id = {"accessionId": accession_id}
         LOG.debug(f"DB doc read for {accession_id}.")
-        return await self.database[collection].find_one(find_by_id_query)
+        return await self.database[collection].find_one(find_by_id)
 
     @auto_reconnect
     async def update(self, collection: str, accession_id: str,
@@ -96,16 +96,16 @@ class DBService:
         updated to object, can replace previous fields and add new ones.
         :returns: True if operation was successful
         """
-        find_by_id_query = {"accessionId": accession_id}
-        update_operation = {"$set": data_to_be_updated}
-        old_data = await self.database[collection].find_one(find_by_id_query)
+        find_by_id = {"accessionId": accession_id}
+        update_op = {"$set": data_to_be_updated}
+        old_data = await self.database[collection].find_one(find_by_id)
         if not old_data:
             reason = f"Object with accession id {accession_id} was not found."
             LOG.error(reason)
             raise web.HTTPNotFound(reason=reason)
         else:
-            result = await self.database[collection].update_one(find_by_id_query,
-                                                                update_operation)
+            result = await self.database[collection].update_one(find_by_id,
+                                                                update_op)
             LOG.debug(f"DB doc updated for {accession_id}.")
             return result.acknowledged
 
@@ -122,8 +122,8 @@ class DBService:
         old data
         :returns: True if operation was successful
         """
-        find_by_id_query = {"accessionId": accession_id}
-        old_data = await self.database[collection].find_one(find_by_id_query)
+        find_by_id = {"accessionId": accession_id}
+        old_data = await self.database[collection].find_one(find_by_id)
         if not old_data:
             reason = f"Object with accession id {accession_id} was not found."
             LOG.error(reason)
@@ -132,7 +132,7 @@ class DBService:
             new_data['dateCreated'] = old_data['dateCreated']
             if 'publishDate' in old_data:
                 new_data['publishDate'] = old_data['publishDate']
-            result = await self.database[collection].replace_one(find_by_id_query,
+            result = await self.database[collection].replace_one(find_by_id,
                                                                  new_data)
             LOG.debug(f"DB doc replaced for {accession_id}.")
             return result.acknowledged
@@ -145,8 +145,8 @@ class DBService:
         :param accession_id: Accession id for object to be updated
         :returns: True if operation was successful
         """
-        find_by_id_query = {"accessionId": accession_id}
-        result = await self.database[collection].delete_one(find_by_id_query)
+        find_by_id = {"accessionId": accession_id}
+        result = await self.database[collection].delete_one(find_by_id)
         if result.deleted_count < 1:
             reason = f"Object with accession id {accession_id} was not found."
             LOG.error(reason)

--- a/metadata_backend/database/db_service.py
+++ b/metadata_backend/database/db_service.py
@@ -1,6 +1,7 @@
 """Services that handle database connections. Implemented with MongoDB."""
 from functools import wraps
 from typing import Any, Callable, Dict
+from aiohttp import web
 
 from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorCursor
 from pymongo.errors import AutoReconnect, ConnectionFailure

--- a/metadata_backend/database/db_service.py
+++ b/metadata_backend/database/db_service.py
@@ -123,13 +123,18 @@ class DBService:
         """
         find_by_id_query = {"accessionId": accession_id}
         old_data = await self.database[collection].find_one(find_by_id_query)
-        new_data['dateCreated'] = old_data['dateCreated']
-        if 'publishDate' in old_data:
-            new_data['publishDate'] = old_data['publishDate']
-        result = await self.database[collection].replace_one(find_by_id_query,
-                                                             new_data)
-        LOG.debug(f"DB doc replaced for {accession_id}.")
-        return result.acknowledged
+        if not old_data:
+            reason = f"Object with accession id {accession_id} was not found."
+            LOG.error(reason)
+            raise web.HTTPNotFound(reason=reason)
+        else:
+            new_data['dateCreated'] = old_data['dateCreated']
+            if 'publishDate' in old_data:
+                new_data['publishDate'] = old_data['publishDate']
+            result = await self.database[collection].replace_one(find_by_id_query,
+                                                                 new_data)
+            LOG.debug(f"DB doc replaced for {accession_id}.")
+            return result.acknowledged
 
     @auto_reconnect
     async def delete(self, collection: str, accession_id: str) -> None:

--- a/metadata_backend/database/db_service.py
+++ b/metadata_backend/database/db_service.py
@@ -146,8 +146,13 @@ class DBService:
         """
         find_by_id_query = {"accessionId": accession_id}
         result = await self.database[collection].delete_one(find_by_id_query)
-        LOG.debug(f"DB doc deleted for {accession_id}.")
-        return result.acknowledged
+        if result.deleted_count < 1:
+            reason = f"Object with accession id {accession_id} was not found."
+            LOG.error(reason)
+            raise web.HTTPNotFound(reason=reason)
+        else:
+            LOG.debug(f"DB doc deleted for {accession_id}.")
+            return result.acknowledged
 
     def query(self, collection: str, query: Dict) -> AsyncIOMotorCursor:
         """Query database with given query.

--- a/metadata_backend/server.py
+++ b/metadata_backend/server.py
@@ -34,7 +34,6 @@ async def init() -> web.Application:
                    rest_handler.delete_object),
         web.get('/objects/{schema}', rest_handler.query_objects),
         web.post('/objects/{schema}', rest_handler.post_object),
-        web.get('/drafts/{schema}', rest_handler.query_objects),
         web.get('/drafts/{schema}/{accessionId}', rest_handler.get_object),
         web.put('/drafts/{schema}/{accessionId}', rest_handler.put_object),
         web.delete('/drafts/{schema}/{accessionId}',

--- a/metadata_backend/server.py
+++ b/metadata_backend/server.py
@@ -34,6 +34,12 @@ async def init() -> web.Application:
                    rest_handler.delete_object),
         web.get('/objects/{schema}', rest_handler.query_objects),
         web.post('/objects/{schema}', rest_handler.post_object),
+        web.get('/drafts/{schema}', rest_handler.query_objects),
+        web.get('/drafts/{schema}/{accessionId}', rest_handler.get_object),
+        web.put('/drafts/{schema}/{accessionId}', rest_handler.put_object),
+        web.delete('/drafts/{schema}/{accessionId}',
+                   rest_handler.delete_object),
+        web.post('/drafts/{schema}', rest_handler.post_object),
         web.post('/submit', submission_handler.submit),
         web.post('/validate', submission_handler.validate)
     ]

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -11,6 +11,7 @@ import aiohttp
 import logging
 from aiohttp import FormData
 from pathlib import Path
+import json
 
 # === Global vars ===
 FORMAT = "[%(asctime)s][%(name)s][%(process)d %(processName)s]" \
@@ -20,14 +21,22 @@ LOG = logging.getLogger(__name__)
 LOG.setLevel(logging.DEBUG)
 
 testfiles_root = Path(__file__).parent.parent / 'test_files'
-test_files = [
+test_xml_files = [
     ("study", "SRP000539.xml"),
     ("sample", "SRS001433.xml"),
     ("run", "ERR000076.xml"),
     ("experiment", "ERX000119.xml"),
     ("analysis", "ERZ266973.xml")
 ]
+test_json_files = [
+    ("study", "SRP000539.json"),
+    ("sample", "SRS001433.json"),
+    ("run", "ERR000076.json"),
+    ("experiment", "ERX000119.json"),
+    ("analysis", "ERZ266973.json")
+]
 base_url = "http://localhost:5430/objects"
+drafts_url = "http://localhost:5430/drafts"
 
 
 # === Helper functions ===
@@ -48,6 +57,19 @@ async def create_request_data(schema, filename):
     return data
 
 
+async def create_request_json_data(schema, filename):
+    """Create request data from pairs of schemas and filenames.
+
+    :param schema: name of the schema (folder) used for testing
+    :param filename: name of the file used for testing.
+    """
+    path_to_file = testfiles_root / schema / filename
+    path = path_to_file.as_posix()
+    with open(path, mode='r') as f:
+        data = json.load(f)
+    return data
+
+
 async def post_object(sess, schema, filename):
     """Post one metadata object within session, returns accession id."""
     data = await create_request_data(schema, filename)
@@ -61,6 +83,31 @@ async def post_object(sess, schema, filename):
 async def delete_object(sess, schema, accession_id):
     """Delete metadata object within session."""
     async with sess.delete(f"{base_url}/{schema}/{accession_id}") as resp:
+        LOG.debug(f"Deleting object {accession_id} from {schema}")
+        assert resp.status == 204, 'HTTP Status code error'
+
+
+async def put_draft(sess, schema, filename):
+    """Post & put one metadata object within session, returns accession id."""
+    data = await create_request_json_data(schema, filename)
+    async with sess.post(f"{drafts_url}/{schema}",
+                         data=json.dumps(data)) as resp:
+        LOG.debug(f"Adding new object to {schema}")
+        assert resp.status == 201, 'HTTP Status code error'
+        ans = await resp.json()
+        test_id = ans["accessionId"]
+    async with sess.put(f"{drafts_url}/{schema}/{test_id}",
+                        data=json.dumps(data)) as resp:
+        LOG.debug(f"Adding new object to {schema}")
+        assert resp.status == 201, 'HTTP Status code error'
+        ans_put = await resp.json()
+        assert ans_put["accessionId"] == test_id, 'accession ID error'
+        return ans_put["accessionId"]
+
+
+async def delete_draft(sess, schema, accession_id):
+    """Delete metadata object within session."""
+    async with sess.delete(f"{drafts_url}/{schema}/{accession_id}") as resp:
         LOG.debug(f"Deleting object {accession_id} from {schema}")
         assert resp.status == 204, 'HTTP Status code error'
 
@@ -96,13 +143,35 @@ async def test_crud_works(schema, filename):
             assert resp.status == 404, 'HTTP Status code error'
 
 
+async def test_crud_drafts_works(schema, filename):
+    """Test REST api POST, PUT and DELETE reqs.
+
+    Tries to create new object, gets accession id and checks if correct
+    resource is returned with that id. Finally deletes the object and checks it
+    was deleted.
+
+    :param schema: name of the schema (folder) used for testing
+    :param filename: name of the file used for testing.
+    """
+    async with aiohttp.ClientSession() as sess:
+        accession_id = await put_draft(sess, schema, filename)
+        async with sess.get(f"{drafts_url}/{schema}/{accession_id}") as resp:
+            LOG.debug(f"Checking that {accession_id} JSON is in {schema}")
+            assert resp.status == 200, 'HTTP Status code error'
+
+        await delete_draft(sess, schema, accession_id)
+        async with sess.get(f"{drafts_url}/{schema}/{accession_id}") as resp:
+            LOG.debug(f"Checking that JSON object {accession_id} was deleted")
+            assert resp.status == 404, 'HTTP Status code error'
+
+
 async def test_querying_works():
     """Test query endpoint with working and failing query."""
     async with aiohttp.ClientSession() as sess:
 
         accession_ids = await asyncio.gather(
             *[post_object(sess, schema, filename)
-              for schema, filename in test_files])
+              for schema, filename in test_xml_files])
 
         queries = {
             "study": [
@@ -148,7 +217,8 @@ async def test_querying_works():
 
         await asyncio.gather(*[delete_object(sess, schema, accession_id) for
                                schema, accession_id in
-                               list(zip([schema for schema, _ in test_files],
+                               list(zip([schema for schema, _
+                                        in test_xml_files],
                                         accession_ids))])
 
 
@@ -196,7 +266,13 @@ async def main():
     # Test adding and getting files
     LOG.debug("=== Testing basic CRUD operations ===")
     await asyncio.gather(
-        *[test_crud_works(schema, file) for schema, file in test_files]
+        *[test_crud_works(schema, file) for schema, file in test_xml_files]
+    )
+
+    LOG.debug("=== Testing basic CRUD drafts operations ===")
+    await asyncio.gather(
+        *[test_crud_drafts_works(schema, file)
+          for schema, file in test_json_files]
     )
 
     # Test queries

--- a/tests/test_files/analysis/ERZ266973.json
+++ b/tests/test_files/analysis/ERZ266973.json
@@ -1,0 +1,164 @@
+{
+    "analysis": {
+      "alias": "hipsci.rel-2016-01.rnaseq.transcripts.sc-20160209.sample_HPSI0114i-eipl_3",
+      "centerName": "SC",
+      "brokerName": "ENA",
+      "analysisCenter": "SC",
+      "analysisDate": "2016-02-09T10:10:10.0Z",
+      "accessionId": "ERZ266973",
+      "identifiers": {
+        "primaryId": "ERZ266973",
+        "submitterId": {
+          "namespace": "SC",
+          "value": "hipsci.rel-2016-01.rnaseq.transcripts.sc-20160209.sample_HPSI0114i-eipl_3"
+        }
+      },
+      "title": "HipSci RNA-seq transcripts counts (sample HPSI0114i-eipl_3)",
+      "description": "HipSci RNA-seq abundances of transcripts estimated by kallisto",
+      "studyRef": {
+        "refcenter": "SC",
+        "refname": "HipSci___RNAseq___healthy_volunteers-sc-3302",
+        "accessionId": "ERP007111",
+        "identifiers": {
+          "primaryId": "ERP007111",
+          "submitterId": {
+            "namespace": "SC",
+            "value": "HipSci___RNAseq___healthy_volunteers-sc-3302"
+          }
+        }
+      },
+      "sampleRef": {
+        "label": "HPSI0114i-eipl_3",
+        "refname": "SAMEA2536405",
+        "refcenter": "BioSD",
+        "accessionId": "ERS1148779",
+        "identifiers": {
+          "primaryId": "ERS1148779",
+          "submitterId": {
+            "namespace": "BioSD",
+            "value": "SAMEA2536405"
+          }
+        }
+      },
+      "analysisType": {
+        "processedReads": {
+          "assembly": {
+            "standard": {
+              "refname": "GRCh37",
+              "accessionId": "GCA_000001405.1"
+            }
+          },
+          "sequence": [
+            {
+              "label": "1",
+              "accessionId": "CM000663.1"
+            },
+            {
+              "label": "10",
+              "accessionId": "CM000672.1"
+            },
+            {
+              "label": "11",
+              "accessionId": "CM000673.1"
+            },
+            {
+              "label": "12",
+              "accessionId": "CM000674.1"
+            },
+            {
+              "label": "13",
+              "accessionId": "CM000675.1"
+            },
+            {
+              "label": "14",
+              "accessionId": "CM000676.1"
+            },
+            {
+              "label": "15",
+              "accessionId": "CM000677.1"
+            },
+            {
+              "label": "16",
+              "accessionId": "CM000678.1"
+            },
+            {
+              "label": "17",
+              "accessionId": "CM000679.1"
+            },
+            {
+              "label": "18",
+              "accessionId": "CM000680.1"
+            },
+            {
+              "label": "19",
+              "accessionId": "CM000681.1"
+            },
+            {
+              "label": "2",
+              "accessionId": "CM000664.1"
+            },
+            {
+              "label": "20",
+              "accessionId": "CM000682.1"
+            },
+            {
+              "label": "21",
+              "accessionId": "CM000683.1"
+            },
+            {
+              "label": "22",
+              "accessionId": "CM000684.1"
+            },
+            {
+              "label": "3",
+              "accessionId": "CM000665.1"
+            },
+            {
+              "label": "4",
+              "accessionId": "CM000666.1"
+            },
+            {
+              "label": "5",
+              "accessionId": "CM000667.1"
+            },
+            {
+              "label": "6",
+              "accessionId": "CM000668.1"
+            },
+            {
+              "label": "7",
+              "accessionId": "CM000669.1"
+            },
+            {
+              "label": "8",
+              "accessionId": "CM000670.1"
+            },
+            {
+              "label": "9",
+              "accessionId": "CM000671.1"
+            },
+            {
+              "label": "MT",
+              "accessionId": "J01415.2"
+            },
+            {
+              "label": "X",
+              "accessionId": "CM000685.1"
+            },
+            {
+              "label": "Y",
+              "accessionId": "CM000686.1"
+            }
+          ]
+        }
+      },
+      "files": {
+        "file": {
+          "filename": "ERZ266/ERZ266973/HPSI0114i-eipl_3.GRCh37.75.cdna.kallisto.transcripts.abundance.rnaseq.20160125.tsv",
+          "filetype": "other",
+          "checksumMethod": "MD5",
+          "checksum": "3185384933bd6dd54a5b869336c751df"
+        }
+      }
+    }
+  }

--- a/tests/test_files/experiment/ERX000119.json
+++ b/tests/test_files/experiment/ERX000119.json
@@ -1,0 +1,73 @@
+{
+    "experiment": {
+      "alias": "NA18504.3",
+      "centerName": "MPIMG",
+      "accessionId": "ERX000119",
+      "identifiers": {
+        "primaryId": "ERX000119",
+        "submitterId": {
+          "namespace": "MPIMG",
+          "value": "NA18504.3"
+        }
+      },
+      "studyRef": {
+        "refname": "1000Genomes Project Pilot 1",
+        "refcenter": "NCBI",
+        "accessionId": "SRP000031",
+        "identifiers": {
+          "primaryId": "SRP000031",
+          "submitterId": {
+            "namespace": "NCBI",
+            "value": "1000Genomes Project Pilot 1"
+          }
+        }
+      },
+      "design": {
+        "designDescription": "SOLiD sequencing of Human HapMap individual NA18504",
+        "sampleDescriptor": {
+          "refname": "NA18504",
+          "refcenter": "NCBI",
+          "accessionId": "SRS000099",
+          "identifiers": {
+            "primaryId": "SRS000099",
+            "submitterId": {
+              "namespace": "NCBI",
+              "value": "NA18504"
+            }
+          }
+        },
+        "libraryDescriptor": {
+          "libraryName": "NA18504.3",
+          "libraryStrategy": "WGS",
+          "librarySource": "GENOMIC",
+          "librarySelection": "RANDOM",
+          "libraryLayout": "single",
+          "libraryConstructionProtocol": "Standard SOLiD protocol"
+        },
+        "spotDescriptor": {
+          "spotDecodeSpec": {
+            "spotLength": 35,
+            "readSpec": {
+              "readIndex": 0,
+              "readClass": "Application Read",
+              "readType": "Forward",
+              "baseCoord": 1
+            }
+          }
+        }
+      },
+      "platform": "AB SOLiD System",
+      "processing": "true",
+      "experimentAttributes": [
+        {
+          "tag": "center_name",
+          "value": "mpimg"
+        },
+        {
+          "tag": "expected_number_bases",
+          "value": "4300",
+          "units": "MB"
+        }
+      ]
+    }
+  }

--- a/tests/test_files/run/ERR000076.json
+++ b/tests/test_files/run/ERR000076.json
@@ -1,0 +1,53 @@
+{
+    "run": {
+      "alias": "BGI-FC304RWAAXX",
+      "runDate": "2008-07-08T00:00:00.000+01:00",
+      "runCenter": "BGI",
+      "centerName": "BGI",
+      "accessionId": "ERR000076",
+      "identifiers": {
+        "primaryId": "ERR000076",
+        "submitterId": {
+          "namespace": "BGI",
+          "value": "BGI-FC304RWAAXX"
+        }
+      },
+      "experimentRef": {
+        "refname": "g1k-bgi-NA18542-HUMsgR2ACDECBPE",
+        "refcenter": "BGI",
+        "accessionId": "ERX000037",
+        "identifiers": {
+          "primaryId": "ERX000037",
+          "submitterId": {
+            "namespace": "BGI",
+            "value": "g1k-bgi-NA18542-HUMsgR2ACDECBPE"
+          }
+        }
+      },
+      "files": [
+        {
+          "file": {
+            "filename": "ERA000/ERA000014/srf/BGI-FC304RWAAXX_5.srf",
+            "filetype": "srf",
+            "checksum": "3dfebb4b30211523853805439fbd7cec",
+            "checksumMethod": "MD5"
+          }
+        }
+      ],
+      "runAttributes": [
+        {
+          "tag": "run",
+          "value": "FC304RWAAXX"
+        },
+        {
+          "tag": "actual_read_length",
+          "value": "102"
+        },
+        {
+          "tag": "total_bases",
+          "value": "798445800",
+          "units": "bp"
+        }
+      ]
+    }
+  }

--- a/tests/test_files/sample/SRS001433.json
+++ b/tests/test_files/sample/SRS001433.json
@@ -1,0 +1,54 @@
+{
+    "sample": {
+      "centerName": "HapMap",
+      "alias": "NA18758",
+      "accessionId": "SRS001433",
+      "identifiers": {
+        "primaryId": "SRS001433",
+        "externalId": {
+          "namespace": "BioSample",
+          "value": "SAMN00000985"
+        },
+        "submitterId": {
+          "namespace": "HapMap",
+          "value": "NA18758"
+        }
+      },
+      "title": "HapMap sample from Homo sapiens",
+      "sampleName": {
+        "taxonId": 9606,
+        "scientificName": "Homo sapiens"
+      },
+      "description": "Human HapMap individual NA18758",
+      "sampleLinks": {
+        "urlLinks": [
+          {
+            "label": "DNA source",
+            "url": "http://ccr.coriell.org/Sections/Collections/NHGRI/hapmap.aspx?PgId=266"
+          }
+        ]
+      },
+      "sampleAttributes": [
+        {
+          "tag": "population",
+          "value": "CHB"
+        },
+        {
+          "tag": "Coriell plate",
+          "value": "1"
+        },
+        {
+          "tag": "Coriell cell culture ID",
+          "value": "N/A"
+        },
+        {
+          "tag": "HapMap sample ID",
+          "value": "NA18758"
+        },
+        {
+          "tag": "BioSampleModel",
+          "value": "HapMap"
+        }
+      ]
+    }
+  }

--- a/tests/test_files/study/SRP000539.json
+++ b/tests/test_files/study/SRP000539.json
@@ -1,0 +1,41 @@
+{
+    "study": {
+      "centerName": "GEO",
+      "alias": "GSE10966",
+      "accessionId": "SRP000539",
+      "identifiers": {
+        "primaryId": "SRP000539",
+        "externalId": [
+          {
+            "namespace": "BioProject",
+            "label": "primary",
+            "value": "PRJNA108793"
+          },
+          {
+            "namespace": "GEO",
+            "value": "GSE10966"
+          }
+        ]
+      },
+      "descriptor": {
+        "studyTitle": "Highly integrated epigenome maps in Arabidopsis - whole genome shotgun bisulfite sequencing",
+        "studyType": "Other",
+        "studyAbstract": "Part of a set of highly integrated epigenome maps for Arabidopsis thaliana. Keywords: Illumina high-throughput bisulfite sequencing Overall design: Whole genome shotgun bisulfite sequencing of wildtype Arabidopsis plants (Columbia-0), and met1, drm1 drm2 cmt3, and ros1 dml2 dml3 null mutants using the Illumina Genetic Analyzer.",
+        "centerProjectName": "GSE10966"
+      },
+      "studyLinks": {
+        "xrefLinks": [
+          {
+            "db": "pubmed",
+            "id": "18423832"
+          }
+        ]
+      },
+      "studyAttributes": [
+        {
+          "tag": "parent_bioproject",
+          "value": "PRJNA107265"
+        }
+      ]
+    }
+  }

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -204,6 +204,27 @@ class HandlersTestCase(AioHTTPTestCase):
         self.MockedOperator().create_metadata_object.assert_called_once()
 
     @unittest_run_loop
+    async def test_submit_draft_works_with_json(self):
+        """Test that draft json submission is handled , operator is called."""
+        json_req = {"centerName": "GEO",
+                    "alias": "GSE10966"}
+        response = await self.client.post("/drafts/study", json=json_req)
+        self.assertEqual(response.status, 201)
+        self.assertIn(self.test_ega_string, await response.text())
+        self.MockedOperator().create_metadata_object.assert_called_once()
+
+    @unittest_run_loop
+    async def test_put_draft_works_with_json(self):
+        """Test that draft json put method is handled , operator is called."""
+        json_req = {"centerName": "GEO",
+                    "alias": "GSE10966"}
+        call = "/drafts/study/EGA123456"
+        response = await self.client.put(call, json=json_req)
+        self.assertEqual(response.status, 201)
+        self.assertIn(self.test_ega_string, await response.text())
+        self.MockedOperator().replace_metadata_object.assert_called_once()
+
+    @unittest_run_loop
     async def test_submit_object_fails_with_too_many_files(self):
         """Test that sending two files to endpoint results failure."""
         files = [("study", "SRP000539.xml"),
@@ -218,6 +239,15 @@ class HandlersTestCase(AioHTTPTestCase):
     async def test_get_object(self):
         """Test that accessionId returns correct json object."""
         url = f"/objects/study/{self.query_accessionId}"
+        response = await self.client.get(url)
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.content_type, "application/json")
+        self.assertEqual(self.metadata_json, await response.json())
+
+    @unittest_run_loop
+    async def test_get_draft_object(self):
+        """Test that draft accessionId returns correct json object."""
+        url = f"/drafts/study/{self.query_accessionId}"
         response = await self.client.get(url)
         self.assertEqual(response.status, 200)
         self.assertEqual(response.content_type, "application/json")
@@ -331,7 +361,17 @@ class HandlersTestCase(AioHTTPTestCase):
         json_get_resp = await get_resp.json()
         self.assertIn("Specified schema", json_get_resp['detail'])
 
+        get_resp = await self.client.get("/drafts/bad_scehma_name")
+        self.assertEqual(get_resp.status, 404)
+        json_get_resp = await get_resp.json()
+        self.assertIn("Specified schema", json_get_resp['detail'])
+
         get_resp = await self.client.delete("/objects/bad_scehma_name/some_id")
+        self.assertEqual(get_resp.status, 404)
+        json_get_resp = await get_resp.json()
+        self.assertIn("Specified schema", json_get_resp['detail'])
+
+        get_resp = await self.client.delete("/drafts/bad_scehma_name/some_id")
         self.assertEqual(get_resp.status, 404)
         json_get_resp = await get_resp.json()
         self.assertIn("Specified schema", json_get_resp['detail'])
@@ -344,4 +384,6 @@ class HandlersTestCase(AioHTTPTestCase):
         get_resp = await self.client.get("/objects/study?page=0")
         self.assertEqual(get_resp.status, 400)
         get_resp = await self.client.get("/objects/study?per_page=0")
+        self.assertEqual(get_resp.status, 400)
+        get_resp = await self.client.get("/drafts/study?per_page=0")
         self.assertEqual(get_resp.status, 400)

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -361,11 +361,6 @@ class HandlersTestCase(AioHTTPTestCase):
         json_get_resp = await get_resp.json()
         self.assertIn("Specified schema", json_get_resp['detail'])
 
-        get_resp = await self.client.get("/drafts/bad_scehma_name")
-        self.assertEqual(get_resp.status, 404)
-        json_get_resp = await get_resp.json()
-        self.assertIn("Specified schema", json_get_resp['detail'])
-
         get_resp = await self.client.delete("/objects/bad_scehma_name/some_id")
         self.assertEqual(get_resp.status, 404)
         json_get_resp = await get_resp.json()
@@ -384,6 +379,4 @@ class HandlersTestCase(AioHTTPTestCase):
         get_resp = await self.client.get("/objects/study?page=0")
         self.assertEqual(get_resp.status, 400)
         get_resp = await self.client.get("/objects/study?per_page=0")
-        self.assertEqual(get_resp.status, 400)
-        get_resp = await self.client.get("/drafts/study?per_page=0")
         self.assertEqual(get_resp.status, 400)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -43,7 +43,7 @@ class AppTestCase(AioHTTPTestCase):
     async def test_api_routes_are_set(self):
         """Test correct amount of api (no frontend) routes is set."""
         server = await self.get_application()
-        self.assertIs(len(server.router.resources()), 9)
+        self.assertIs(len(server.router.resources()), 8)
 
     @unittest_run_loop
     async def test_frontend_routes_are_set(self):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -43,7 +43,7 @@ class AppTestCase(AioHTTPTestCase):
     async def test_api_routes_are_set(self):
         """Test correct amount of api (no frontend) routes is set."""
         server = await self.get_application()
-        self.assertIs(len(server.router.resources()), 6)
+        self.assertIs(len(server.router.resources()), 9)
 
     @unittest_run_loop
     async def test_frontend_routes_are_set(self):


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

Fixes #53 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Changes Made

<!-- List changes made. -->
1. added new endpoints for `drafts` submission
   * structuring into `/objects/drafts` proved challenging to use `/objects/{schema}/{accession_id}` therefore moved to separate endpoints
   * reused existing function
2. moved query code private function to address code reuse
3. add put endpoint for draft submission but making it general to address other object types
4. typo fixes in method documentation
5. raise error if deleted document not found also on update and replace
6. fix tests
7. other small fixes

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests
- [x] Integration Tests

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
