### PR TITLE
Remove id from mongo read

### DIFF
--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -391,7 +391,6 @@ class RESTApiHandler:
             LOG.error(reason)
             raise web.HTTPBadRequest(reason=reason)
 
-        folder.pop('_id', None)  # remove unneccessary mongodb id from result
         LOG.info(f"GET folder with folder ID {folder_id}.")
         return web.Response(body=json.dumps(folder), status=200,
                             content_type="application/json")

--- a/metadata_backend/api/operators.py
+++ b/metadata_backend/api/operators.py
@@ -505,7 +505,6 @@ class Operator(BaseOperator):
             doc[key] = doc[key].isoformat()
             return doc
 
-        del doc["_id"]
         doc = format_date("dateCreated", doc)
         doc = format_date("dateModified", doc)
         if schema_type == "study":

--- a/metadata_backend/database/db_service.py
+++ b/metadata_backend/database/db_service.py
@@ -82,7 +82,8 @@ class DBService:
         """
         find_by_id = {"accessionId": accession_id}
         LOG.debug(f"DB doc read for {accession_id}.")
-        exists = await self.database[collection].find_one(find_by_id)
+        exists = await self.database[collection].find_one(find_by_id,
+                                                          {'_id': False})
         return True if exists else False
 
     @auto_reconnect
@@ -96,7 +97,8 @@ class DBService:
         id_key = "folderId" if collection == "folder" else "accessionId"
         find_by_id = {id_key: id}
         LOG.debug(f"DB doc read for {id}.")
-        return await self.database[collection].find_one(find_by_id)
+        return await self.database[collection].find_one(find_by_id,
+                                                        {'_id': False})
 
     @auto_reconnect
     async def update(self, collection: str, accession_id: str,

--- a/metadata_backend/database/db_service.py
+++ b/metadata_backend/database/db_service.py
@@ -170,7 +170,7 @@ class DBService:
         :returns: Async cursor instance which should be awaited when iterating
         """
         LOG.debug("DB doc query performed.")
-        return self.database[collection].find(query)
+        return self.database[collection].find(query, {'_id': False})
 
     @auto_reconnect
     async def get_count(self, collection: str, query: Dict) -> int:

--- a/tests/test_db_service.py
+++ b/tests/test_db_service.py
@@ -73,14 +73,16 @@ class DatabaseTestCase(AsyncTestCase):
         found_doc = await self.test_service.read("test", self.id_stub)
         self.assertEqual(found_doc, self.data_stub)
         self.collection.find_one.assert_called_once_with({"accessionId":
-                                                          self.id_stub})
+                                                          self.id_stub},
+                                                         {'_id': False})
 
     async def test_exists_returns_false(self):
         """Test that exists method works and returns false."""
         found_doc = await self.test_service.exists("test", self.id_stub)
         self.assertEqual(found_doc, False)
         self.collection.find_one.assert_called_once_with({"accessionId":
-                                                          self.id_stub})
+                                                          self.id_stub},
+                                                         {'_id': False})
 
     async def test_exists_returns_true(self):
         """Test that exists method works and returns True."""
@@ -88,7 +90,8 @@ class DatabaseTestCase(AsyncTestCase):
         found_doc = await self.test_service.exists("test", self.id_stub)
         self.assertEqual(found_doc, True)
         self.collection.find_one.assert_called_once_with({"accessionId":
-                                                          self.id_stub})
+                                                          self.id_stub},
+                                                         {'_id': False})
 
     async def test_update_updates_data(self):
         """Test that update method works and returns success."""
@@ -163,6 +166,7 @@ class DatabaseTestCase(AsyncTestCase):
         self.collection.find_one.return_value = futurized(self.folder_stub)
         found_folder = await self.test_service.read("folder", self.f_id_stub)
         self.collection.find_one.assert_called_once_with({"folderId":
-                                                          self.f_id_stub})
+                                                          self.f_id_stub},
+                                                         {'_id': False})
         self.assertEqual(found_folder, self.folder_stub)
         self.assertIn('_id', found_folder)

--- a/tests/test_db_service.py
+++ b/tests/test_db_service.py
@@ -135,7 +135,7 @@ class DatabaseTestCase(AsyncTestCase):
         self.collection.find.return_value = AsyncIOMotorCursor(None, None)
         cursor = self.test_service.query("test", {})
         self.assertEqual(type(cursor), AsyncIOMotorCursor)
-        self.collection.find.assert_called_once_with({})
+        self.collection.find.assert_called_once_with({}, {'_id': False})
 
     async def test_count_returns_amount(self):
         """Test that get_count method works and returns amount."""

--- a/tests/test_db_service.py
+++ b/tests/test_db_service.py
@@ -37,8 +37,7 @@ class DatabaseTestCase(AsyncTestCase):
                           "dateCreated": "2020-07-26T20:59:35.177Z"
                           }
         self.f_id_stub = "FOL12345678"
