### PR TITLE
Location header, HTTP status codes and small fixes

### DIFF
--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -179,7 +179,7 @@ class RESTApiHandler:
         """Save metadata object to database.
 
         For JSON request body we validate it is consistent with the
-        assosicated JSON schema.
+        associated JSON schema.
 
         :param req: POST request
         :returns: JSON response containing accessionId for submitted object
@@ -208,9 +208,12 @@ class RESTApiHandler:
         accession_id = await operator.create_metadata_object(collection,
                                                              content)
         body = json.dumps({"accessionId": accession_id})
+        url = f"{req.scheme}://{req.host}{req.path}"
+        location_headers = {"Location": f"{url}{accession_id}"}
         LOG.info(f"POST object with accesssion ID {accession_id} "
                  f"in schema {collection} was successful.")
         return web.Response(body=body, status=201,
+                            headers=location_headers,
                             content_type="application/json")
 
     async def query_objects(self, req: Request) -> Response:

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -282,7 +282,7 @@ class RESTApiHandler:
         body = json.dumps({"accessionId": accession_id})
         LOG.info(f"PUT object with accesssion ID {accession_id} "
                  f"in schema {collection} was successful.")
-        return web.Response(body=body, status=201,
+        return web.Response(body=body, status=200,
                             content_type="application/json")
 
     async def patch_object(self, req: Request) -> Response:
@@ -319,7 +319,7 @@ class RESTApiHandler:
         body = json.dumps({"accessionId": accession_id})
         LOG.info(f"PUT object with accesssion ID {accession_id} "
                  f"in schema {collection} was successful.")
-        return web.Response(body=body, status=201,
+        return web.Response(body=body, status=200,
                             content_type="application/json")
 
     @auto_reconnect
@@ -499,7 +499,7 @@ class SubmissionAPIHandler:
                 raise web.HTTPBadRequest(reason=reason)
         body = json.dumps(results)
         LOG.info(f"Processed a submission of {len(results)} actions.")
-        return web.Response(body=body, status=201,
+        return web.Response(body=body, status=200,
                             content_type="application/json")
 
     async def validate(self, req: Request) -> Response:

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -369,9 +369,12 @@ class RESTApiHandler:
             raise web.HTTPBadRequest(reason=reason)
         else:
             body = json.dumps({"folderId": content['folderId']})
+            url = f"{req.scheme}://{req.host}{req.path}"
+            location_headers = {"Location": f"{url}/{content['folderId']}"}
             LOG.info(f"POST new folder with folder ID {content['folderId']} "
                      "was successful.")
             return web.Response(body=body, status=201,
+                                headers=location_headers,
                                 content_type="application/json")
 
     async def get_folder(self, req: Request) -> Response:

--- a/metadata_backend/api/middlewares.py
+++ b/metadata_backend/api/middlewares.py
@@ -15,7 +15,7 @@ from ..helpers.logger import LOG
 
 @middleware
 async def http_error_handler(req: Request, handler: Callable) -> Response:
-    """Middleware for handling exceptions recieved from the API methods.
+    """Middleware for handling exceptions received from the API methods.
 
     :param req: A request instance
     :param handler: A request handler

--- a/metadata_backend/api/operators.py
+++ b/metadata_backend/api/operators.py
@@ -105,7 +105,7 @@ class BaseOperator(ABC):
 
         :param schema_type: Schema type of the object to read.
         :param accession_id: Accession Id of the object to read.
-        :raises: 400 if reading was not succesful, 404 if no data found
+        :raises: 400 if reading was not successful, 404 if no data found
         :returns: Metadata object formatted to JSON or XML, content type
         """
         try:
@@ -129,7 +129,7 @@ class BaseOperator(ABC):
 
         :param schema_type: Schema type of the object to delete.
         :param accession_id: Accession Id of the object to delete.
-        :raises: 400 if deleting was not succesful
+        :raises: 400 if deleting was not successful
         """
         db_client = self.db_service.db_client
         await self._remove_object_from_db(Operator(db_client),
@@ -148,7 +148,7 @@ class BaseOperator(ABC):
         :param schema_type: Schema type of the object to insert.
         :param data: Single document formatted as JSON
         :returns: Accession Id for object inserted to database
-        :raises: 400 if reading was not succesful
+        :raises: 400 if reading was not successful
         """
         try:
             insert_success = (await self.db_service.create(schema_type, data))
@@ -171,7 +171,7 @@ class BaseOperator(ABC):
         :param schema_type: Schema type of the object to replace.
         :param accession_id: Identifier of object to replace.
         :param data: Single document formatted as JSON
