### PR TITLE
Add folder get methods

### DIFF
--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -302,12 +302,6 @@ class RESTApiHandler:
         """
         db_client = req.app['db_client']
         db_service = DBService("folders", db_client)
-        """
-        if not db_service.database["folder"].count_documents({}):
-            reason = f"No folders found."
-            LOG.error(reason)
-            raise web.HTTPNotFound(reason=reason)
-        """
         cursor = db_service.query("folder", {})
         folders = [folder async for folder in cursor]
         body = json.dumps({"folders": folders})

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -15,12 +15,12 @@ from xmlschema import XMLSchemaException
 
 from ..conf.conf import schema_types
 from ..database.db_service import DBService
+from ..helpers.logger import LOG
 from ..helpers.parser import XMLToJSONParser
-from ..helpers.schema_loader import (XMLSchemaLoader, SchemaNotFoundException,
-                                     JSONSchemaLoader)
+from ..helpers.schema_loader import (JSONSchemaLoader, SchemaNotFoundException,
+                                     XMLSchemaLoader)
 from ..helpers.validator import XMLValidator
 from .operators import Operator, XMLOperator
-from ..helpers.logger import LOG
 
 
 class RESTApiHandler:

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -357,7 +357,7 @@ class RESTApiHandler:
         try:
             folder = await db_service.read("folder", folder_id)
             if not folder:
-                reason = f"Folder with {folder_id} not found."
+                reason = f"Folder with id {folder_id} not found."
                 LOG.error(reason)
                 raise web.HTTPNotFound(reason=reason)
         except (ConnectionFailure, OperationFailure) as error:
@@ -365,7 +365,7 @@ class RESTApiHandler:
             LOG.error(reason)
             raise web.HTTPBadRequest(reason=reason)
 
-        del folder['_id']  # remove unneccessary mongodb id from result
+        folder.pop('_id', None)  # remove unneccessary mongodb id from result
         LOG.info(f"GET folder with folder ID {folder_id}.")
         return web.Response(body=json.dumps(folder), status=200,
                             content_type="application/json")

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -344,8 +344,15 @@ class RESTApiHandler:
         :param req: GET request
         :returns: JSON response containing object folder
         """
-        # folder_id = req.match_info['folderId']
-        raise web.HTTPNotImplemented
+        folder_id = req.match_info['folderId']
+        db_client = req.app['db_client']
+        db_service = DBService('folders', db_client)
+        # TODO: edit db_service.read() in DBService so that below works
+        data = await db_service.read("folder", folder_id)
+        LOG.info(f"GET folder with folder ID {folder_id}.")
+        return web.Response(body=data, status=200,
+                            content_type="application/json")
+
 
     async def replace_folder(self, req: Request) -> Response:
         """Replace object folder with a specific folder id.

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -348,17 +348,17 @@ class RESTApiHandler:
         db_client = req.app['db_client']
         db_service = DBService("folders", db_client)
         try:
-            raw_data = await db_service.read("folder", folder_id)
-            if not raw_data:
+            folder = await db_service.read("folder", folder_id)
+            if not folder:
                 reason = f"Folder with {folder_id} not found."
                 LOG.error(reason)
                 raise web.HTTPNotFound(reason=reason)
-            folder = await self._format_folder_data(raw_data)
         except (ConnectionFailure, OperationFailure) as error:
             reason = f"Error happened while getting folder: {error}"
             LOG.error(reason)
             raise web.HTTPBadRequest(reason=reason)
 
+        del folder['_id']  # remove unneccessary mongodb id from result
         LOG.info(f"GET folder with folder ID {folder_id}.")
         return web.Response(body=folder, status=200,
                             content_type="application/json")
@@ -395,15 +395,6 @@ class RESTApiHandler:
         sequence = ''.join(secrets.choice(string.digits) for i in range(8))
         LOG.debug("Generated folder ID.")
         return f"FOL{sequence}"
-
-    def _format_folder_data(self, raw_data: Dict) -> Dict:
-        """Get JSON content of folder from given mongodb data.
-
-        :param schema_type: Schema type of the object to read.
-        :param raw_data: Data from mongodb query, can contain multiple results
-        :returns: Mongodb query result, formatted to readable dicts
-        """
-        raise web.HTTPNotImplemented
 
 
 class SubmissionAPIHandler:

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -297,9 +297,19 @@ class RESTApiHandler:
         """Get all possible object folders from database.
 
         :param req: GET Request
