### PR TITLE
Bugfix integer parameter query and filetype

### DIFF
--- a/metadata_backend/conf/conf.py
+++ b/metadata_backend/conf/conf.py
@@ -82,7 +82,7 @@ query_map = {
                    "keys": ["taxonId", "scientificName",
                             "commonName"]},
     "scientificName": "sampleName.scientificName",
-    "fileType": "dataBlock.files.file.filetype",
+    "fileType": "files.file.filetype",
     "studyReference": {"base": "studyRef",
                        "keys": ["accessionId", "refname", "refcenter"]},
     "sampleReference": {"base": "sampleRef",

--- a/metadata_backend/helpers/parser.py
+++ b/metadata_backend/helpers/parser.py
@@ -75,6 +75,10 @@ class MetadataXMLConverter(XMLSchemaConverter):
                 children[key] = list(value.values())[0]['instrumentModel']
                 continue
 
+            if "dataBlock" in key:
+                children['files'] = list(value.values())
+                continue
+
             if key in links and len(value) == 1:
                 grp = defaultdict(list)
                 if isinstance(value[key[:-1]], dict):
@@ -136,6 +140,8 @@ class MetadataXMLConverter(XMLSchemaConverter):
           the structure.
         - Study type takes the value of its attribute existingStudyType.
         - Platform data we assign the string value of the instrument Model.
+        - dataBlock has the content of files array to be the same in run
+          and analysis.
         """
         xsd_type = xsd_type or xsd_element.type
         if xsd_type.simple_type is not None:

--- a/metadata_backend/helpers/schemas/ena_analysis.json
+++ b/metadata_backend/helpers/schemas/ena_analysis.json
@@ -408,71 +408,71 @@
             }
         },
         "files": {
-            "type": "object",
+            "type": "array",
             "title": "files",
             "required": [
                 "file"
             ],
-            "additionalProperties": true,
-            "properties": {
-                "file": {
-                    "type": "object",
-                    "title": "file",
-                    "required": [
-                        "filename",
-                        "filetype",
-                        "checksumMethod",
-                        "checksum"
-                    ],
-                    "additionalProperties": true,
-                    "properties": {
-                        "filename": {
-                            "type": "string",
-                            "title": "filename"
-                        },
-                        "filetype": {
-                            "type": "string",
-                            "title": "filetype",
-                            "enum": [
-                                "tab",
-                                "bam",
-                                "bai",
-                                "cram",
-                                "crai",
-                                "vcf",
-                                "vcf_aggregate",
-                                "bcf",
-                                "tabix",
-                                "wig",
-                                "bed",
-                                "gff",
-                                "fasta",
-                                "fastq",
-                                "flatfile",
-                                "chromosome_list",
-                                "sample_list",
-                                "readme_file",
-                                "phenotype_file",
-                                "BioNano_native",
-                                "Kallisto_native",
-                                "agp",
-                                "unlocalised_list",
-                                "info",
-                                "manifest",
-                                "other"
-                            ]
-                        },
-                        "checksumMethod": {
-                            "type": "string",
-                            "title": "checksumMethod",
-                            "enum": [
-                                "MD5",
-                                "SHA256"
-                            ]
-                        },
-                        "checksum": {
-                            "type": "string",
-                            "title": "checksum"
+            "items": {
+                "properties": {
+                    "file": {
+                        "type": "object",
+                        "title": "file",
+                        "required": [
+                            "filename",
+                            "filetype",
+                            "checksumMethod",
+                            "checksum"
+                        ],
+                        "properties": {
+                            "filename": {
+                                "type": "string",
+                                "title": "filename"
+                            },
+                            "filetype": {
+                                "type": "string",
+                                "title": "filetype",
+                                "enum": [
+                                    "tab",
+                                    "bam",
+                                    "bai",
+                                    "cram",
+                                    "crai",
+                                    "vcf",
+                                    "vcf_aggregate",
+                                    "bcf",
+                                    "tabix",
+                                    "wig",
+                                    "bed",
+                                    "gff",
+                                    "fasta",
+                                    "fastq",
+                                    "flatfile",
+                                    "chromosome_list",
+                                    "sample_list",
+                                    "readme_file",
+                                    "phenotype_file",
+                                    "BioNano_native",
+                                    "Kallisto_native",
+                                    "agp",
+                                    "unlocalised_list",
+                                    "info",
+                                    "manifest",
+                                    "other"
+                                ]
+                            },
+                            "checksumMethod": {
+                                "type": "string",
+                                "title": "checksumMethod",
+                                "enum": [
+                                    "MD5",
+                                    "SHA256"
+                                ]
+                            },
+                            "checksum": {
+                                "type": "string",
+                                "title": "checksum"
+                            }
                         }
                     }
                 }

--- a/metadata_backend/helpers/schemas/ena_run.json
+++ b/metadata_backend/helpers/schemas/ena_run.json
@@ -232,7 +232,6 @@
             "required": [
                 "file"
             ],
-            "additionalProperties": true,
             "properties": {
                 "file": {
                     "type": "object",
@@ -243,7 +242,6 @@
                         "checksumMethod",
                         "checksum"
                     ],
-                    "additionalProperties": true,
                     "properties": {
                         "filename": {
                             "type": "string",

--- a/metadata_backend/helpers/schemas/ena_run.json
+++ b/metadata_backend/helpers/schemas/ena_run.json
@@ -228,78 +228,73 @@
         "fileType": {
             "$id": "#/definitions/fileType",
             "type": "object",
+            "title": "files",
+            "required": [
+                "file"
+            ],
+            "additionalProperties": true,
             "properties": {
-                "files": {
+                "file": {
                     "type": "object",
-                    "title": "files",
+                    "title": "file",
                     "required": [
-                        "file"
+                        "filename",
+                        "filetype",
+                        "checksumMethod",
+                        "checksum"
                     ],
                     "additionalProperties": true,
                     "properties": {
-                        "file": {
-                            "type": "object",
-                            "title": "file",
-                            "required": [
-                                "filename",
-                                "filetype",
-                                "checksumMethod",
-                                "checksum"
-                            ],
-                            "additionalProperties": true,
-                            "properties": {
-                                "filename": {
-                                    "type": "string",
-                                    "title": "filename"
-                                },
-                                "filetype": {
-                                    "type": "string",
-                                    "title": "filetype",
-                                    "enum": [
-                                        "tab",
-                                        "bam",
-                                        "bai",
-                                        "cram",
-                                        "crai",
-                                        "vcf",
-                                        "vcf_aggregate",
-                                        "bcf",
-                                        "tabix",
-                                        "wig",
-                                        "sra",
-                                        "sff",
-                                        "srf",
-                                        "bed",
-                                        "gff",
-                                        "fasta",
-                                        "fastq",
-                                        "flatfile",
-                                        "chromosome_list",
-                                        "sample_list",
-                                        "readme_file",
-                                        "phenotype_file",
-                                        "BioNano_native",
-                                        "Kallisto_native",
-                                        "agp",
-                                        "unlocalised_list",
-                                        "info",
-                                        "manifest",
-                                        "other"
-                                    ]
-                                },
-                                "checksumMethod": {
-                                    "type": "string",
-                                    "title": "checksumMethod",
-                                    "enum": [
-                                        "MD5",
-                                        "SHA256"
-                                    ]
-                                },
-                                "checksum": {
-                                    "type": "string",
-                                    "title": "checksum"
-                                }
-                            }
+                        "filename": {
+                            "type": "string",
+                            "title": "filename"
+                        },
+                        "filetype": {
+                            "type": "string",
+                            "title": "filetype",
+                            "enum": [
+                                "tab",
+                                "bam",
+                                "bai",
+                                "cram",
+                                "crai",
+                                "vcf",
+                                "vcf_aggregate",
+                                "bcf",
+                                "tabix",
+                                "wig",
+                                "sra",
+                                "sff",
+                                "srf",
+                                "bed",
+                                "gff",
+                                "fasta",
+                                "fastq",
+                                "flatfile",
+                                "chromosome_list",
+                                "sample_list",
+                                "readme_file",
+                                "phenotype_file",
+                                "BioNano_native",
+                                "Kallisto_native",
+                                "agp",
+                                "unlocalised_list",
+                                "info",
+                                "manifest",
+                                "other"
+                            ]
+                        },
+                        "checksumMethod": {
+                            "type": "string",
+                            "title": "checksumMethod",
+                            "enum": [
+                                "MD5",
+                                "SHA256"
+                            ]
+                        },
+                        "checksum": {
+                            "type": "string",
+                            "title": "checksum"
                         }
                     }
                 }
@@ -532,20 +527,12 @@
                 }
             ]
         },
-        "dataBlock": {
-            "oneOf": [
-                {
-                    "title": "Single File",
-                    "$ref": "#/definitions/fileType"
-                },
-                {
-                    "type": "array",
-                    "title": "Data Block, files",
-                    "items": {
-                        "$ref": "#/definitions/fileType"
-                    }
-                }
-            ]
+        "files": {
+            "type": "array",
+            "title": "files",
+            "items": {
+                "$ref": "#/definitions/fileType"
+            }
         },
         "runLinks": {
             "type": "object",

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -129,6 +129,7 @@ async def test_querying_works():
                 ("studyReference", "1000Genomes project pilot")
             ],
             "analysis": [
+                ("fileType", "other"),
                 ("studyReference", "HipSci___RNAseq___"),
                 ("sampleReference", "HPSI0114i-eipl_3")
             ]

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -117,7 +117,8 @@ async def test_querying_works():
                 ("description", "human hapmap individual"),
                 ("centerName", "hapmap"),
                 ("sampleName", "homo sapiens"),
-                ("scientificName", "homo sapiens")
+                ("scientificName", "homo sapiens"),
+                ("sampleName", 9606)
             ],
             "run": [
                 ("fileType", "srf"),

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -62,7 +62,7 @@ class ParserTestCase(unittest.TestCase):
         run_xml = self.load_xml_from_file("run", "ERR000076.xml")
         run_json = self.parser.parse("run", run_xml)
         self.assertIn("ERA000/ERA000014/srf/BGI-FC304RWAAXX_5.srf",
-                      run_json['dataBlock']['files']['file']['filename'])
+                      run_json['files'][0]['file']['filename'])
         self.assertIn("ERX000037", run_json['experimentRef']['accessionId'])
 
     def test_analysis_is_parsed(self):


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

Fixes #76 
Fixes #77

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

<!-- List changes made. -->
1. added option to check if query parameter is integer and address accordingly
2. adjust `dataBlock` to contain the content of files making `run` an `analysis` under the same format
3. adjust query map for `filetype` query
4. adjust schemas for new parser change

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Integration Tests 

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