-        self.folder_stub = {"_id": {"$oid": "5ecd28877f55c72e263f45c2"},
-                            "folderId": self.f_id_stub,
+        self.folder_stub = {"folderId": self.f_id_stub,
                             "name": "test",
                             "description": "test folder",
                             "metadata_objects": []}
@@ -169,4 +168,3 @@ class DatabaseTestCase(AsyncTestCase):
                                                           self.f_id_stub},
                                                          {'_id': False})
         self.assertEqual(found_folder, self.folder_stub)
-        self.assertIn('_id', found_folder)

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -516,8 +516,7 @@ class HandlersTestCase(AioHTTPTestCase):
     @unittest_run_loop
     async def test_get_folders_with_1_folder(self):
         """Test get_folders() endpoint returns list with 1 folder."""
-        folder = [{"_id": {"$oid": "5ecd28877f55c72e263f45c2"},
-                   "folderId": self.folder_id,
+        folder = [{"folderId": self.folder_id,
                    "name": "test",
                    "description": "test folder",
                    "metadata_objects": []}]
@@ -548,8 +547,7 @@ class HandlersTestCase(AioHTTPTestCase):
     @unittest_run_loop
     async def test_get_folder_works(self):
         """Test folder is returned when correct folder id is given."""
-        folder = {"_id": {"$oid": "5ecd28877f55c72e263f45c2"},
-                  "folderId": self.folder_id,
+        folder = {"folderId": self.folder_id,
                   "name": "test",
                   "description": "test folder",
                   "metadata_objects": []}

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -71,9 +71,6 @@ class TestOperators(AsyncTestCase):
         """Test json is read from db correctly."""
         operator = Operator(self.client)
         data = {
-            "_id": {
-                "$oid": "5ecd28877f55c72e263f45c2"
-            },
             "dateCreated": datetime.datetime(2020, 6, 14, 0, 0),
             "dateModified": datetime.datetime(2020, 6, 14, 0, 0),
             "accessionId": "EGA123456",

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -117,9 +117,6 @@ class TestOperators(AsyncTestCase):
     def test_operator_fixes_single_document_presentation(self):
         """Test datetime is fixed and id removed."""
         study_test = {
-            "_id": {
-                "$oid": "5ecd28877f55c72e263f45c2"
-            },
             "publishDate": datetime.datetime(2020, 6, 14, 0, 0),
             "accessionId": "EDAG3945644754983408",
             "dateCreated": datetime.datetime(2020, 6, 14, 0, 0),
@@ -380,9 +377,6 @@ class TestOperators(AsyncTestCase):
         """Test that database is called with correct query."""
         operator = Operator(self.client)
         study_test = [{
-            "_id": {
-                "$oid": "5ecd28877f55c72e263f45c2"
-            },
             "publishDate": datetime.datetime(2020, 6, 14, 0, 0),
             "accessionId": "EDAG3945644754983408",
             "dateCreated": datetime.datetime(2020, 6, 14, 0, 0),
@@ -404,9 +398,6 @@ class TestOperators(AsyncTestCase):
         """Test that database with empty query, when url params are wrong."""
         operator = Operator(self.client)
         study_test = [{
-            "_id": {
-                "$oid": "5ecd28877f55c72e263f45c2"
-            },
             "publishDate": datetime.datetime(2020, 6, 14, 0, 0),
             "accessionId": "EDAG3945644754983408",
             "dateCreated": datetime.datetime(2020, 6, 14, 0, 0),
@@ -424,17 +415,11 @@ class TestOperators(AsyncTestCase):
         operator = Operator(self.client)
         multiple_result = [
             {
-                "_id": {
-                    "$oid": "5ecd28877f55c72e263f45c2"
-                },
                 "dateCreated": datetime.datetime(2020, 6, 14, 0, 0),
                 "dateModified": datetime.datetime(2020, 6, 14, 0, 0),
                 "accessionId": "EGA123456",
                 "foo": "bar"
             }, {
-                "_id": {
-                    "$oid": "5ecd28877f55c72e263f45c2"
-                },
                 "dateCreated": datetime.datetime(2020, 6, 14, 0, 0),
                 "dateModified": datetime.datetime(2020, 6, 14, 0, 0),
                 "accessionId": "EGA123456",


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
no need to remove `_id` from dictionary as we could just ask mongo not to return it.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->
Not exactly a bug, but still a fix that we should not do this processing on the dictionary
- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

<!-- List changes made. -->
1. added `{'_id': False}` to `find_one`
2. remove `del` and `pop` for `_id`
3 fix unit tests

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

but still need to pass

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
triggered by: https://github.com/CSCfi/metadata-submitter/pull/104#pullrequestreview-459095753