-        :returns: JSON list of folders
+        :returns: JSON list of folders available for the user
         """
-        raise web.HTTPNotImplemented
+        db_client = req.app['db_client']
+        db_service = DBService('folders', db_client)
+        collection = db_service.database['folder']
+        cursor = collection.find({})
+        folders = []
+        for folder in cursor:
+            folders.append(folder)
+        body = json.dumps({"folders": folders})
+        LOG.info(f"GET folders. Retrieved {len(folders)} folders.")
+        return web.Response(body=body, status=200,
+                            content_type="application/json")
 
     async def post_folder(self, req: Request) -> Response:
         """Save object folder to database.
@@ -308,7 +318,7 @@ class RESTApiHandler:
         :returns: JSON response containing folder ID for submitted object
         """
         db_client = req.app['db_client']
-        db_service = DBService("folders", db_client)
+        db_service = DBService('folders', db_client)
         data = await req.json()
         data['folderId'] = self._generate_folder_id()
         try:

--- a/metadata_backend/api/middlewares.py
+++ b/metadata_backend/api/middlewares.py
@@ -7,7 +7,7 @@ from typing import Callable
 
 from aiohttp import web
 from aiohttp.web import Request, Response, middleware
-from authlib.jose import jwt, errors
+from authlib.jose import errors, jwt
 from yarl import URL
 
 from ..helpers.logger import LOG

--- a/metadata_backend/conf/conf.py
+++ b/metadata_backend/conf/conf.py
@@ -35,6 +35,7 @@ import os
 from pathlib import Path
 
 from motor.motor_asyncio import AsyncIOMotorClient
+
 from ..helpers.logger import LOG
 
 # 1) Set up database client and custom timeouts for spesific parameters.

--- a/metadata_backend/database/db_service.py
+++ b/metadata_backend/database/db_service.py
@@ -93,10 +93,8 @@ class DBService:
         :param id: Accession id of the document or folder id of the folder
         :returns: First document matching the accession_id
         """
-        if collection == "folder":
-            find_by_id = {"folderId": id}
-        else:
-            find_by_id = {"accessionId": id}
+        id_key = "folderId" if collection == "folder" else "accessionId"
+        find_by_id = {id_key: id}
         LOG.debug(f"DB doc read for {id}.")
         return await self.database[collection].find_one(find_by_id)
 

--- a/metadata_backend/database/db_service.py
+++ b/metadata_backend/database/db_service.py
@@ -86,15 +86,18 @@ class DBService:
         return True if exists else False
 
     @auto_reconnect
-    async def read(self, collection: str, accession_id: str) -> Dict:
+    async def read(self, collection: str, id: str) -> Dict:
         """Find object by its accessionId.
 
         :param collection: Collection where document should be searched from
-        :param accession_id: Accession id of the document to be searched
+        :param id: Accession id of the document or folder id of the folder
         :returns: First document matching the accession_id
         """
-        find_by_id = {"accessionId": accession_id}
-        LOG.debug(f"DB doc read for {accession_id}.")
+        if collection == "folder":
+            find_by_id = {"folderId": id}
+        else:
+            find_by_id = {"accessionId": id}
+        LOG.debug(f"DB doc read for {id}.")
         return await self.database[collection].find_one(find_by_id)
 
     @auto_reconnect

--- a/metadata_backend/helpers/parser.py
+++ b/metadata_backend/helpers/parser.py
@@ -1,16 +1,16 @@
 """Tool to parse XML files to JSON."""
 
 import re