-        :raises: 400 if reading was not succesful, 404 if no data found
+        :raises: 400 if reading was not successful, 404 if no data found
         :returns: Accession Id for object inserted to database
         """
         try:
@@ -208,7 +208,7 @@ class BaseOperator(ABC):
         :param schema_type: Schema type of the object to update.
         :param accession_id: Identifier of object to update.
         :param data: Single document formatted as JSON
-        :raises: 400 if reading was not succesful, 404 if no data found
+        :raises: 400 if reading was not successful, 404 if no data found
         :returns: Accession Id for object inserted to database
         """
         try:
@@ -251,7 +251,7 @@ class BaseOperator(ABC):
         :param schema_type: Schema type of the object to delete.
         :param accession_id: Identifier of object to delete.
         :param data: Single document formatted as JSON
-        :raises: 400 if reading was not succesful, 404 if no data found
+        :raises: 400 if reading was not successful, 404 if no data found
         :returns: None
         """
         try:

--- a/metadata_backend/helpers/parser.py
+++ b/metadata_backend/helpers/parser.py
@@ -180,7 +180,7 @@ class XMLToJSONParser:
     def parse(self, schema_type: str, content: str) -> Dict:
         """Validate xml file and parse it to json.
 
-        We validate resulting JSON aginst a JSON schema
+        We validate resulting JSON against a JSON schema
         to be sure the resulting content is consistent.
 
         :param schema_type: Schema type to be used

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -100,7 +100,7 @@ async def put_draft(sess, schema, filename, filename2):
     async with sess.put(f"{drafts_url}/{schema}/{test_id}",
                         data=data2) as resp:
         LOG.debug(f"Replace object in {schema}")
-        assert resp.status == 201, 'HTTP Status code error'
+        assert resp.status == 200, 'HTTP Status code error'
         ans_put = await resp.json()
         assert ans_put["accessionId"] == test_id, 'accession ID error'
         return ans_put["accessionId"]
@@ -119,7 +119,7 @@ async def patch_draft(sess, schema, filename, filename2):
     async with sess.patch(f"{drafts_url}/{schema}/{test_id}",
                           data=data) as resp:
         LOG.debug(f"Update object in {schema}")
-        assert resp.status == 201, 'HTTP Status code error'
+        assert resp.status == 200, 'HTTP Status code error'
         ans_put = await resp.json()
         assert ans_put["accessionId"] == test_id, 'accession ID error'
         return ans_put["accessionId"]

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -135,7 +135,7 @@ class HandlersTestCase(AioHTTPTestCase):
         files = [("submission", "ERA521986_valid.xml")]
         data = self.create_submission_data(files)
         response = await self.client.post("/submit", data=data)
-        self.assertEqual(response.status, 201)
+        self.assertEqual(response.status, 200)
         self.assertEqual(response.content_type, "application/json")
 
     @unittest_run_loop
@@ -301,7 +301,7 @@ class HandlersTestCase(AioHTTPTestCase):
                                    "studyType": "Other"}}
         call = "/drafts/study/EGA123456"
         response = await self.client.put(call, json=json_req)
-        self.assertEqual(response.status, 201)
+        self.assertEqual(response.status, 200)
         self.assertIn(self.test_ega_string, await response.text())
         self.MockedOperator().replace_metadata_object.assert_called_once()
 
@@ -312,7 +312,7 @@ class HandlersTestCase(AioHTTPTestCase):
         data = self.create_submission_data(files)
         call = "/drafts/study/EGA123456"
         response = await self.client.put(call, data=data)
-        self.assertEqual(response.status, 201)
+        self.assertEqual(response.status, 200)
         self.assertIn(self.test_ega_string, await response.text())
         self.MockedXMLOperator().replace_metadata_object.assert_called_once()
 
@@ -323,7 +323,7 @@ class HandlersTestCase(AioHTTPTestCase):
                     "alias": "GSE10966"}
         call = "/drafts/study/EGA123456"
         response = await self.client.patch(call, json=json_req)
-        self.assertEqual(response.status, 201)
+        self.assertEqual(response.status, 200)
         self.assertIn(self.test_ega_string, await response.text())
         self.MockedOperator().update_metadata_object.assert_called_once()
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->

Add `Location` header to HTTP response for `201` HTTP status.

![image](https://user-images.githubusercontent.com/47524/89160170-54483980-d579-11ea-8203-38bca933c044.png)


### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
spelling and general concerns

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

<!-- List changes made. -->
1. fix spelling typos
2. add location header to `/objects`
3. add location header to `/folders`
4. modify put, patch response codes from 201 to 200
5 modify `/submit` response code from 201 to 200
6. address changes in tests

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

but still need to pass.

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
