### PR TITLE
Add link headers for pagination results

### DIFF
--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -103,7 +103,7 @@ class RESTApiHandler:
         url = f"{req.scheme}://{req.host}{req.path}"
         link_headers = self._header_links(url, page_num,
                                           per_page, total_objects)
-        LOG.info(link_headers)
+        LOG.debug(f"Pagination header links: {link_headers}")
         LOG.info(f"Querying for objects in {collection} "
                  f"resulted in {total_objects} objects ")
         return web.Response(body=result, status=200,

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -50,7 +50,8 @@ class RESTApiHandler:
                      if page < total_pages else "")
         last_link = (f'<{url}?page={total_pages}&per_page={size}>; rel="last"'
                      if page < total_pages else "")
-        first_link = (f'<{url}?page=1&per_page={size}>; rel="first", '
+        comma = (", " if page > 1 and page < total_pages else "")
+        first_link = (f'<{url}?page=1&per_page={size}>; rel="first"{comma}'
                       if page > 1 else "")
         links = f"{prev_link}{next_link}{first_link}{last_link}"
         link_headers = {"Link": f"{links}"}

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -33,6 +33,30 @@ class RESTApiHandler:
             LOG.error(reason)
             raise web.HTTPNotFound(reason=reason)
 
+    def _header_links(self, url: str, page: int, size: int,
+                      total_objects: int) -> Dict[str, str]:
+        """Create link header for pagination.
+
+        :param url: base url for request
+        :param page: current page
+        :param size: results per page
+        :param total_objects: total objects to compute the total pages
+        :returns: JSON with query results
+        """
+        total_pages = ceil(total_objects / size)
+        prev_link = (f'<{url}?page={page-1}&per_page={size}>; rel="prev", '
+                     if page > 1 else "")
+        next_link = (f'<{url}?page={page+1}&per_page={size}>; rel="next", '
+                     if page < total_pages else "")
+        last_link = (f'<{url}?page={total_pages}&per_page={size}>; rel="last"'
+                     if page < total_pages else "")
+        first_link = (f'<{url}?page=1&per_page={size}>; rel="first", '
+                      if page > 1 else "")
+        links = f"{prev_link}{next_link}{first_link}{last_link}"
+        link_headers = {"Link": f"{links}"}
+        LOG.debug("Link headers created")
+        return link_headers
+
     async def _handle_query(self, req: Request) -> Response:
         """Handle query results.
 
@@ -76,9 +100,14 @@ class RESTApiHandler:
             },
             "objects": data
         })
+        url = f"{req.scheme}://{req.host}{req.path}"
+        link_headers = self._header_links(url, page_num,
+                                          per_page, total_objects)
+        LOG.info(link_headers)
         LOG.info(f"Querying for objects in {collection} "
                  f"resulted in {total_objects} objects ")
         return web.Response(body=result, status=200,
+                            headers=link_headers,
                             content_type="application/json")
 
     async def get_schema_types(self, req: Request) -> Response:


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->

use the RFC5988 as a template.

result:

```
➜ curl -vvv --location --request GET 'http://localhost:5430/objects/study?page=2&per_page=5' \
--header 'Accept: */*'
* About to connect() to localhost port 5430 (#0)
*   Trying ::1...
* Connected to localhost (::1) port 5430 (#0)
> GET /objects/study?page=2&per_page=5 HTTP/1.1
> User-Agent: curl/7.29.0
> Host: localhost:5430
> Accept: */*
> 
< HTTP/1.1 200 OK
< Link: <http://localhost:5430/objects/study?page=1&per_page=5>; rel="prev", <http://localhost:5430/objects/study?page=3&per_page=5>; rel="next", <http://localhost:5430/objects/study?page=1&per_page=5>; rel="first", <http://localhost:5430/objects/study?page=36&per_page=5>; rel="last"
< Content-Type: application/json
< Content-Length: 5414
< Date: Tue, 28 Jul 2020 14:00:45 GMT
< Server: Python/3.7 aiohttp/3.6.2
```


### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->



Fixes #75 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

<!-- List changes made. -->

1. added private method `_header_links` in order to construct headers for pagination requests

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

I would say:
- [x] Tests do not apply

 or they can be added later

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