+from collections import defaultdict
 from typing import Any, Dict, List, Union
 
 from aiohttp import web
 from xmlschema import (XMLSchema, XMLSchemaConverter, XMLSchemaException,
                        XsdElement, XsdType)
 
-from .schema_loader import XMLSchemaLoader, SchemaNotFoundException
 from .logger import LOG
+from .schema_loader import SchemaNotFoundException, XMLSchemaLoader
 from .validator import XMLValidator
-from collections import defaultdict
 
 
 class MetadataXMLConverter(XMLSchemaConverter):

--- a/metadata_backend/helpers/schema_loader.py
+++ b/metadata_backend/helpers/schema_loader.py
@@ -4,12 +4,12 @@ Current implementation relies on searching XSD files from folder, should
 probably be replaced with database searching in the future.
 """
 
+import json
+from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any
 
 from xmlschema import XMLSchema
-import json
-from abc import ABC, abstractmethod
 
 SCHEMAS_ROOT = Path(__file__).parent / 'schemas'
 

--- a/metadata_backend/helpers/validator.py
+++ b/metadata_backend/helpers/validator.py
@@ -1,7 +1,7 @@
 """Utility class for validating XML files."""
 
-import re
 import json
+import re
 from io import StringIO
 from urllib.error import URLError
 

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -6,11 +6,12 @@ should be taken into account.
 """
 
 import asyncio
+import logging
+from pathlib import Path
+
 import aiofiles
 import aiohttp
-import logging
 from aiohttp import FormData
-from pathlib import Path
 
 # === Global vars ===
 FORMAT = "[%(asctime)s][%(name)s][%(process)d %(processName)s]" \

--- a/tests/test_db_service.py
+++ b/tests/test_db_service.py
@@ -37,7 +37,8 @@ class DatabaseTestCase(AsyncTestCase):
                           "dateCreated": "2020-07-26T20:59:35.177Z"
                           }
         self.f_id_stub = "FOL12345678"
-        self.folder_stub = {"folderId": self.f_id_stub,
+        self.folder_stub = {"_id": {"$oid": "5ecd28877f55c72e263f45c2"},
+                            "folderId": self.f_id_stub,
                             "name": "test",
                             "description": "test folder",
                             "metadata_objects": []}
@@ -161,6 +162,7 @@ class DatabaseTestCase(AsyncTestCase):
         """Test that read method works for folder and returns folder."""
         self.collection.find_one.return_value = futurized(self.folder_stub)
         found_folder = await self.test_service.read("folder", self.f_id_stub)
-        self.assertEqual(found_folder, self.folder_stub)
         self.collection.find_one.assert_called_once_with({"folderId":
                                                           self.f_id_stub})
+        self.assertEqual(found_folder, self.folder_stub)
+        self.assertIn('_id', found_folder)

--- a/tests/test_db_service.py
+++ b/tests/test_db_service.py
@@ -35,7 +35,9 @@ class DatabaseTestCase(AsyncTestCase):
                           "identifiers": ["foo", "bar"],
                           "dateCreated": "2020-07-26T20:59:35.177Z"
                           }
-        self.folder_stub = {"name": "test",
+        self.f_id_stub = "FOL12345678"
+        self.folder_stub = {"folderId": self.f_id_stub,
+                            "name": "test",
                             "description": "test folder",
                             "metadata_objects": []}
 
@@ -146,10 +148,18 @@ class DatabaseTestCase(AsyncTestCase):
         self.assertEqual(self.collection.insert_one.call_count, 6)
 
     async def test_create_folder_inserts_folder(self):
-        """Test that create folder method works and returns success and id."""
+        """Test that create method works for folder and returns success."""
         self.collection.insert_one.return_value = futurized(
             InsertOneResult(ObjectId('0000000000aa1111111111bb'), True)
         )
         folder = await self.test_service.create("folder", self.folder_stub)
         self.collection.insert_one.assert_called_once_with(self.folder_stub)
         self.assertTrue(folder)
+
+    async def test_read_folder_returns_data(self):
+        """Test that read method works for folder and returns folder."""
+        self.collection.find_one.return_value = futurized(self.folder_stub)
+        found_folder = await self.test_service.read("folder", self.f_id_stub)
+        self.assertEqual(found_folder, self.folder_stub)
+        self.collection.find_one.assert_called_once_with({"folderId":
+                                                          self.f_id_stub})

--- a/tests/test_db_service.py
+++ b/tests/test_db_service.py
@@ -1,10 +1,11 @@
 """Test db_services."""
-from aiounittest import AsyncTestCase, futurized
 from unittest.mock import MagicMock, patch
-from pymongo.results import InsertOneResult, UpdateResult, DeleteResult
-from pymongo.errors import AutoReconnect, ConnectionFailure
+
+from aiounittest import AsyncTestCase, futurized
 from bson import ObjectId
 from motor.motor_asyncio import AsyncIOMotorCursor
+from pymongo.errors import AutoReconnect, ConnectionFailure
+from pymongo.results import DeleteResult, InsertOneResult, UpdateResult
 
 from metadata_backend.database.db_service import DBService
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,7 +1,7 @@
 """Test api endpoints from views module."""
 
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from aiohttp import FormData, web
 from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
@@ -9,6 +9,7 @@ from aiounittest import futurized
 
 from metadata_backend.helpers.schema_loader import SchemaNotFoundException
 from metadata_backend.server import init
+from tests.test_operators import MockCursor
 
 
 class HandlersTestCase(AioHTTPTestCase):
@@ -438,10 +439,9 @@ class HandlersTestCase(AioHTTPTestCase):
     @unittest_run_loop
     async def test_get_folders(self):
         """Test get_folders() endpoint returns empty list."""
-        self.MockedDbService().db_client = MagicMock()
-        client = self.MockedDbService().db_client
-        self.MockedDbService().database = client.db_client['folders']
+        self.MockedDbService().query.return_value = MockCursor({})
         response = await self.client.get("/folders")
+        self.MockedDbService().query.assert_called_once()
         self.assertEqual(response.status, 200)
         self.assertEqual(await response.json(), {'folders': []})
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -444,3 +444,11 @@ class HandlersTestCase(AioHTTPTestCase):
         response = await self.client.get("/folders")
         self.assertEqual(response.status, 200)
         self.assertEqual(await response.json(), {'folders': []})
+
+    @unittest_run_loop
+    async def test_get_folder_fails(self):
+        """Test 404 error is raised if incorrect folder id is given."""
+        response = await self.client.get("/folders/some_id")
+        self.assertEqual(response.status, 404)
+        json_resp = await response.json()
+        self.assertEqual("Folder with some_id not found.", json_resp['detail'])

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,7 +1,7 @@
 """Test api endpoints from views module."""
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from aiohttp import FormData, web
 from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
@@ -434,3 +434,13 @@ class HandlersTestCase(AioHTTPTestCase):
         self.MockedDbService().create.assert_called_once()
         self.assertEqual(response.status, 201)
         self.assertEqual(json_resp['folderId'], self.folder_id)
+
+    @unittest_run_loop
+    async def test_get_folders(self):
+        """Test get_folders() endpoint returns empty list."""
+        self.MockedDbService().db_client = MagicMock()
+        client = self.MockedDbService().db_client
+        self.MockedDbService().database = client.db_client['folders']
+        response = await self.client.get("/folders")
+        self.assertEqual(response.status, 200)
+        self.assertEqual(await response.json(), {'folders': []})

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,13 +1,13 @@
 """Test api endpoints from views module."""
 
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 from aiohttp import FormData, web
 from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
 from aiounittest import futurized
-from metadata_backend.helpers.schema_loader import SchemaNotFoundException
 
+from metadata_backend.helpers.schema_loader import SchemaNotFoundException
 from metadata_backend.server import init
 
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -473,9 +473,9 @@ class HandlersTestCase(AioHTTPTestCase):
         response = await self.client.get("/folders/some_id")
         self.assertEqual(response.status, 404)
         json_resp = await response.json()
-        self.assertEqual("Folder with some_id not found.", json_resp['detail'])
+        self.assertEqual("Folder with id some_id not found.",
+                         json_resp['detail'])
 
-    '''
     @unittest_run_loop
     async def test_get_folder_works(self):
         """Test folder is returned when correct folder id is given."""
@@ -484,11 +484,9 @@ class HandlersTestCase(AioHTTPTestCase):
                   "name": "test",
                   "description": "test folder",
                   "metadata_objects": []}
-        self.MockedDbService().read.return_value = folder
+        self.MockedDbService().read.return_value = futurized(folder)
         response = await self.client.get("/folders/FOL12345678")
         self.MockedDbService().read.assert_called_once()
         self.assertEqual(response.status, 200)
-        del folder['_id']
         json_resp = await response.json()
         self.assertEqual(folder, json_resp)
-    '''

--- a/tests/test_middlewares.py
+++ b/tests/test_middlewares.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+
 from aiohttp import FormData
 from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
 from authlib.jose import jwt

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1,14 +1,16 @@
 """Test api endpoints from views module."""
-import re
 import datetime
+import re
 import unittest
-from aiohttp.web import HTTPNotFound, HTTPBadRequest
+from unittest.mock import MagicMock, patch
+
+from aiohttp.web import HTTPBadRequest, HTTPNotFound
 from aiounittest import AsyncTestCase, futurized
 from aiounittest.mock import AsyncMockIterator
-from unittest.mock import patch, MagicMock
-from metadata_backend.api.operators import Operator, XMLOperator
-from multidict import MultiDictProxy, MultiDict
+from multidict import MultiDict, MultiDictProxy
 from pymongo.errors import ConnectionFailure
+
+from metadata_backend.api.operators import Operator, XMLOperator
 
 
 class MockCursor(AsyncMockIterator):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,9 +1,10 @@
 """Test api endpoints from views module."""
+import unittest
 from pathlib import Path
 
-from metadata_backend.helpers.parser import XMLToJSONParser
 from aiohttp import web
-import unittest
+
+from metadata_backend.helpers.parser import XMLToJSONParser
 
 
 class ParserTestCase(unittest.TestCase):

--- a/tests/test_schema_loader.py
+++ b/tests/test_schema_loader.py
@@ -4,8 +4,8 @@ import unittest
 import xmlschema
 
 from metadata_backend.helpers.schema_loader import (JSONSchemaLoader,
-                                                    XMLSchemaLoader,
-                                                    SchemaNotFoundException)
+                                                    SchemaNotFoundException,
+                                                    XMLSchemaLoader)
 
 
 class TestXMLSchemaLoader(unittest.TestCase):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,9 +1,9 @@
 """Tests for server module."""
 
-import unittest
-from unittest.mock import patch
-from pathlib import Path
 import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
 
 from aiohttp import web
 from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop

--- a/tox.ini
+++ b/tox.ini
@@ -9,9 +9,6 @@ exclude = .git/, ./venv/, ./.tox/, build/, metadata_backend.egg-info/
 per-file-ignores =
     tests/*:ANN
 
-[isort]
-skip = ./venv/, build/, tests/, docs/
-
 [testenv:docs]
 deps =
     .[docs]
@@ -30,7 +27,7 @@ commands = flake8 .
 skip_install = true
 deps =
     isort
-commands = isort -c
+commands = isort metadata_backend/ tests/ setup.py -c
 
 [testenv:mypy]
 skip_install = true


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
So this PR includes the get methods for a single folder and all folders. Proper testing still lacks but I currently believe things here work more or less.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
Part of #97 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

<!-- List changes made. -->
- moved `patch_object()` method up so it's not below all the folder methods
- added `get_folders()` method
- added `get_folder()` method
- edited `db_service.read()` to accommodate folders
- added couple unit tests 
- fixed isort errors

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit tests
- [x] Needs testing (start an issue or do a follow up PR about it)

### Mentions
POST content check implemented the same way as @blankdots in #107 
