### PR TITLE
Feature/add black codeformatter

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -26,5 +26,3 @@ jobs:
       run: tox -e flake8
     - name: Type hints check
       run: tox -e mypy
-    - name: Do Isort check
-      run: tox -e isort

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -22,7 +22,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install tox tox-gh-actions
-    - name: Test flake8 syntax with tox
+    - name: Black formatting check
+      uses: psf/black@stable
+      run: tox -e black
+    - name: Flake8 syntax check
       run: tox -e flake8
     - name: Type hints check
       run: tox -e mypy

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -23,7 +23,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install tox tox-gh-actions
     - name: Black formatting check
-      uses: psf/black@stable
       run: tox -e black
     - name: Flake8 syntax check
       run: tox -e flake8

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,10 +42,9 @@ We do optimize for readability, and it would be awesome if you go through the co
 - Indentation should be 4 *spaces*
 - 80 character limit is almost strict, but can be broken in documentation when hyperlinks go over the limits
 - We follow [pep8](https://www.python.org/dev/peps/pep-0008/) and [pep257](https://www.python.org/dev/peps/pep-0257/) with some small exceptions. You can see the stated exceptions in `tox.ini` configuration file
-- Imports should be sorted according to `isort` guidelines.
 - We like to keep things simple, so when possible avoid importing any big libraries.
 - Tools to help you:
-  - Tox is configured to run bunch of tests: flake8, docstrings, isort, missing type hints, mypy.
+  - Tox is configured to run bunch of tests: flake8, docstrings, missing type hints, mypy.
   - Tox is also ran in our CI, so you probably want to run tox before each push to this repo
   - If you like things to happen automagically, you can add pre-commit hook to your git workflow! Hook can be found from [scripts-folder](scripts) and it includes settings for tox and [misspell](https://github.com/client9/misspell)(which is there just for, well, spelling errors).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,8 @@ Give your branch a short descriptive name (like the names between the `<>` below
 
 We do optimize for readability, and it would be awesome if you go through the code and see what conventions we've used so far, some are also explained here:
 - Indentation should be 4 *spaces*
-- 80 character limit is almost strict, but can be broken in documentation when hyperlinks go over the limits
+- 120 character limit is almost strict, but can be broken in documentation when
+ hyperlinks go over the limits
 - We follow [pep8](https://www.python.org/dev/peps/pep-0008/) and [pep257](https://www.python.org/dev/peps/pep-0257/) with some small exceptions. You can see the stated exceptions in `tox.ini` configuration file
 - We like to keep things simple, so when possible avoid importing any big libraries.
 - Tools to help you:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,12 +42,12 @@ We do optimize for readability, and it would be awesome if you go through the co
 - Indentation should be 4 *spaces*
 - 120 character limit is almost strict, but can be broken in documentation when
  hyperlinks go over the limits
-- We follow [pep8](https://www.python.org/dev/peps/pep-0008/) and [pep257](https://www.python.org/dev/peps/pep-0257/) with some small exceptions. You can see the stated exceptions in `tox.ini` configuration file
+- We use [black](https://github.com/psf/black) code formatter and also check for [pep8](https://www.python.org/dev/peps/pep-0008/) and [pep257](https://www.python.org/dev/peps/pep-0257/) with some small exceptions. You can see the stated exceptions in `tox.ini` configuration file
 - We like to keep things simple, so when possible avoid importing any big libraries.
 - Tools to help you:
-  - Tox is configured to run bunch of tests: flake8, docstrings, missing type hints, mypy.
-  - Tox is also ran in our CI, so you probably want to run tox before each push to this repo
-  - If you like things to happen automagically, you can add pre-commit hook to your git workflow! Hook can be found from [scripts-folder](scripts) and it includes settings for tox and [misspell](https://github.com/client9/misspell)(which is there just for, well, spelling errors).
+  - Tox is configured to run bunch of tests: black, flake8, docstrings, missing type hints, mypy.
+  - Tox is also ran in our CI, so please run tox before each push to this repo
+  - If you like things to happen automagically, you can add pre-commit hook to your git workflow! Hook can be found from [scripts-folder](scripts) and it includes settings for tox and [misspell](https://github.com/client9/misspell) (which is there just for, well, spelling errors).
 
 Thanks,
 CSC developers

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If you also need frontend for development, check out [frontend repository](https
 
 ## Tests
 
-Tests and flake8 style checks can be run with tox automation: just run `tox` on project root (remember to install it first with `pip install tox`).
+Tests can be run with tox automation: just run `tox` on project root (remember to install it first with `pip install tox`).
 
 ## Build and deploy
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,12 +6,12 @@ from typing import Callable
 # -- Project information -----------------------------------------------------
 
 current_year = str(datetime.date.today().year)
-project = 'Metadata Submitter'
-copyright = f'{current_year}, CSC Developers'
-author = 'CSC Developers'
+project = "Metadata Submitter"
+copyright = f"{current_year}, CSC Developers"
+author = "CSC Developers"
 
 # The full version, including alpha/beta/rc tags
-release = '0.2.0'
+release = "0.2.0"
 
 
 # -- General configuration ---------------------------------------------------
@@ -19,23 +19,25 @@ release = '0.2.0'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc',
-              'sphinx.ext.autosummary',
-              'sphinx.ext.coverage',
-              'sphinx.ext.ifconfig',
-              'sphinx.ext.viewcode',
-              'sphinx.ext.githubpages',
-              'sphinx.ext.todo']
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.coverage",
+    "sphinx.ext.ifconfig",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.githubpages",
+    "sphinx.ext.todo",
+]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
-master_doc = 'index'
+master_doc = "index"
 
 autosummary_generate = True
 
@@ -45,26 +47,26 @@ autosummary_generate = True
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 html_theme_options = {
-    'collapse_navigation': True,
-    'sticky_navigation': True,
-    'display_version': True,
-    'prev_next_buttons_location': 'bottom'}
+    "collapse_navigation": True,
+    "sticky_navigation": True,
+    "display_version": True,
+    "prev_next_buttons_location": "bottom",
+}
 
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 
 def setup(app: Callable) -> None:
     """Add custom stylesheet."""
-    app.add_css_file('custom.css')
+    app.add_css_file("custom.css")
 
 
-htmlhelp_basename = 'metadata-submitter'
-man_pages = [(master_doc, 'metadata-submitter', [author], 1)]
-texinfo_documents = [(master_doc, 'metadata-submitter',
-                     author, 'Miscellaneous')]
+htmlhelp_basename = "metadata-submitter"
+man_pages = [(master_doc, "metadata-submitter", [author], 1)]
+texinfo_documents = [(master_doc, "metadata-submitter", author, "Miscellaneous")]

--- a/metadata_backend/__init__.py
+++ b/metadata_backend/__init__.py
@@ -1,5 +1,5 @@
 """Backend for submitting and validating XML Files containing ENA metadata."""
 
-__title__ = 'metadata_backend'
-__version__ = VERSION = '0.2.0'
-__author__ = 'CSC Developers'
+__title__ = "metadata_backend"
+__version__ = VERSION = "0.2.0"
+__author__ = "CSC Developers"

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -14,8 +14,7 @@ from xmlschema import XMLSchemaException
 from ..conf.conf import schema_types
 from ..helpers.logger import LOG
 from ..helpers.parser import XMLToJSONParser
-from ..helpers.schema_loader import (JSONSchemaLoader, SchemaNotFoundException,
-                                     XMLSchemaLoader)
+from ..helpers.schema_loader import JSONSchemaLoader, SchemaNotFoundException, XMLSchemaLoader
 from ..helpers.validator import JSONValidator, XMLValidator
 from .operators import FolderOperator, Operator, XMLOperator
 
@@ -34,8 +33,7 @@ class RESTApiHandler:
             LOG.error(reason)
             raise web.HTTPNotFound(reason=reason)
 
-    def _header_links(self, url: str, page: int, size: int,
-                      total_objects: int) -> Dict[str, str]:
+    def _header_links(self, url: str, page: int, size: int, total_objects: int) -> Dict[str, str]:
         """Create link header for pagination.
 
         :param url: base url for request
@@ -45,15 +43,11 @@ class RESTApiHandler:
         :returns: JSON with query results
         """
         total_pages = ceil(total_objects / size)
-        prev_link = (f'<{url}?page={page-1}&per_page={size}>; rel="prev", '
-                     if page > 1 else "")
-        next_link = (f'<{url}?page={page+1}&per_page={size}>; rel="next", '
-                     if page < total_pages else "")
-        last_link = (f'<{url}?page={total_pages}&per_page={size}>; rel="last"'
-                     if page < total_pages else "")
-        comma = (", " if page > 1 and page < total_pages else "")
-        first_link = (f'<{url}?page=1&per_page={size}>; rel="first"{comma}'
-                      if page > 1 else "")
+        prev_link = f'<{url}?page={page-1}&per_page={size}>; rel="prev", ' if page > 1 else ""
+        next_link = f'<{url}?page={page+1}&per_page={size}>; rel="next", ' if page < total_pages else ""
+        last_link = f'<{url}?page={total_pages}&per_page={size}>; rel="last"' if page < total_pages else ""
+        comma = ", " if page > 1 and page < total_pages else ""
+        first_link = f'<{url}?page=1&per_page={size}>; rel="first"{comma}' if page > 1 else ""
         links = f"{prev_link}{next_link}{first_link}{last_link}"
         link_headers = {"Link": f"{links}"}
         LOG.debug("Link headers created")
@@ -65,7 +59,7 @@ class RESTApiHandler:
         :param req: GET request with query parameters
         :returns: JSON with query results
         """
-        collection = req.match_info['schema']
+        collection = req.match_info["schema"]
         req_format = req.query.get("format", "json").lower()
         if req_format == "xml":
             reason = "xml-formatted query results are not supported"
@@ -76,8 +70,7 @@ class RESTApiHandler:
             try:
                 param = int(req.query.get(param_name, default))
             except ValueError:
-                reason = (f"{param_name} must a number, now it was "
-                          f"{req.query.get(param_name)}")
+                reason = f"{param_name} must a number, now it was " f"{req.query.get(param_name)}"
                 LOG.error(reason)
                 raise web.HTTPBadRequest(reason=reason)
             if param < 1:
@@ -85,32 +78,29 @@ class RESTApiHandler:
                 LOG.error(reason)
                 raise web.HTTPBadRequest(reason=reason)
             return param
+
         page = get_page_param("page", 1)
         per_page = get_page_param("per_page", 10)
-        db_client = req.app['db_client']
-        data, page_num, page_size, total_objects = (
-            await Operator(db_client).query_metadata_database(collection,
-                                                              req.query,
-                                                              page,
-                                                              per_page))
-        result = json.dumps({
-            "page": {
-                "page": page_num,
-                "size": page_size,
-                "totalPages": ceil(total_objects / per_page),
-                "totalObjects": total_objects
-            },
-            "objects": data
-        })
+        db_client = req.app["db_client"]
+        data, page_num, page_size, total_objects = await Operator(db_client).query_metadata_database(
+            collection, req.query, page, per_page
+        )
+        result = json.dumps(
+            {
+                "page": {
+                    "page": page_num,
+                    "size": page_size,
+                    "totalPages": ceil(total_objects / per_page),
+                    "totalObjects": total_objects,
+                },
+                "objects": data,
+            }
+        )
         url = f"{req.scheme}://{req.host}{req.path}"
-        link_headers = self._header_links(url, page_num,
-                                          per_page, total_objects)
+        link_headers = self._header_links(url, page_num, per_page, total_objects)
         LOG.debug(f"Pagination header links: {link_headers}")
-        LOG.info(f"Querying for objects in {collection} "
-                 f"resulted in {total_objects} objects ")
-        return web.Response(body=result, status=200,
-                            headers=link_headers,
-                            content_type="application/json")
+        LOG.info(f"Querying for objects in {collection} " f"resulted in {total_objects} objects ")
+        return web.Response(body=result, status=200, headers=link_headers, content_type="application/json")
 
     async def _get_data(self, req: Request) -> Dict:
         """Get the data content from a request.
@@ -123,8 +113,7 @@ class RESTApiHandler:
             content = await req.json()
             return content
         except json.decoder.JSONDecodeError as e:
-            reason = ("JSON is not correctly formatted."
-                      f" See: {e}")
+            reason = "JSON is not correctly formatted." f" See: {e}"
             LOG.error(reason)
             raise web.HTTPBadRequest(reason=reason)
 
@@ -135,11 +124,9 @@ class RESTApiHandler:
         :param req: GET Request
         :returns: JSON list of schema types
         """
-        types_json = json.dumps([x["description"] for x in
-                                 schema_types.values()])
+        types_json = json.dumps([x["description"] for x in schema_types.values()])
         LOG.info(f"GET schema types. Retrieved {len(schema_types)} schemas.")
-        return web.Response(body=types_json, status=200,
-                            content_type="application/json")
+        return web.Response(body=types_json, status=200, content_type="application/json")
 
     async def get_json_schema(self, req: Request) -> Response:
         """Get all JSON Schema for a specific schema type.
@@ -148,14 +135,13 @@ class RESTApiHandler:
         :param req: GET Request
         :returns: JSON list of schema types
         """
-        schema_type = req.match_info['schema']
+        schema_type = req.match_info["schema"]
         self._check_schema_exists(schema_type)
 
         try:
             schema = JSONSchemaLoader().get_schema(schema_type)
             LOG.info(f"{schema_type} schema loaded.")
-            return web.Response(body=json.dumps(schema), status=200,
-                                content_type="application/json")
+            return web.Response(body=json.dumps(schema), status=200, content_type="application/json")
 
         except SchemaNotFoundException as error:
             reason = f"{error} ({schema_type})"
@@ -171,21 +157,17 @@ class RESTApiHandler:
         :param req: GET request
         :returns: JSON or XML response containing metadata object
         """
-        accession_id = req.match_info['accessionId']
-        schema_type = req.match_info['schema']
+        accession_id = req.match_info["accessionId"]
+        schema_type = req.match_info["schema"]
         self._check_schema_exists(schema_type)
-        collection = (f"draft-{schema_type}" if req.path.startswith("/drafts")
-                      else schema_type)
+        collection = f"draft-{schema_type}" if req.path.startswith("/drafts") else schema_type
 
         req_format = req.query.get("format", "json").lower()
-        db_client = req.app['db_client']
-        operator = (XMLOperator(db_client) if req_format == "xml"
-                    else Operator(db_client))
-        data, content_type = await operator.read_metadata_object(collection,
-                                                                 accession_id)
-        data = (data if req_format == "xml" else json.dumps(data))
-        LOG.info(f"GET object with accesssion ID {accession_id} "
-                 f"from schema {collection}.")
+        db_client = req.app["db_client"]
+        operator = XMLOperator(db_client) if req_format == "xml" else Operator(db_client)
+        data, content_type = await operator.read_metadata_object(collection, accession_id)
+        data = data if req_format == "xml" else json.dumps(data)
+        LOG.info(f"GET object with accesssion ID {accession_id} " f"from schema {collection}.")
         return web.Response(body=data, status=200, content_type=content_type)
 
     async def post_object(self, req: Request) -> Response:
@@ -197,12 +179,11 @@ class RESTApiHandler:
         :param req: POST request
         :returns: JSON response containing accessionId for submitted object
         """
-        schema_type = req.match_info['schema']
+        schema_type = req.match_info["schema"]
         self._check_schema_exists(schema_type)
-        collection = (f"draft-{schema_type}" if req.path.startswith("/drafts")
-                      else schema_type)
+        collection = f"draft-{schema_type}" if req.path.startswith("/drafts") else schema_type
 
-        db_client = req.app['db_client']
+        db_client = req.app["db_client"]
         content: Union[Dict, str]
         operator: Union[Operator, XMLOperator]
         if req.content_type == "multipart/form-data":
@@ -213,16 +194,12 @@ class RESTApiHandler:
             content = await self._get_data(req)
             JSONValidator(content, schema_type).validate
             operator = Operator(db_client)
-        accession_id = await operator.create_metadata_object(collection,
-                                                             content)
+        accession_id = await operator.create_metadata_object(collection, content)
         body = json.dumps({"accessionId": accession_id})
         url = f"{req.scheme}://{req.host}{req.path}"
         location_headers = {"Location": f"{url}{accession_id}"}
-        LOG.info(f"POST object with accesssion ID {accession_id} "
-                 f"in schema {collection} was successful.")
-        return web.Response(body=body, status=201,
-                            headers=location_headers,
-                            content_type="application/json")
+        LOG.info(f"POST object with accesssion ID {accession_id} " f"in schema {collection} was successful.")
+        return web.Response(body=body, status=201, headers=location_headers, content_type="application/json")
 
     async def query_objects(self, req: Request) -> Response:
         """Query metadata objects from database.
@@ -230,7 +207,7 @@ class RESTApiHandler:
         :param req: GET request with query parameters (can be empty).
         :returns: Query results as JSON
         """
-        schema_type = req.match_info['schema']
+        schema_type = req.match_info["schema"]
         self._check_schema_exists(schema_type)
         return await self._handle_query(req)
 
@@ -240,17 +217,14 @@ class RESTApiHandler:
         :param req: DELETE request
         :returns: HTTP No Content response
         """
-        schema_type = req.match_info['schema']
+        schema_type = req.match_info["schema"]
         self._check_schema_exists(schema_type)
-        collection = (f"draft-{schema_type}" if req.path.startswith("/drafts")
-                      else schema_type)
+        collection = f"draft-{schema_type}" if req.path.startswith("/drafts") else schema_type
 
-        accession_id = req.match_info['accessionId']
-        db_client = req.app['db_client']
-        await Operator(db_client).delete_metadata_object(collection,
-                                                         accession_id)
-        LOG.info(f"DELETE object with accesssion ID {accession_id} "
-                 f"in schema {collection} was successful.")
+        accession_id = req.match_info["accessionId"]
+        db_client = req.app["db_client"]
+        await Operator(db_client).delete_metadata_object(collection, accession_id)
+        LOG.info(f"DELETE object with accesssion ID {accession_id} " f"in schema {collection} was successful.")
         return web.Response(status=204)
 
     async def put_object(self, req: Request) -> Response:
@@ -262,13 +236,12 @@ class RESTApiHandler:
         :param req: PUT request
         :returns: JSON response containing accessionId for submitted object
         """
-        schema_type = req.match_info['schema']
-        accession_id = req.match_info['accessionId']
+        schema_type = req.match_info["schema"]
+        accession_id = req.match_info["accessionId"]
         self._check_schema_exists(schema_type)
-        collection = (f"draft-{schema_type}" if req.path.startswith("/drafts")
-                      else schema_type)
+        collection = f"draft-{schema_type}" if req.path.startswith("/drafts") else schema_type
 
-        db_client = req.app['db_client']
+        db_client = req.app["db_client"]
         content: Union[Dict, str]
         operator: Union[Operator, XMLOperator]
         if req.content_type == "multipart/form-data":
@@ -279,14 +252,10 @@ class RESTApiHandler:
             content = await self._get_data(req)
             JSONValidator(content, schema_type).validate
             operator = Operator(db_client)
-        await operator.replace_metadata_object(collection,
-                                               accession_id,
-                                               content)
+        await operator.replace_metadata_object(collection, accession_id, content)
         body = json.dumps({"accessionId": accession_id})
-        LOG.info(f"PUT object with accesssion ID {accession_id} "
-                 f"in schema {collection} was successful.")
-        return web.Response(body=body, status=200,
-                            content_type="application/json")
+        LOG.info(f"PUT object with accesssion ID {accession_id} " f"in schema {collection} was successful.")
+        return web.Response(body=body, status=200, content_type="application/json")
 
     async def patch_object(self, req: Request) -> Response:
         """Update metadata object in database.
@@ -296,13 +265,12 @@ class RESTApiHandler:
         :param req: PATCH request
         :returns: JSON response containing accessionId for submitted object
         """
-        schema_type = req.match_info['schema']
-        accession_id = req.match_info['accessionId']
+        schema_type = req.match_info["schema"]
+        accession_id = req.match_info["accessionId"]
         self._check_schema_exists(schema_type)
-        collection = (f"draft-{schema_type}" if req.path.startswith("/drafts")
-                      else schema_type)
+        collection = f"draft-{schema_type}" if req.path.startswith("/drafts") else schema_type
 
-        db_client = req.app['db_client']
+        db_client = req.app["db_client"]
         operator: Union[Operator, XMLOperator]
         if req.content_type == "multipart/form-data":
             reason = "XML patching is not possible."
@@ -310,14 +278,10 @@ class RESTApiHandler:
         else:
             content = await self._get_data(req)
             operator = Operator(db_client)
-        await operator.update_metadata_object(collection,
-                                              accession_id,
-                                              content)
+        await operator.update_metadata_object(collection, accession_id, content)
         body = json.dumps({"accessionId": accession_id})
-        LOG.info(f"PATCH object with accesssion ID {accession_id} "
-                 f"in schema {collection} was successful.")
-        return web.Response(body=body, status=200,
-                            content_type="application/json")
+        LOG.info(f"PATCH object with accesssion ID {accession_id} " f"in schema {collection} was successful.")
+        return web.Response(body=body, status=200, content_type="application/json")
 
     async def get_folders(self, req: Request) -> Response:
         """Get all possible object folders from database.
@@ -325,13 +289,12 @@ class RESTApiHandler:
         :param req: GET Request
         :returns: JSON list of folders available for the user
         """
-        db_client = req.app['db_client']
+        db_client = req.app["db_client"]
         operator = FolderOperator(db_client)
         folders = await operator.query_folders({})
         body = json.dumps({"folders": folders})
         LOG.info(f"GET folders. Retrieved {len(folders)} folders.")
-        return web.Response(body=body, status=200,
-                            content_type="application/json")
+        return web.Response(body=body, status=200, content_type="application/json")
 
     async def post_folder(self, req: Request) -> Response:
         """Save object folder to database.
@@ -339,7 +302,7 @@ class RESTApiHandler:
         :param req: POST request
         :returns: JSON response containing folder ID for submitted folder
         """
-        db_client = req.app['db_client']
+        db_client = req.app["db_client"]
         content = await self._get_data(req)
         operator = FolderOperator(db_client)
         folder = await operator.create_folder(content)
@@ -347,9 +310,7 @@ class RESTApiHandler:
         url = f"{req.scheme}://{req.host}{req.path}"
         location_headers = {"Location": f"{url}/{folder}"}
         LOG.info(f"POST new folder with ID {folder} was successful.")
-        return web.Response(body=body, status=201,
-                            headers=location_headers,
-                            content_type="application/json")
+        return web.Response(body=body, status=201, headers=location_headers, content_type="application/json")
 
     async def get_folder(self, req: Request) -> Response:
         """Get one object folder by its folder id.
@@ -358,13 +319,12 @@ class RESTApiHandler:
         :raises: HTTP 404 if folder not found and 400 if something else fails
         :returns: JSON response containing object folder
         """
-        folder_id = req.match_info['folderId']
-        db_client = req.app['db_client']
+        folder_id = req.match_info["folderId"]
+        db_client = req.app["db_client"]
         operator = FolderOperator(db_client)
         folder = await operator.read_folder(folder_id)
         LOG.info(f"GET folder with folder ID {folder_id} was successful.")
-        return web.Response(body=json.dumps(folder), status=200,
-                            content_type="application/json")
+        return web.Response(body=json.dumps(folder), status=200, content_type="application/json")
 
     async def patch_folder(self, req: Request) -> Response:
         """Update object folder with a specific folder id.
@@ -373,16 +333,15 @@ class RESTApiHandler:
         :raises: HTTP 400 if something fails during processing the request
         :returns: JSON response containing folder ID for updated folder
         """
-        folder_id = req.match_info['folderId']
-        db_client = req.app['db_client']
+        folder_id = req.match_info["folderId"]
+        db_client = req.app["db_client"]
 
         # Check patch operations in request are valid
         patch_ops = await self._get_data(req)
-        allowed_paths = ['/name', '/description', '/metadataObjects']
+        allowed_paths = ["/name", "/description", "/metadataObjects"]
         for op in patch_ops:
-            if not any([i in op['path'] for i in allowed_paths]):
-                reason = (f"Request contains '{op['path']}' key that cannot be"
-                          " updated to folders.")
+            if not any([i in op["path"] for i in allowed_paths]):
+                reason = f"Request contains '{op['path']}' key that cannot be" " updated to folders."
                 LOG.error(reason)
                 raise web.HTTPBadRequest(reason=reason)
         patch = JsonPatch(patch_ops)
@@ -391,8 +350,7 @@ class RESTApiHandler:
         folder = await operator.update_folder(folder_id, patch)
         body = json.dumps({"folderId": folder})
         LOG.info(f"PATCH folder with ID {folder} was successful.")
-        return web.Response(body=body, status=200,
-                            content_type="application/json")
+        return web.Response(body=body, status=200, content_type="application/json")
 
     async def delete_folder(self, req: Request) -> Response:
         """Delete object folder from database.
@@ -400,8 +358,8 @@ class RESTApiHandler:
         :param req: DELETE request
         :returns: HTTP No Content response
         """
-        folder_id = req.match_info['folderId']
-        db_client = req.app['db_client']
+        folder_id = req.match_info["folderId"]
+        db_client = req.app["db_client"]
         operator = FolderOperator(db_client)
         folder = await operator.delete_folder(folder_id)
         LOG.info(f"DELETE folder with ID {folder} was successful.")
@@ -439,13 +397,13 @@ class SubmissionAPIHandler:
         submission_json = XMLToJSONParser().parse("submission", submission_xml)
         # Check what actions should be performed, collect them to dictionary
         actions = {}
-        for action_set in submission_json["actions"]['action']:
+        for action_set in submission_json["actions"]["action"]:
             for action, attr in action_set.items():
                 if not attr:
-                    reason = (f"""You also need to provide necessary
+                    reason = f"""You also need to provide necessary
                                   information for submission action.
                                   Now {action} was provided without any
-                                  extra information.""")
+                                  extra information."""
                     LOG.error(reason)
                     raise web.HTTPBadRequest(reason=reason)
                 LOG.debug(f"submission has action {action}")
@@ -453,7 +411,7 @@ class SubmissionAPIHandler:
         # Go through parsed files and do the actual action
         # Only "add" action is supported for now.
         results: List[Dict] = []
-        db_client = req.app['db_client']
+        db_client = req.app["db_client"]
         for file in files:
             content_xml = file[0]
             schema_type = file[1]
@@ -462,12 +420,12 @@ class SubmissionAPIHandler:
                 continue  # No need to use submission xml
             action = actions[schema_type]
             if action == "add":
-                results.append({
-                    "accessionId":
-                    await XMLOperator(db_client).
-                        create_metadata_object(schema_type, content_xml),
-                    "schema": schema_type
-                })
+                results.append(
+                    {
+                        "accessionId": await XMLOperator(db_client).create_metadata_object(schema_type, content_xml),
+                        "schema": schema_type,
+                    }
+                )
                 LOG.debug(f"added some content in {schema_type} ...")
             else:
                 reason = f"action {action} is not supported yet"
@@ -475,8 +433,7 @@ class SubmissionAPIHandler:
                 raise web.HTTPBadRequest(reason=reason)
         body = json.dumps(results)
         LOG.info(f"Processed a submission of {len(results)} actions.")
-        return web.Response(body=body, status=200,
-                            content_type="application/json")
+        return web.Response(body=body, status=200, content_type="application/json")
 
     async def validate(self, req: Request) -> Response:
         """Validate xml file sent to endpoint.
@@ -498,8 +455,7 @@ class SubmissionAPIHandler:
             LOG.error(reason)
             raise web.HTTPBadRequest(reason=reason)
 
-        return web.Response(body=validator.resp_body,
-                            content_type="application/json")
+        return web.Response(body=validator.resp_body, content_type="application/json")
 
 
 class StaticHandler:
@@ -518,8 +474,7 @@ class StaticHandler:
         """
         index_path = self.path / "index.html"
         LOG.debug("Serve Frontend SPA.")
-        return Response(body=index_path.read_bytes(),
-                        content_type="text/html")
+        return Response(body=index_path.read_bytes(), content_type="text/html")
 
     def setup_static(self) -> Path:
         """Set path for static js files and correct return mimetypes.
@@ -534,8 +489,7 @@ class StaticHandler:
 
 
 # Private functions shared between handlers
-async def _extract_xml_upload(req: Request, extract_one: bool = False
-                              ) -> List[Tuple[str, str]]:
+async def _extract_xml_upload(req: Request, extract_one: bool = False) -> List[Tuple[str, str]]:
     """Extract submitted xml-file(s) from multi-part request.
 
     Files are sorted to spesific order by their schema priorities (e.g.
@@ -574,7 +528,7 @@ async def _extract_xml_upload(req: Request, extract_one: bool = False
             if not chunk:
                 break
             data.append(chunk)
-        xml_content = ''.join(x.decode('UTF-8') for x in data)
+        xml_content = "".join(x.decode("UTF-8") for x in data)
         files.append((xml_content, schema_type))
         LOG.debug(f"processed file in {schema_type}")
     return sorted(files, key=lambda x: schema_types[x[1]]["priority"])

--- a/metadata_backend/api/middlewares.py
+++ b/metadata_backend/api/middlewares.py
@@ -28,22 +28,17 @@ async def http_error_handler(req: Request, handler: Callable) -> Response:
     except web.HTTPError as error:
         details = _json_exception(error.status, error, req.url)
         LOG.error(details)
-        c_type = 'application/problem+json'
+        c_type = "application/problem+json"
         if error.status == 400:
-            raise web.HTTPBadRequest(text=details,
-                                     content_type=c_type)
+            raise web.HTTPBadRequest(text=details, content_type=c_type)
         elif error.status == 401:
-            raise web.HTTPUnauthorized(text=details,
-                                       content_type=c_type)
+            raise web.HTTPUnauthorized(text=details, content_type=c_type)
         elif error.status == 403:
-            raise web.HTTPForbidden(text=details,
-                                    content_type=c_type)
+            raise web.HTTPForbidden(text=details, content_type=c_type)
         elif error.status == 404:
-            raise web.HTTPNotFound(text=details,
-                                   content_type=c_type)
+            raise web.HTTPNotFound(text=details, content_type=c_type)
         elif error.status == 415:
-            raise web.HTTPUnsupportedMediaType(text=details,
-                                               content_type=c_type)
+            raise web.HTTPUnsupportedMediaType(text=details, content_type=c_type)
         else:
             raise web.HTTPServerError()
 
@@ -59,41 +54,32 @@ async def jwt_authentication(req: Request, handler: Callable) -> Response:
     :raises: HTTP Exception with status code 401 or 403
     :returns: Successful requests unaffected
     """
-    if 'Authorization' in req.headers:
+    if "Authorization" in req.headers:
         # Check token exists
         try:
-            scheme, token = req.headers.get('Authorization').split(' ')
-            LOG.info('Auth token received.')
+            scheme, token = req.headers.get("Authorization").split(" ")
+            LOG.info("Auth token received.")
         except ValueError as err:
             raise web.HTTPUnauthorized(reason=f"Failure to read token: {err}")
 
         # Check token has proper scheme and was provided.
-        if not re.match('Bearer', scheme):
-            raise web.HTTPUnauthorized(reason="Invalid token scheme, "
-                                              "Bearer required.")
+        if not re.match("Bearer", scheme):
+            raise web.HTTPUnauthorized(reason="Invalid token scheme, " "Bearer required.")
         if token is None:
-            raise web.HTTPUnauthorized(reason='Token cannot be empty.')
+            raise web.HTTPUnauthorized(reason="Token cannot be empty.")
 
         # JWK and JWTClaims parameters for decoding
-        key = environ.get('PUBLIC_KEY', None)
+        key = environ.get("PUBLIC_KEY", None)
 
         # Include claims that are required to be present
         # in the payload of the token
-        claims_options = {
-            "iss": {
-                "essential": True,
-                "values": ["haka_iss", "elixir_iss"]
-            },
-            "exp": {
-                "essential": True
-            }
-        }
+        claims_options = {"iss": {"essential": True, "values": ["haka_iss", "elixir_iss"]}, "exp": {"essential": True}}
 
         # Decode and validate token
         try:
             claims = jwt.decode(token, key, claims_options=claims_options)
             claims.validate()
-            LOG.info('Auth token decoded and validated.')
+            LOG.info("Auth token decoded and validated.")
             req["token"] = {"authenticated": True}
             return await handler(req)
         except errors.MissingClaimError as err:
@@ -103,18 +89,15 @@ async def jwt_authentication(req: Request, handler: Callable) -> Response:
         except errors.InvalidClaimError as err:
             raise web.HTTPForbidden(reason=f"Token contains {err}")
         except errors.BadSignatureError as err:
-            raise web.HTTPUnauthorized(reason="Token signature is invalid"
-                                              f", {err}")
+            raise web.HTTPUnauthorized(reason="Token signature is invalid" f", {err}")
         except errors.InvalidTokenError as err:
-            raise web.HTTPUnauthorized(reason="Invalid authorization token"
-                                              f": {err}")
+            raise web.HTTPUnauthorized(reason="Invalid authorization token" f": {err}")
     else:
         req["token"] = {"authenticated": False}
         return await handler(req)
 
 
-def _json_exception(status: int, exception: web.HTTPException,
-                    url: URL) -> str:
+def _json_exception(status: int, exception: web.HTTPException, url: URL) -> str:
     """Convert an HTTP exception into a problem detailed JSON object.
 
     The problem details are in accordance with RFC 7807.
@@ -125,12 +108,14 @@ def _json_exception(status: int, exception: web.HTTPException,
     :param url: Request URL that caused the exception
     :returns: Problem detail JSON object as a string
     """
-    body = json.dumps({
-        'type': "about:blank",
-        # Replace type value above with an URL to
-        # a custom error document when one exists
-        'title': HTTPStatus(status).phrase,
-        'detail': exception.reason,
-        'instance': url.path,  # optional
-    })
+    body = json.dumps(
+        {
+            "type": "about:blank",
+            # Replace type value above with an URL to
+            # a custom error document when one exists
+            "title": HTTPStatus(status).phrase,
+            "detail": exception.reason,
+            "instance": url.path,  # optional
+        }
+    )
     return body

--- a/metadata_backend/api/operators.py
+++ b/metadata_backend/api/operators.py
@@ -27,8 +27,7 @@ class BaseOperator(ABC):
     :param ABC: The abstract base class
     """
 
-    def __init__(self, db_name: str, content_type: str,
-                 db_client: AsyncIOMotorClient) -> None:
+    def __init__(self, db_name: str, content_type: str, db_client: AsyncIOMotorClient) -> None:
         """Init needed variables, must be given by subclass.
 
         :param db_name: Name for database to save objects to.
@@ -40,8 +39,7 @@ class BaseOperator(ABC):
         self.db_service = DBService(db_name, db_client)
         self.content_type = content_type
 
-    async def create_metadata_object(self, schema_type: str,
-                                     data: Union[Dict, str]) -> str:
+    async def create_metadata_object(self, schema_type: str, data: Union[Dict, str]) -> str:
         """Create new metadata object to database.
 
         Data formatting and addition step for JSON or XML must be implemented
@@ -51,16 +49,13 @@ class BaseOperator(ABC):
         :param data: Data to be saved to database.
         :returns: Accession id for the object inserted to database
         """
-        accession_id = (await self.
-                        _format_data_to_create_and_add_to_db(schema_type,
-                                                             data))
-        LOG.info(f"Inserting object with schema {schema_type} to database "
-                 f"succeeded with accession id: {accession_id}")
+        accession_id = await self._format_data_to_create_and_add_to_db(schema_type, data)
+        LOG.info(
+            f"Inserting object with schema {schema_type} to database " f"succeeded with accession id: {accession_id}"
+        )
         return accession_id
 
-    async def replace_metadata_object(self, schema_type: str,
-                                      accession_id: str,
-                                      data: Union[Dict, str]) -> str:
+    async def replace_metadata_object(self, schema_type: str, accession_id: str, data: Union[Dict, str]) -> str:
         """Replace metadata object from database.
 
         Data formatting and addition step for JSON or XML must be implemented
@@ -71,16 +66,13 @@ class BaseOperator(ABC):
         :param data: Data to be saved to database.
         :returns: Accession id for the object replaced to database
         """
-        await self._format_data_to_replace_and_add_to_db(schema_type,
-                                                         accession_id,
-                                                         data)
-        LOG.info(f"Replacing object with schema {schema_type} to database "
-                 f"succeeded with accession id: {accession_id}")
+        await self._format_data_to_replace_and_add_to_db(schema_type, accession_id, data)
+        LOG.info(
+            f"Replacing object with schema {schema_type} to database " f"succeeded with accession id: {accession_id}"
+        )
         return accession_id
 
-    async def update_metadata_object(self, schema_type: str,
-                                     accession_id: str,
-                                     data: Union[Dict, str]) -> str:
+    async def update_metadata_object(self, schema_type: str, accession_id: str, data: Union[Dict, str]) -> str:
         """Update metadata object from database.
 
         Data formatting and addition step for JSON or XML must be implemented
@@ -91,15 +83,13 @@ class BaseOperator(ABC):
         :param data: Data to be saved to database.
         :returns: Accession id for the object updated to database
         """
-        await self._format_data_to_update_and_add_to_db(schema_type,
-                                                        accession_id,
-                                                        data)
-        LOG.info(f"Updated object with schema {schema_type} to database "
-                 f"succeeded with accession id: {accession_id}")
+        await self._format_data_to_update_and_add_to_db(schema_type, accession_id, data)
+        LOG.info(
+            f"Updated object with schema {schema_type} to database " f"succeeded with accession id: {accession_id}"
+        )
         return accession_id
 
-    async def read_metadata_object(self, schema_type: str, accession_id:
-                                   str) -> Tuple[Union[Dict, str], str]:
+    async def read_metadata_object(self, schema_type: str, accession_id: str) -> Tuple[Union[Dict, str], str]:
         """Read metadata object from database.
 
         Data formatting to JSON or XML must be implemented by corresponding
@@ -122,8 +112,7 @@ class BaseOperator(ABC):
             raise web.HTTPBadRequest(reason=reason)
         return data, self.content_type
 
-    async def delete_metadata_object(self, schema_type: str,
-                                     accession_id: str) -> None:
+    async def delete_metadata_object(self, schema_type: str, accession_id: str) -> None:
         """Delete metadata object from database.
 
         Tries to remove both JSON and original XML from database, passes
@@ -134,17 +123,11 @@ class BaseOperator(ABC):
         :raises: 400 if deleting was not successful
         """
         db_client = self.db_service.db_client
-        await self._remove_object_from_db(Operator(db_client),
-                                          schema_type,
-                                          accession_id)
-        await self._remove_object_from_db(XMLOperator(db_client),
-                                          schema_type,
-                                          accession_id)
-        LOG.info(f"Removing object with schema {schema_type} from database "
-                 f"and accession id: {accession_id}")
+        await self._remove_object_from_db(Operator(db_client), schema_type, accession_id)
+        await self._remove_object_from_db(XMLOperator(db_client), schema_type, accession_id)
+        LOG.info(f"Removing object with schema {schema_type} from database " f"and accession id: {accession_id}")
 
-    async def _insert_formatted_object_to_db(self, schema_type: str,
-                                             data: Dict) -> str:
+    async def _insert_formatted_object_to_db(self, schema_type: str, data: Dict) -> str:
         """Insert formatted metadata object to database.
 
         :param schema_type: Schema type of the object to insert.
@@ -153,7 +136,7 @@ class BaseOperator(ABC):
         :raises: 400 if reading was not successful
         """
         try:
-            insert_success = (await self.db_service.create(schema_type, data))
+            insert_success = await self.db_service.create(schema_type, data)
         except (ConnectionFailure, OperationFailure) as error:
             reason = f"Error happened while getting object: {error}"
             LOG.error(reason)
@@ -165,9 +148,7 @@ class BaseOperator(ABC):
             LOG.error(reason)
             raise web.HTTPBadRequest(reason=reason)
 
-    async def _replace_object_from_db(self, schema_type: str,
-                                      accession_id: str,
-                                      data: Dict) -> str:
+    async def _replace_object_from_db(self, schema_type: str, accession_id: str, data: Dict) -> str:
         """Replace formatted metadata object in database.
 
         :param schema_type: Schema type of the object to replace.
@@ -177,16 +158,12 @@ class BaseOperator(ABC):
         :returns: Accession Id for object inserted to database
         """
         try:
-            check_exists = await self.db_service.exists(schema_type,
-                                                        accession_id)
+            check_exists = await self.db_service.exists(schema_type, accession_id)
             if not check_exists:
-                reason = (f"Object with accession id {accession_id} "
-                          "was not found.")
+                reason = f"Object with accession id {accession_id} " "was not found."
                 LOG.error(reason)
                 raise web.HTTPNotFound(reason=reason)
-            replace_success = (await self.db_service.replace(schema_type,
-                                                             accession_id,
-                                                             data))
+            replace_success = await self.db_service.replace(schema_type, accession_id, data)
         except (ConnectionFailure, OperationFailure) as error:
             reason = f"Error happened while getting object: {error}"
             LOG.error(reason)
@@ -198,9 +175,7 @@ class BaseOperator(ABC):
             LOG.error(reason)
             raise web.HTTPBadRequest(reason=reason)
 
-    async def _update_object_from_db(self, schema_type: str,
-                                     accession_id: str,
-                                     data: Dict) -> str:
+    async def _update_object_from_db(self, schema_type: str, accession_id: str, data: Dict) -> str:
         """Update formatted metadata object in database.
 
         After the data has been update we need to do a sanity check
@@ -214,21 +189,15 @@ class BaseOperator(ABC):
         :returns: Accession Id for object inserted to database
         """
         try:
-            check_exists = await self.db_service.exists(schema_type,
-                                                        accession_id)
+            check_exists = await self.db_service.exists(schema_type, accession_id)
             if not check_exists:
-                reason = (f"Object with accession id {accession_id} "
-                          "was not found.")
+                reason = f"Object with accession id {accession_id} " "was not found."
                 LOG.error(reason)
                 raise web.HTTPNotFound(reason=reason)
-            update_success = (await self.db_service.update(schema_type,
-                                                           accession_id,
-                                                           data))
-            sanity_check = await self.db_service.read(schema_type,
-                                                      accession_id)
+            update_success = await self.db_service.update(schema_type, accession_id, data)
+            sanity_check = await self.db_service.read(schema_type, accession_id)
             # remove `draft-` from schema type
-            schema = (schema_type[6:] if schema_type.startswith("draft")
-                      else schema_type)
+            schema = schema_type[6:] if schema_type.startswith("draft") else schema_type
             JSONValidator(sanity_check, schema).validate
         except (ConnectionFailure, OperationFailure) as error:
             reason = f"Error happened while getting object: {error}"
@@ -241,10 +210,7 @@ class BaseOperator(ABC):
             LOG.error(reason)
             raise web.HTTPBadRequest(reason=reason)
 
-    async def _remove_object_from_db(self,
-                                     operator: Any,
-                                     schema_type: str,
-                                     accession_id: str) -> None:
+    async def _remove_object_from_db(self, operator: Any, schema_type: str, accession_id: str) -> None:
         """Delete object from database.
 
         We can omit raising error for XMLOperator if id is not
@@ -257,17 +223,14 @@ class BaseOperator(ABC):
         :returns: None
         """
         try:
-            check_exists = await operator.db_service.exists(schema_type,
-                                                            accession_id)
+            check_exists = await operator.db_service.exists(schema_type, accession_id)
             if not check_exists and not isinstance(operator, XMLOperator):
-                reason = (f"Object with accession id {accession_id} "
-                          "was not found.")
+                reason = f"Object with accession id {accession_id} " "was not found."
                 LOG.error(reason)
                 raise web.HTTPNotFound(reason=reason)
             else:
                 LOG.debug("XML is not in backup collection")
-            delete_success = (await operator.db_service.delete(schema_type,
-                                                               accession_id))
+            delete_success = await operator.db_service.delete(schema_type, accession_id)
         except (ConnectionFailure, OperationFailure) as error:
             reason = f"Error happened while deleting object: {error}"
             LOG.error(reason)
@@ -280,26 +243,21 @@ class BaseOperator(ABC):
             raise web.HTTPBadRequest(reason=reason)
 
     @abstractmethod
-    async def _format_data_to_create_and_add_to_db(self, schema_type: str,
-                                                   data: Any) -> str:
+    async def _format_data_to_create_and_add_to_db(self, schema_type: str, data: Any) -> str:
         """Format and add data to database.
 
         Must be implemented by subclass.
         """
 
     @abstractmethod
-    async def _format_data_to_replace_and_add_to_db(self, schema_type: str,
-                                                    accession_id: str,
-                                                    data: Any) -> str:
+    async def _format_data_to_replace_and_add_to_db(self, schema_type: str, accession_id: str, data: Any) -> str:
         """Format and replace data in database.
 
         Must be implemented by subclass.
         """
 
     @abstractmethod
-    async def _format_data_to_update_and_add_to_db(self, schema_type: str,
-                                                   accession_id: str,
-                                                   data: Any) -> str:
+    async def _format_data_to_update_and_add_to_db(self, schema_type: str, accession_id: str, data: Any) -> str:
         """Format and update data in database.
 
         Must be implemented by subclass.
@@ -328,10 +286,9 @@ class Operator(BaseOperator):
         """
         super().__init__("objects", "application/json", db_client)
 
-    async def query_metadata_database(self, schema_type: str,
-                                      que: MultiDictProxy,
-                                      page_num: int, page_size: int
-                                      ) -> Tuple[Dict, int, int, int]:
+    async def query_metadata_database(
+        self, schema_type: str, que: MultiDictProxy, page_num: int, page_size: int
+    ) -> Tuple[Dict, int, int, int]:
         """Query database based on url query parameters.
 
         Url queries are mapped to mongodb queries based on query_map in
@@ -357,9 +314,14 @@ class Operator(BaseOperator):
                         mongo_query["$or"] = []
                     for key in query_map[query]["keys"]:  # type: ignore
                         if value.isdigit():
-                            regi = {"$expr": {"$regexMatch": {
-                                    "input": {"$toString": f"${base}.{key}"},
-                                    "regex": f".*{int(value)}.*"}}}
+                            regi = {
+                                "$expr": {
+                                    "$regexMatch": {
+                                        "input": {"$toString": f"${base}.{key}"},
+                                        "regex": f".*{int(value)}.*",
+                                    }
+                                }
+                            }
                             mongo_query["$or"].append(regi)
                         else:
                             mongo_query["$or"].append({f"{base}.{key}": regx})
@@ -380,16 +342,16 @@ class Operator(BaseOperator):
             LOG.error(f"could not find any data in {schema_type}.")
             raise web.HTTPNotFound
         page_size = len(data) if len(data) != page_size else page_size
-        total_objects = await self.db_service.get_count(schema_type,
-                                                        mongo_query)
+        total_objects = await self.db_service.get_count(schema_type, mongo_query)
         LOG.debug(f"DB query: {que}")
-        LOG.info(f"DB query successful for query on {schema_type} "
-                 f"resulted in {total_objects}. "
-                 f"Requested was page {page_num} and page size {page_size}.")
+        LOG.info(
+            f"DB query successful for query on {schema_type} "
+            f"resulted in {total_objects}. "
+            f"Requested was page {page_num} and page size {page_size}."
+        )
         return data, page_num, page_size, total_objects
 
-    async def _format_data_to_create_and_add_to_db(self, schema_type: str,
-                                                   data: Dict) -> str:
+    async def _format_data_to_create_and_add_to_db(self, schema_type: str, data: Dict) -> str:
         """Format JSON metadata object and add it to db.
 
         Adds necessary additional information to object before adding to db.
@@ -411,9 +373,7 @@ class Operator(BaseOperator):
         LOG.debug(f"Operator formatted data for {schema_type} to add to DB.")
         return await self._insert_formatted_object_to_db(schema_type, data)
 
-    async def _format_data_to_replace_and_add_to_db(self, schema_type: str,
-                                                    accession_id: str,
-                                                    data: Dict) -> str:
+    async def _format_data_to_replace_and_add_to_db(self, schema_type: str, accession_id: str, data: Dict) -> str:
         """Format JSON metadata object and replace it in db.
 
         Replace information to object before adding to db.
@@ -428,21 +388,17 @@ class Operator(BaseOperator):
         :param data: Metadata object
         :returns: Accession Id for object inserted to database
         """
-        forbidden_keys = ['accessionId', 'publishDate', 'dateCreated']
+        forbidden_keys = ["accessionId", "publishDate", "dateCreated"]
         if any([i in data for i in forbidden_keys]):
-            reason = (f"Some items (e.g: {', '.join(forbidden_keys)}) "
-                      "cannot be changed.")
+            reason = f"Some items (e.g: {', '.join(forbidden_keys)}) " "cannot be changed."
             LOG.error(reason)
             raise web.HTTPBadRequest(reason=reason)
         data["accessionId"] = accession_id
         data["dateModified"] = datetime.utcnow()
         LOG.debug(f"Operator formatted data for {schema_type} to add to DB")
-        return await self._replace_object_from_db(schema_type, accession_id,
-                                                  data)
+        return await self._replace_object_from_db(schema_type, accession_id, data)
 
-    async def _format_data_to_update_and_add_to_db(self, schema_type: str,
-                                                   accession_id: str,
-                                                   data: Any) -> str:
+    async def _format_data_to_update_and_add_to_db(self, schema_type: str, accession_id: str, data: Any) -> str:
         """Format and update data in database.
 
         :param schema_type: Schema type of the object to replace.
@@ -450,31 +406,29 @@ class Operator(BaseOperator):
         :param data: Metadata object
         :returns: Accession Id for object inserted to database
         """
-        forbidden_keys = ['accessionId', 'publishDate', 'dateCreated']
+        forbidden_keys = ["accessionId", "publishDate", "dateCreated"]
         if any([i in data for i in forbidden_keys]):
-            reason = (f"Some items (e.g: {', '.join(forbidden_keys)}) "
-                      "cannot be changed.")
+            reason = f"Some items (e.g: {', '.join(forbidden_keys)}) " "cannot be changed."
             LOG.error(reason)
             raise web.HTTPBadRequest(reason=reason)
         data["accessionId"] = accession_id
         data["dateModified"] = datetime.utcnow()
         LOG.debug(f"Operator formatted data for {schema_type} to add to DB")
-        return await self._update_object_from_db(schema_type, accession_id,
-                                                 data)
+        return await self._update_object_from_db(schema_type, accession_id, data)
 
     def _generate_accession_id(self) -> str:
         """Generate random accession id.
 
         Will be replaced later with external id generator.
         """
-        sequence = ''.join(secrets.choice(string.digits) for i in range(16))
+        sequence = "".join(secrets.choice(string.digits) for i in range(16))
         LOG.debug("Generated accession ID.")
         return f"EDAG{sequence}"
 
     @auto_reconnect
-    async def _format_read_data(self, schema_type: str, data_raw: Union[Dict,
-                                AsyncIOMotorCursor]) -> Union[Dict,
-                                                              List[Dict]]:
+    async def _format_read_data(
+        self, schema_type: str, data_raw: Union[Dict, AsyncIOMotorCursor]
+    ) -> Union[Dict, List[Dict]]:
         """Get JSON content from given mongodb data.
 
         Data can be either one result or cursor containing multiple
@@ -490,8 +444,7 @@ class Operator(BaseOperator):
         if isinstance(data_raw, dict):
             return self._format_single_dict(schema_type, data_raw)
         else:
-            return ([self._format_single_dict(schema_type, doc) async for
-                     doc in data_raw])
+            return [self._format_single_dict(schema_type, doc) async for doc in data_raw]
 
     def _format_single_dict(self, schema_type: str, doc: Dict) -> Dict:
         """Format single result dictionary.
@@ -503,6 +456,7 @@ class Operator(BaseOperator):
         :param doc: single document from mongodb
         :returns: formatted version of document
         """
+
         def format_date(key: str, doc: Dict) -> Dict:
             doc[key] = doc[key].isoformat()
             return doc
@@ -529,8 +483,7 @@ class XMLOperator(BaseOperator):
         """
         super().__init__("backups", "text/xml", db_client)
 
-    async def _format_data_to_create_and_add_to_db(self, schema_type: str,
-                                                   data: str) -> str:
+    async def _format_data_to_create_and_add_to_db(self, schema_type: str, data: str) -> str:
         """Format XML metadata object and add it to db.
 
         XML is validated, then parsed to json and json is added to database.
@@ -542,21 +495,13 @@ class XMLOperator(BaseOperator):
         """
         db_client = self.db_service.db_client
         # remove `drafs-` from schema type
-        schema = (schema_type[6:] if schema_type.startswith("draft")
-                  else schema_type)
+        schema = schema_type[6:] if schema_type.startswith("draft") else schema_type
         data_as_json = XMLToJSONParser().parse(schema, data)
-        accession_id = (await Operator(db_client).
-                        _format_data_to_create_and_add_to_db(schema_type,
-                                                             data_as_json))
+        accession_id = await Operator(db_client)._format_data_to_create_and_add_to_db(schema_type, data_as_json)
         LOG.debug(f"XMLOperator formatted data for {schema_type} to add to DB")
-        return (await self.
-                _insert_formatted_object_to_db(schema_type,
-                                               {"accessionId": accession_id,
-                                                "content": data}))
+        return await self._insert_formatted_object_to_db(schema_type, {"accessionId": accession_id, "content": data})
 
-    async def _format_data_to_replace_and_add_to_db(self, schema_type: str,
-                                                    accession_id: str,
-                                                    data: str) -> str:
+    async def _format_data_to_replace_and_add_to_db(self, schema_type: str, accession_id: str, data: str) -> str:
         """Format XML metadata object and add it to db.
 
         XML is validated, then parsed to json and json is added to database.
@@ -569,22 +514,16 @@ class XMLOperator(BaseOperator):
         """
         db_client = self.db_service.db_client
         # remove `draft-` from schema type
-        schema = (schema_type[6:] if schema_type.startswith("draft")
-                  else schema_type)
+        schema = schema_type[6:] if schema_type.startswith("draft") else schema_type
         data_as_json = XMLToJSONParser().parse(schema, data)
-        accession_id = (await Operator(db_client).
-                        _format_data_to_replace_and_add_to_db(schema_type,
-                                                              accession_id,
-                                                              data_as_json))
+        accession_id = await Operator(db_client)._format_data_to_replace_and_add_to_db(
+            schema_type, accession_id, data_as_json
+        )
         LOG.debug(f"XMLOperator formatted data for {schema_type} to add to DB")
-        await self._replace_object_from_db(schema_type, accession_id,
-                                           {"accessionId": accession_id,
-                                            "content": data})
+        await self._replace_object_from_db(schema_type, accession_id, {"accessionId": accession_id, "content": data})
         return accession_id
 
-    async def _format_data_to_update_and_add_to_db(self, schema_type: str,
-                                                   accession_id: str,
-                                                   data: str) -> str:
+    async def _format_data_to_update_and_add_to_db(self, schema_type: str, accession_id: str, data: str) -> str:
         """Raise not implemented.
 
         Patch update for XML not supported
@@ -630,7 +569,7 @@ class FolderOperator:
         :returns: Folder id for the folder inserted to database
         """
         folder_id = self._generate_folder_id()
-        data['folderId'] = folder_id
+        data["folderId"] = folder_id
         try:
             insert_success = await self.db_service.create("folder", data)
         except (ConnectionFailure, OperationFailure) as error:
@@ -643,8 +582,7 @@ class FolderOperator:
             LOG.error(reason)
             raise web.HTTPBadRequest(reason=reason)
         else:
-            LOG.info(f"Inserting folder with id {folder_id} to database "
-                     "succeeded.")
+            LOG.info(f"Inserting folder with id {folder_id} to database " "succeeded.")
             return folder_id
 
     @auto_reconnect
@@ -687,15 +625,13 @@ class FolderOperator:
         try:
             folder = await self.db_service.read("folder", folder_id)
             upd_content = patch.apply(folder)
-            update_success = await self.db_service.update("folder", folder_id,
-                                                          upd_content)
+            update_success = await self.db_service.update("folder", folder_id, upd_content)
         except (ConnectionFailure, OperationFailure) as error:
             reason = f"Error happened while getting folder: {error}"
             LOG.error(reason)
             raise web.HTTPBadRequest(reason=reason)
 
-        except (InvalidJsonPatch, JsonPatchConflict,
-                JsonPointerException) as error:
+        except (InvalidJsonPatch, JsonPatchConflict, JsonPointerException) as error:
             reason = f"Error happened while applying JSON Patch: {error}"
             LOG.error(reason)
             raise web.HTTPBadRequest(reason=reason)
@@ -705,8 +641,7 @@ class FolderOperator:
             LOG.error(reason)
             raise web.HTTPBadRequest(reason=reason)
         else:
-            LOG.info(f"Updating folder with id {folder_id} to database "
-                     "succeeded.")
+            LOG.info(f"Updating folder with id {folder_id} to database " "succeeded.")
             return folder_id
 
     async def delete_folder(self, folder_id: str) -> None:
@@ -731,12 +666,12 @@ class FolderOperator:
         """Check the existance of a folder by its id in the database."""
         exists = await db.exists("folder", id)
         if not exists:
-            reason = (f"Folder with id {id} was not found.")
+            reason = f"Folder with id {id} was not found."
             LOG.error(reason)
             raise web.HTTPNotFound(reason=reason)
 
     def _generate_folder_id(self) -> str:
         """Generate random folder id."""
-        sequence = ''.join(secrets.choice(string.digits) for i in range(8))
+        sequence = "".join(secrets.choice(string.digits) for i in range(8))
         LOG.debug("Generated folder ID.")
         return f"FOL{sequence}"

--- a/metadata_backend/conf/conf.py
+++ b/metadata_backend/conf/conf.py
@@ -56,9 +56,7 @@ def create_db_client() -> AsyncIOMotorClient:
     :returns: Coroutine-based Motor client for Mongo operations
     """
     LOG.debug("initialised DB client")
-    return AsyncIOMotorClient(url,
-                              connectTimeoutMS=connectTimeout,
-                              serverSelectionTimeoutMS=serverTimeout)
+    return AsyncIOMotorClient(url, connectTimeoutMS=connectTimeout, serverSelectionTimeoutMS=serverTimeout)
 
 
 # 2) Load schema types and descriptions from json
@@ -77,26 +75,15 @@ query_map = {
     "studyTitle": "descriptor.studyTitle",
     "studyType": "descriptor.studyType",
     "studyAbstract": "descriptor.studyAbstract",
-    "studyAttributes": {"base": "studyAttributes",
-                        "keys": ["tag", "value"]},
-    "sampleName": {"base": "sampleName",
-                   "keys": ["taxonId", "scientificName",
-                            "commonName"]},
+    "studyAttributes": {"base": "studyAttributes", "keys": ["tag", "value"]},
+    "sampleName": {"base": "sampleName", "keys": ["taxonId", "scientificName", "commonName"]},
     "scientificName": "sampleName.scientificName",
     "fileType": "files.file.filetype",
-    "studyReference": {"base": "studyRef",
-                       "keys": ["accessionId", "refname", "refcenter"]},
-    "sampleReference": {"base": "sampleRef",
-                        "keys": ["accessionId", "label", "refname",
-                                 "refcenter"]},
-    "experimentReference": {"base": "experimentRef",
-                            "keys": ["accessionId", "refname",
-                                     "refcenter"]},
-    "runReference": {"base": "runRef",
-                     "keys": ["accessionId", "refname", "refcenter"]},
-    "analysisReference": {"base": "analysisRef",
-                          "keys": ["accessionId", "refname",
-                                   "refcenter"]},
+    "studyReference": {"base": "studyRef", "keys": ["accessionId", "refname", "refcenter"]},
+    "sampleReference": {"base": "sampleRef", "keys": ["accessionId", "label", "refname", "refcenter"]},
+    "experimentReference": {"base": "experimentRef", "keys": ["accessionId", "refname", "refcenter"]},
+    "runReference": {"base": "runRef", "keys": ["accessionId", "refname", "refcenter"]},
+    "analysisReference": {"base": "analysisRef", "keys": ["accessionId", "refname", "refcenter"]},
 }
 
 

--- a/metadata_backend/database/db_service.py
+++ b/metadata_backend/database/db_service.py
@@ -11,6 +11,7 @@ from ..helpers.logger import LOG
 
 def auto_reconnect(db_func: Callable) -> Callable:
     """Auto reconnection decorator."""
+
     @wraps(db_func)
     async def retry(*args: Any, **kwargs: Any) -> Any:
         """Retry given function for many times with increasing interval.
@@ -28,13 +29,15 @@ def auto_reconnect(db_func: Callable) -> Callable:
                 return await db_func(*args, **kwargs)
             except AutoReconnect:
                 if attempt == max_attempts:
-                    message = (f"Connection to database failed after {attempt}"
-                               "tries")
+                    message = f"Connection to database failed after {attempt}" "tries"
                     raise ConnectionFailure(message=message)
-                LOG.error("Connection not successful, trying to reconnect."
-                          f"Reconnection attempt number {attempt}, waiting "
-                          f" for {default_timeout} seconds.")
+                LOG.error(
+                    "Connection not successful, trying to reconnect."
+                    f"Reconnection attempt number {attempt}, waiting "
+                    f" for {default_timeout} seconds."
+                )
                 continue
+
     return retry
 
 
@@ -49,8 +52,7 @@ class DBService:
     automatically.
     """
 
-    def __init__(self, database_name: str,
-                 db_client: AsyncIOMotorClient) -> None:
+    def __init__(self, database_name: str, db_client: AsyncIOMotorClient) -> None:
         """Create service for given database.
 
         Service will have read-write access to given database. Database will be
@@ -83,8 +85,7 @@ class DBService:
         id_key = "folderId" if collection == "folder" else "accessionId"
         find_by_id = {id_key: id}
         LOG.debug(f"DB doc read for {id}.")
-        exists = await self.database[collection].find_one(find_by_id,
-                                                          {'_id': False})
+        exists = await self.database[collection].find_one(find_by_id, {"_id": False})
         return True if exists else False
 
     @auto_reconnect
@@ -98,12 +99,10 @@ class DBService:
         id_key = "folderId" if collection == "folder" else "accessionId"
         find_by_id = {id_key: id}
         LOG.debug(f"DB doc read for {id}.")
-        return await self.database[collection].find_one(find_by_id,
-                                                        {'_id': False})
+        return await self.database[collection].find_one(find_by_id, {"_id": False})
 
     @auto_reconnect
-    async def update(self, collection: str, id: str,
-                     data_to_be_updated: Dict) -> bool:
+    async def update(self, collection: str, id: str, data_to_be_updated: Dict) -> bool:
         """Update some elements of object by its accessionId.
 
         :param collection: Collection where document should be searched from
@@ -115,14 +114,12 @@ class DBService:
         id_key = "folderId" if collection == "folder" else "accessionId"
         find_by_id = {id_key: id}
         update_op = {"$set": data_to_be_updated}
-        result = await self.database[collection].update_one(find_by_id,
-                                                            update_op)
+        result = await self.database[collection].update_one(find_by_id, update_op)
         LOG.debug(f"DB doc updated for {id}.")
         return result.acknowledged
 
     @auto_reconnect
-    async def replace(self, collection: str, accession_id: str,
-                      new_data: Dict) -> bool:
+    async def replace(self, collection: str, accession_id: str, new_data: Dict) -> bool:
         """Replace whole object by its accessionId.
 
         We keep the dateCreated and publishDate dates as these
@@ -138,12 +135,11 @@ class DBService:
         """
         find_by_id = {"accessionId": accession_id}
         old_data = await self.database[collection].find_one(find_by_id)
-        if not (len(new_data) == 2 and new_data['content'].startswith('<')):
-            new_data['dateCreated'] = old_data['dateCreated']
-            if 'publishDate' in old_data:
-                new_data['publishDate'] = old_data['publishDate']
-        result = await self.database[collection].replace_one(find_by_id,
-                                                             new_data)
+        if not (len(new_data) == 2 and new_data["content"].startswith("<")):
+            new_data["dateCreated"] = old_data["dateCreated"]
+            if "publishDate" in old_data:
+                new_data["publishDate"] = old_data["publishDate"]
+        result = await self.database[collection].replace_one(find_by_id, new_data)
         LOG.debug(f"DB doc replaced for {accession_id}.")
         return result.acknowledged
 
@@ -172,7 +168,7 @@ class DBService:
         :returns: Async cursor instance which should be awaited when iterating
         """
         LOG.debug("DB doc query performed.")
-        return self.database[collection].find(query, {'_id': False})
+        return self.database[collection].find(query, {"_id": False})
 
     @auto_reconnect
     async def get_count(self, collection: str, query: Dict) -> int:

--- a/metadata_backend/helpers/logger.py
+++ b/metadata_backend/helpers/logger.py
@@ -4,9 +4,10 @@ import json
 import logging
 from typing import Any, Dict
 
-FORMAT = "[%(asctime)s][%(name)s][%(process)d %(processName)s]" \
-         "[%(levelname)-8s](L:%(lineno)s) %(funcName)s: %(message)s"
-logging.basicConfig(format=FORMAT, datefmt='%Y-%m-%d %H:%M:%S')
+FORMAT = (
+    "[%(asctime)s][%(name)s][%(process)d %(processName)s]" "[%(levelname)-8s](L:%(lineno)s) %(funcName)s: %(message)s"
+)
+logging.basicConfig(format=FORMAT, datefmt="%Y-%m-%d %H:%M:%S")
 
 LOG = logging.getLogger("server")
 LOG.setLevel(logging.INFO)

--- a/metadata_backend/helpers/schema_loader.py
+++ b/metadata_backend/helpers/schema_loader.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from xmlschema import XMLSchema
 
-SCHEMAS_ROOT = Path(__file__).parent / 'schemas'
+SCHEMAS_ROOT = Path(__file__).parent / "schemas"
 
 
 class SchemaNotFoundException(Exception):
@@ -19,8 +19,7 @@ class SchemaNotFoundException(Exception):
 
     def __init__(self) -> None:
         """Set up exception message."""
-        Exception.__init__(self,
-                           "The provided schema type could not be found.")
+        Exception.__init__(self, "The provided schema type could not be found.")
 
 
 class SchemaLoader(ABC):
@@ -41,8 +40,7 @@ class SchemaLoader(ABC):
         schema_type = schema_type.lower()
         schema_file = None
         for file in [x for x in self.path.iterdir()]:
-            if (schema_type in file.name
-               and file.name.endswith(self.loader_type)):
+            if schema_type in file.name and file.name.endswith(self.loader_type):
                 schema_file = file
         if not schema_file:
             raise SchemaNotFoundException

--- a/metadata_backend/server.py
+++ b/metadata_backend/server.py
@@ -23,54 +23,51 @@ async def init() -> web.Application:
     Note:: if using variable resources (such as {schema}), add
     specific ones on top of more generic ones.
     """
-    server = web.Application(middlewares=[http_error_handler,
-                                          jwt_authentication])
+    server = web.Application(middlewares=[http_error_handler, jwt_authentication])
     rest_handler = RESTApiHandler()
     submission_handler = SubmissionAPIHandler()
     api_routes = [
-        web.get('/schemas', rest_handler.get_schema_types),
-        web.get('/schemas/{schema}', rest_handler.get_json_schema),
-        web.get('/objects/{schema}/{accessionId}', rest_handler.get_object),
-        web.delete('/objects/{schema}/{accessionId}',
-                   rest_handler.delete_object),
-        web.get('/objects/{schema}', rest_handler.query_objects),
-        web.post('/objects/{schema}', rest_handler.post_object),
-        web.get('/drafts/{schema}/{accessionId}', rest_handler.get_object),
-        web.put('/drafts/{schema}/{accessionId}', rest_handler.put_object),
-        web.patch('/drafts/{schema}/{accessionId}', rest_handler.patch_object),
-        web.delete('/drafts/{schema}/{accessionId}',
-                   rest_handler.delete_object),
-        web.post('/drafts/{schema}', rest_handler.post_object),
-        web.get('/folders', rest_handler.get_folders),
-        web.post('/folders', rest_handler.post_folder),
-        web.get('/folders/{folderId}', rest_handler.get_folder),
-        web.patch('/folders/{folderId}', rest_handler.patch_folder),
-        web.delete('/folders/{folderId}', rest_handler.delete_folder),
-        web.post('/submit', submission_handler.submit),
-        web.post('/validate', submission_handler.validate)
+        web.get("/schemas", rest_handler.get_schema_types),
+        web.get("/schemas/{schema}", rest_handler.get_json_schema),
+        web.get("/objects/{schema}/{accessionId}", rest_handler.get_object),
+        web.delete("/objects/{schema}/{accessionId}", rest_handler.delete_object),
+        web.get("/objects/{schema}", rest_handler.query_objects),
+        web.post("/objects/{schema}", rest_handler.post_object),
+        web.get("/drafts/{schema}/{accessionId}", rest_handler.get_object),
+        web.put("/drafts/{schema}/{accessionId}", rest_handler.put_object),
+        web.patch("/drafts/{schema}/{accessionId}", rest_handler.patch_object),
+        web.delete("/drafts/{schema}/{accessionId}", rest_handler.delete_object),
+        web.post("/drafts/{schema}", rest_handler.post_object),
+        web.get("/folders", rest_handler.get_folders),
+        web.post("/folders", rest_handler.post_folder),
+        web.get("/folders/{folderId}", rest_handler.get_folder),
+        web.patch("/folders/{folderId}", rest_handler.patch_folder),
+        web.delete("/folders/{folderId}", rest_handler.delete_folder),
+        web.post("/submit", submission_handler.submit),
+        web.post("/validate", submission_handler.validate),
     ]
     server.router.add_routes(api_routes)
     LOG.info("Server configurations and routes loaded")
     if frontend_static_files.exists():
         static_handler = StaticHandler(frontend_static_files)
         frontend_routes = [
-            web.static('/static', static_handler.setup_static()),
-            web.get('/{path:.*}', static_handler.frontend),
+            web.static("/static", static_handler.setup_static()),
+            web.get("/{path:.*}", static_handler.frontend),
         ]
         server.router.add_routes(frontend_routes)
         LOG.info("Frontend routes loaded")
-    server['db_client'] = create_db_client()
+    server["db_client"] = create_db_client()
     LOG.info("Database client loaded")
     return server
 
 
 def main() -> None:
     """Launch the server."""
-    host = '0.0.0.0'  # nosec
+    host = "0.0.0.0"  # nosec
     port = 5430
     web.run_app(init(), host=host, port=port, shutdown_timeout=0)
     LOG.info(f"Started server on {host}:{port}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,6 @@ setup(
         "": ["schemas/*.xsd", "schemas/*.json", "frontend/*", "frontend/static/js/*", "conf/ena_schemas.json"]
     },
     include_package_data=True,
-    entry_points={"console_scripts": ["metadata_submitter=metadata_backend.server:main",],},
-    project_urls={"Source": "https://github.com/CSCfi/metadata_submitter",},
+    entry_points={"console_scripts": ["metadata_submitter=metadata_backend.server:main"]},
+    project_urls={"Source": "https://github.com/CSCfi/metadata_submitter"},
 )

--- a/setup.py
+++ b/setup.py
@@ -11,49 +11,31 @@ setup(
     # There are some restrictions on what makes a valid project name
     # specification here:
     # https://packaging.python.org/specifications/core-metadata/#name
-    name='metadata_backend',
-
+    name="metadata_backend",
     # Versions should comply with PEP 440:
     # https://www.python.org/dev/peps/pep-0440/
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
     version=__version__,
-
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:
     # https://packaging.python.org/specifications/core-metadata/#summary
     description=__title__,
-
     author=__author__,
-
-    classifiers=[
-        'License :: OSI Approved :: MIT License'
-    ],
-
+    classifiers=["License :: OSI Approved :: MIT License"],
     # Instead of listing each package manually, we can use find_packages() to
     # automatically discover all packages and subpackages.
     packages=find_packages(exclude=["tests"]),
-
     install_requires=requirements,
-
     extras_require={
-        'test': ['aiounittest', 'coverage', 'coveralls', 'pytest',
-                 'pytest-cov', 'tox'],
-        'docs': ['sphinx >= 1.4', 'sphinx_rtd_theme'],
+        "test": ["aiounittest", "coverage", "coveralls", "pytest", "pytest-cov", "tox"],
+        "docs": ["sphinx >= 1.4", "sphinx_rtd_theme"],
     },
-
-    package_data={'': ['schemas/*.xsd', 'schemas/*.json', 'frontend/*',
-                       'frontend/static/js/*', 'conf/ena_schemas.json']},
+    package_data={
+        "": ["schemas/*.xsd", "schemas/*.json", "frontend/*", "frontend/static/js/*", "conf/ena_schemas.json"]
+    },
     include_package_data=True,
-
-    entry_points={
-        'console_scripts': [
-            'metadata_submitter=metadata_backend.server:main',
-        ],
-    },
-
-    project_urls={
-        'Source': 'https://github.com/CSCfi/metadata_submitter',
-    },
+    entry_points={"console_scripts": ["metadata_submitter=metadata_backend.server:main",],},
+    project_urls={"Source": "https://github.com/CSCfi/metadata_submitter",},
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,9 +7,7 @@ def pytest_itemcollected(item):
     par = item.parent.obj
     node = item.obj
     # First line only
-    prefix = par.__doc__.split('\n', 1)[0].strip() if \
-        par.__doc__ else par.__class__.__name__
-    suffix = node.__doc__.split('\n', 1)[0].strip() if \
-        node.__doc__ else node.__name__
+    prefix = par.__doc__.split("\n", 1)[0].strip() if par.__doc__ else par.__class__.__name__
+    suffix = node.__doc__.split("\n", 1)[0].strip() if node.__doc__ else node.__name__
     if prefix or suffix:
-        item._nodeid = ' | '.join((prefix, suffix))
+        item._nodeid = " | ".join((prefix, suffix))

--- a/tests/coveralls.py
+++ b/tests/coveralls.py
@@ -6,9 +6,9 @@ import os
 import sys
 from subprocess import call
 
-if __name__ == '__main__':
-    if 'COVERALLS_REPO_TOKEN' in os.environ:
-        rc = call('coveralls')
+if __name__ == "__main__":
+    if "COVERALLS_REPO_TOKEN" in os.environ:
+        rc = call("coveralls")
         sys.stdout.write("Coveralls report from Github Actions.\n")
         raise SystemExit(rc)
     else:

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -14,26 +14,27 @@ import aiohttp
 from aiohttp import FormData
 
 # === Global vars ===
-FORMAT = "[%(asctime)s][%(name)s][%(process)d %(processName)s]" \
-         "[%(levelname)-8s](L:%(lineno)s) %(funcName)s: %(message)s"
-logging.basicConfig(format=FORMAT, datefmt='%Y-%m-%d %H:%M:%S')
+FORMAT = (
+    "[%(asctime)s][%(name)s][%(process)d %(processName)s]" "[%(levelname)-8s](L:%(lineno)s) %(funcName)s: %(message)s"
+)
+logging.basicConfig(format=FORMAT, datefmt="%Y-%m-%d %H:%M:%S")
 LOG = logging.getLogger(__name__)
 LOG.setLevel(logging.DEBUG)
 
-testfiles_root = Path(__file__).parent.parent / 'test_files'
+testfiles_root = Path(__file__).parent.parent / "test_files"
 test_xml_files = [
     ("study", "SRP000539.xml"),
     ("sample", "SRS001433.xml"),
     ("run", "ERR000076.xml"),
     ("experiment", "ERX000119.xml"),
-    ("analysis", "ERZ266973.xml")
+    ("analysis", "ERZ266973.xml"),
 ]
 test_json_files = [
     ("study", "SRP000539.json", "SRP000539.json"),
     ("sample", "SRS001433.json", "SRS001433.json"),
     ("run", "ERR000076.json", "ERR000076.json"),
     ("experiment", "ERX000119.json", "ERX000119.json"),
-    ("analysis", "ERZ266973.json", "ERZ266973.json")
+    ("analysis", "ERZ266973.json", "ERZ266973.json"),
 ]
 base_url = "http://localhost:5430/objects"
 drafts_url = "http://localhost:5430/drafts"
@@ -49,11 +50,8 @@ async def create_request_data(schema, filename):
     data = FormData()
     path_to_file = testfiles_root / schema / filename
     path = path_to_file.as_posix()
-    async with aiofiles.open(path, mode='r') as f:
-        data.add_field(schema.upper(),
-                       await f.read(),
-                       filename=filename,
-                       content_type='text/xml')
+    async with aiofiles.open(path, mode="r") as f:
+        data.add_field(schema.upper(), await f.read(), filename=filename, content_type="text/xml")
     return data
 
 
@@ -65,7 +63,7 @@ async def create_request_json_data(schema, filename):
     """
     path_to_file = testfiles_root / schema / filename
     path = path_to_file.as_posix()
-    async with aiofiles.open(path, mode='r') as f:
+    async with aiofiles.open(path, mode="r") as f:
         data = await f.read()
     return data
 
@@ -75,7 +73,7 @@ async def post_object(sess, schema, filename):
     data = await create_request_data(schema, filename)
     async with sess.post(f"{base_url}/{schema}", data=data) as resp:
         LOG.debug(f"Adding new object to {schema}")
-        assert resp.status == 201, 'HTTP Status code error'
+        assert resp.status == 201, "HTTP Status code error"
         ans = await resp.json()
         return ans["accessionId"]
 
@@ -84,44 +82,40 @@ async def delete_object(sess, schema, accession_id):
     """Delete metadata object within session."""
     async with sess.delete(f"{base_url}/{schema}/{accession_id}") as resp:
         LOG.debug(f"Deleting object {accession_id} from {schema}")
-        assert resp.status == 204, 'HTTP Status code error'
+        assert resp.status == 204, "HTTP Status code error"
 
 
 async def put_draft(sess, schema, filename, filename2):
     """Post & put one metadata object within session, returns accessionId."""
     data = await create_request_json_data(schema, filename)
-    async with sess.post(f"{drafts_url}/{schema}",
-                         data=data) as resp:
+    async with sess.post(f"{drafts_url}/{schema}", data=data) as resp:
         LOG.debug(f"Adding new object to {schema}")
-        assert resp.status == 201, 'HTTP Status code error'
+        assert resp.status == 201, "HTTP Status code error"
         ans = await resp.json()
         test_id = ans["accessionId"]
     data2 = await create_request_json_data(schema, filename2)
-    async with sess.put(f"{drafts_url}/{schema}/{test_id}",
-                        data=data2) as resp:
+    async with sess.put(f"{drafts_url}/{schema}/{test_id}", data=data2) as resp:
         LOG.debug(f"Replace object in {schema}")
-        assert resp.status == 200, 'HTTP Status code error'
+        assert resp.status == 200, "HTTP Status code error"
         ans_put = await resp.json()
-        assert ans_put["accessionId"] == test_id, 'accession ID error'
+        assert ans_put["accessionId"] == test_id, "accession ID error"
         return ans_put["accessionId"]
 
 
 async def patch_draft(sess, schema, filename, filename2):
     """Post & patch one metadata object within session, return accessionId."""
     data = await create_request_json_data(schema, filename)
-    async with sess.post(f"{drafts_url}/{schema}",
-                         data=data) as resp:
+    async with sess.post(f"{drafts_url}/{schema}", data=data) as resp:
         LOG.debug(f"Adding new object to {schema}")
-        assert resp.status == 201, 'HTTP Status code error'
+        assert resp.status == 201, "HTTP Status code error"
         ans = await resp.json()
         test_id = ans["accessionId"]
     data = await create_request_json_data(schema, filename2)
-    async with sess.patch(f"{drafts_url}/{schema}/{test_id}",
-                          data=data) as resp:
+    async with sess.patch(f"{drafts_url}/{schema}/{test_id}", data=data) as resp:
         LOG.debug(f"Update object in {schema}")
-        assert resp.status == 200, 'HTTP Status code error'
+        assert resp.status == 200, "HTTP Status code error"
         ans_put = await resp.json()
-        assert ans_put["accessionId"] == test_id, 'accession ID error'
+        assert ans_put["accessionId"] == test_id, "accession ID error"
         return ans_put["accessionId"]
 
 
@@ -129,7 +123,7 @@ async def delete_draft(sess, schema, accession_id):
     """Delete metadata object within session."""
     async with sess.delete(f"{drafts_url}/{schema}/{accession_id}") as resp:
         LOG.debug(f"Deleting object {accession_id} from {schema}")
-        assert resp.status == 204, 'HTTP Status code error'
+        assert resp.status == 204, "HTTP Status code error"
 
 
 # === Integration tests ===
@@ -147,20 +141,18 @@ async def test_crud_works(schema, filename):
         accession_id = await post_object(sess, schema, filename)
         async with sess.get(f"{base_url}/{schema}/{accession_id}") as resp:
             LOG.debug(f"Checking that {accession_id} JSON is in {schema}")
-            assert resp.status == 200, 'HTTP Status code error'
-        async with sess.get(f"{base_url}/{schema}/{accession_id}"
-                            "?format=xml") as resp:
+            assert resp.status == 200, "HTTP Status code error"
+        async with sess.get(f"{base_url}/{schema}/{accession_id}" "?format=xml") as resp:
             LOG.debug(f"Checking that {accession_id} XML is in {schema}")
-            assert resp.status == 200, 'HTTP Status code error'
+            assert resp.status == 200, "HTTP Status code error"
 
         await delete_object(sess, schema, accession_id)
         async with sess.get(f"{base_url}/{schema}/{accession_id}") as resp:
             LOG.debug(f"Checking that JSON object {accession_id} was deleted")
-            assert resp.status == 404, 'HTTP Status code error'
-        async with sess.get(f"{base_url}/{schema}/{accession_id}"
-                            "?format=xml") as resp:
+            assert resp.status == 404, "HTTP Status code error"
+        async with sess.get(f"{base_url}/{schema}/{accession_id}" "?format=xml") as resp:
             LOG.debug(f"Checking that XML object {accession_id} was deleted")
-            assert resp.status == 404, 'HTTP Status code error'
+            assert resp.status == 404, "HTTP Status code error"
 
 
 async def test_crud_drafts_works(schema, filename, filename2):
@@ -177,12 +169,12 @@ async def test_crud_drafts_works(schema, filename, filename2):
         accession_id = await put_draft(sess, schema, filename, filename2)
         async with sess.get(f"{drafts_url}/{schema}/{accession_id}") as resp:
             LOG.debug(f"Checking that {accession_id} JSON is in {schema}")
-            assert resp.status == 200, 'HTTP Status code error'
+            assert resp.status == 200, "HTTP Status code error"
 
         await delete_draft(sess, schema, accession_id)
         async with sess.get(f"{drafts_url}/{schema}/{accession_id}") as resp:
             LOG.debug(f"Checking that JSON object {accession_id} was deleted")
-            assert resp.status == 404, 'HTTP Status code error'
+            assert resp.status == 404, "HTTP Status code error"
 
 
 async def test_put_drafts_works(schema, filename, filename2):
@@ -199,12 +191,12 @@ async def test_put_drafts_works(schema, filename, filename2):
         accession_id = await put_draft(sess, schema, filename, filename2)
         async with sess.get(f"{drafts_url}/{schema}/{accession_id}") as resp:
             LOG.debug(f"Checking that {accession_id} JSON is in {schema}")
-            assert resp.status == 200, 'HTTP Status code error'
+            assert resp.status == 200, "HTTP Status code error"
 
         await delete_draft(sess, schema, accession_id)
         async with sess.get(f"{drafts_url}/{schema}/{accession_id}") as resp:
             LOG.debug(f"Checking that JSON object {accession_id} was deleted")
-            assert resp.status == 404, 'HTTP Status code error'
+            assert resp.status == 404, "HTTP Status code error"
 
 
 async def test_patch_drafts_works(schema, filename, filename2):
@@ -222,14 +214,14 @@ async def test_patch_drafts_works(schema, filename, filename2):
         async with sess.get(f"{drafts_url}/{schema}/{accession_id}") as resp:
             LOG.debug(f"Checking that {accession_id} JSON is in {schema}")
             res = await resp.json()
-            assert res['centerName'] == 'GEOM', 'content mismatch'
-            assert res['alias'] == 'GSE10968', 'content mismatch'
-            assert resp.status == 200, 'HTTP Status code error'
+            assert res["centerName"] == "GEOM", "content mismatch"
+            assert res["alias"] == "GSE10968", "content mismatch"
+            assert resp.status == 200, "HTTP Status code error"
 
         await delete_draft(sess, schema, accession_id)
         async with sess.get(f"{drafts_url}/{schema}/{accession_id}") as resp:
             LOG.debug(f"Checking that JSON object {accession_id} was deleted")
-            assert resp.status == 404, 'HTTP Status code error'
+            assert resp.status == 404, "HTTP Status code error"
 
 
 async def test_querying_works():
@@ -237,8 +229,8 @@ async def test_querying_works():
     async with aiohttp.ClientSession() as sess:
 
         accession_ids = await asyncio.gather(
-            *[post_object(sess, schema, filename)
-              for schema, filename in test_xml_files])
+            *[post_object(sess, schema, filename) for schema, filename in test_xml_files]
+        )
 
         queries = {
             "study": [
@@ -246,7 +238,7 @@ async def test_querying_works():
                 ("studyType", "Other"),
                 ("studyAbstract", "arabidopsis thaliana"),
                 ("studyAttributes", "prjna107265"),
-                ("studyAttributes", "parent_bioproject")
+                ("studyAttributes", "parent_bioproject"),
             ],
             "sample": [
                 ("title", "HapMap sample"),
@@ -254,41 +246,38 @@ async def test_querying_works():
                 ("centerName", "hapmap"),
                 ("sampleName", "homo sapiens"),
                 ("scientificName", "homo sapiens"),
-                ("sampleName", 9606)
+                ("sampleName", 9606),
             ],
             "run": [
                 ("fileType", "srf"),
                 ("experimentReference", "g1k-bgi-na18542"),
-                ("experimentReference", "erx000037")
+                ("experimentReference", "erx000037"),
             ],
-            "experiment": [
-                ("studyReference", "1000Genomes project pilot")
-            ],
+            "experiment": [("studyReference", "1000Genomes project pilot")],
             "analysis": [
                 ("fileType", "other"),
                 ("studyReference", "HipSci___RNAseq___"),
-                ("sampleReference", "HPSI0114i-eipl_3")
-            ]
+                ("sampleReference", "HPSI0114i-eipl_3"),
+            ],
         }
 
         async def do_one_query(schema, key, value, expected_status):
             async with sess.get(f"{base_url}/{schema}?{key}={value}") as resp:
-                assert resp.status == expected_status, 'HTTP Status code error'
+                assert resp.status == expected_status, "HTTP Status code error"
 
         for schema, schema_queries in queries.items():
             LOG.debug(f"Querying {schema} collection with working params")
-            await asyncio.gather(*[do_one_query(schema, key, value, 200) for
-                                   key, value in schema_queries])
+            await asyncio.gather(*[do_one_query(schema, key, value, 200) for key, value in schema_queries])
             LOG.debug("Querying {schema} collection with non-working params")
             invalid = "yoloswaggings"
-            await asyncio.gather(*[do_one_query(schema, key, invalid, 404) for
-                                   key, _ in schema_queries])
+            await asyncio.gather(*[do_one_query(schema, key, invalid, 404) for key, _ in schema_queries])
 
-        await asyncio.gather(*[delete_object(sess, schema, accession_id) for
-                               schema, accession_id in
-                               list(zip([schema for schema, _
-                                        in test_xml_files],
-                                        accession_ids))])
+        await asyncio.gather(
+            *[
+                delete_object(sess, schema, accession_id)
+                for schema, accession_id in list(zip([schema for schema, _ in test_xml_files], accession_ids))
+            ]
+        )
 
 
 async def test_getting_all_objects_from_schema_works():
@@ -296,8 +285,7 @@ async def test_getting_all_objects_from_schema_works():
     async with aiohttp.ClientSession() as sess:
 
         # Add objects
-        accession_ids = await asyncio.gather(
-            *[post_object(sess, "study", "SRP000539.xml") for _ in range(13)])
+        accession_ids = await asyncio.gather(*[post_object(sess, "study", "SRP000539.xml") for _ in range(13)])
 
         # Test default values
         async with sess.get(f"{base_url}/study") as resp:
@@ -326,24 +314,18 @@ async def test_getting_all_objects_from_schema_works():
             assert resp.status == 400
 
         # Delete objects
-        await asyncio.gather(*[delete_object(sess, "study", accession_id) for
-                               accession_id in accession_ids])
+        await asyncio.gather(*[delete_object(sess, "study", accession_id) for accession_id in accession_ids])
 
 
 async def main():
     """Launch different test tasks and run them."""
     # Test adding and getting objects
     LOG.debug("=== Testing basic CRUD operations ===")
-    await asyncio.gather(
-        *[test_crud_works(schema, file) for schema, file in test_xml_files]
-    )
+    await asyncio.gather(*[test_crud_works(schema, file) for schema, file in test_xml_files])
 
     # Test adding and getting draft objects
     LOG.debug("=== Testing basic CRUD drafts operations ===")
-    await asyncio.gather(
-        *[test_crud_drafts_works(schema, file, file2)
-          for schema, file, file2 in test_json_files]
-    )
+    await asyncio.gather(*[test_crud_drafts_works(schema, file, file2) for schema, file, file2 in test_json_files])
 
     # Test patch and put
     LOG.debug("=== Testing patch and put drafts operations ===")
@@ -358,5 +340,6 @@ async def main():
     LOG.debug("=== Testing getting all objects & pagination ===")
     await test_getting_all_objects_from_schema_works()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     asyncio.run(main())

--- a/tests/test_db_service.py
+++ b/tests/test_db_service.py
@@ -22,8 +22,10 @@ class DatabaseTestCase(AsyncTestCase):
         Monkey patching can probably be removed when upgrading requirements to
         python 3.8+ since Mock 4.0+ library has async version of MagicMock.
         """
+
         async def async_patch():
             pass
+
         MagicMock.__await__ = lambda x: async_patch().__await__()
         self.client = MagicMock()
         self.database = MagicMock()
@@ -32,15 +34,18 @@ class DatabaseTestCase(AsyncTestCase):
         self.database.__getitem__.return_value = self.collection
         self.test_service = DBService("test", self.client)
         self.id_stub = "EGA123456"
-        self.data_stub = {"accessionId": self.id_stub,
-                          "identifiers": ["foo", "bar"],
-                          "dateCreated": "2020-07-26T20:59:35.177Z"
-                          }
+        self.data_stub = {
+            "accessionId": self.id_stub,
+            "identifiers": ["foo", "bar"],
+            "dateCreated": "2020-07-26T20:59:35.177Z",
+        }
         self.f_id_stub = "FOL12345678"
-        self.folder_stub = {"folderId": self.f_id_stub,
-                            "name": "test",
-                            "description": "test folder",
-                            "metadata_objects": []}
+        self.folder_stub = {
+            "folderId": self.f_id_stub,
+            "name": "test",
+            "description": "test folder",
+            "metadata_objects": [],
+        }
 
     def test_db_services_share_mongodb_client(self):
         """Test client is shared across different db_service_objects."""
@@ -50,18 +55,14 @@ class DatabaseTestCase(AsyncTestCase):
 
     async def test_create_inserts_data(self):
         """Test that create method works and returns success."""
-        self.collection.insert_one.return_value = futurized(
-            InsertOneResult(ObjectId('0123456789ab0123456789ab'), True)
-        )
+        self.collection.insert_one.return_value = futurized(InsertOneResult(ObjectId("0123456789ab0123456789ab"), True))
         success = await self.test_service.create("test", self.data_stub)
         self.collection.insert_one.assert_called_once_with(self.data_stub)
         self.assertTrue(success)
 
     async def test_create_reports_fail_correctly(self):
         """Test that failure is reported, when write not acknowledged."""
-        self.collection.insert_one.return_value = futurized(
-            InsertOneResult(None, False)
-        )
+        self.collection.insert_one.return_value = futurized(InsertOneResult(None, False))
         success = await self.test_service.create("test", self.data_stub)
         self.collection.insert_one.assert_called_once_with(self.data_stub)
         self.assertFalse(success)
@@ -71,62 +72,42 @@ class DatabaseTestCase(AsyncTestCase):
         self.collection.find_one.return_value = futurized(self.data_stub)
         found_doc = await self.test_service.read("test", self.id_stub)
         self.assertEqual(found_doc, self.data_stub)
-        self.collection.find_one.assert_called_once_with({"accessionId":
-                                                          self.id_stub},
-                                                         {'_id': False})
+        self.collection.find_one.assert_called_once_with({"accessionId": self.id_stub}, {"_id": False})
 
     async def test_exists_returns_false(self):
         """Test that exists method works and returns false."""
         found_doc = await self.test_service.exists("test", self.id_stub)
         self.assertEqual(found_doc, False)
-        self.collection.find_one.assert_called_once_with({"accessionId":
-                                                          self.id_stub},
-                                                         {'_id': False})
+        self.collection.find_one.assert_called_once_with({"accessionId": self.id_stub}, {"_id": False})
 
     async def test_exists_returns_true(self):
         """Test that exists method works and returns True."""
         self.collection.find_one.return_value = futurized(self.data_stub)
         found_doc = await self.test_service.exists("test", self.id_stub)
         self.assertEqual(found_doc, True)
-        self.collection.find_one.assert_called_once_with({"accessionId":
-                                                          self.id_stub},
-                                                         {'_id': False})
+        self.collection.find_one.assert_called_once_with({"accessionId": self.id_stub}, {"_id": False})
 
     async def test_update_updates_data(self):
         """Test that update method works and returns success."""
         self.collection.find_one.return_value = futurized(self.data_stub)
-        self.collection.update_one.return_value = futurized(
-            UpdateResult({}, True)
-        )
-        success = await self.test_service.update("test", self.id_stub,
-                                                 self.data_stub)
-        self.collection.update_one.assert_called_once_with({"accessionId":
-                                                            self.id_stub},
-                                                           {"$set":
-                                                            self.data_stub})
+        self.collection.update_one.return_value = futurized(UpdateResult({}, True))
+        success = await self.test_service.update("test", self.id_stub, self.data_stub)
+        self.collection.update_one.assert_called_once_with({"accessionId": self.id_stub}, {"$set": self.data_stub})
         self.assertTrue(success)
 
     async def test_replace_replaces_data(self):
         """Test that replace method works and returns success."""
         self.collection.find_one.return_value = futurized(self.data_stub)
-        self.collection.replace_one.return_value = futurized(
-            UpdateResult({}, True)
-        )
-        success = await self.test_service.replace("test", self.id_stub,
-                                                  self.data_stub)
-        self.collection.replace_one.assert_called_once_with({"accessionId":
-                                                            self.id_stub},
-                                                            self.data_stub)
+        self.collection.replace_one.return_value = futurized(UpdateResult({}, True))
+        success = await self.test_service.replace("test", self.id_stub, self.data_stub)
+        self.collection.replace_one.assert_called_once_with({"accessionId": self.id_stub}, self.data_stub)
         self.assertTrue(success)
 
     async def test_delete_deletes_data(self):
         """Test that delete method works and returns success."""
-        self.collection.delete_one.return_value = futurized(
-            DeleteResult({'n': 1}, True)
-        )
+        self.collection.delete_one.return_value = futurized(DeleteResult({"n": 1}, True))
         success = await self.test_service.delete("test", self.id_stub)
-        self.collection.delete_one.assert_called_once_with({"accessionId":
-                                                           self.id_stub})
+        self.collection.delete_one.assert_called_once_with({"accessionId": self.id_stub})
         self.assertTrue(success)
 
     def test_query_executes_find(self):
@@ -134,7 +115,7 @@ class DatabaseTestCase(AsyncTestCase):
         self.collection.find.return_value = AsyncIOMotorCursor(None, None)
         cursor = self.test_service.query("test", {})
         self.assertEqual(type(cursor), AsyncIOMotorCursor)
-        self.collection.find.assert_called_once_with({}, {'_id': False})
+        self.collection.find.assert_called_once_with({}, {"_id": False})
 
     async def test_count_returns_amount(self):
         """Test that get_count method works and returns amount."""
@@ -153,9 +134,7 @@ class DatabaseTestCase(AsyncTestCase):
 
     async def test_create_folder_inserts_folder(self):
         """Test that create method works for folder and returns success."""
-        self.collection.insert_one.return_value = futurized(
-            InsertOneResult(ObjectId('0000000000aa1111111111bb'), True)
-        )
+        self.collection.insert_one.return_value = futurized(InsertOneResult(ObjectId("0000000000aa1111111111bb"), True))
         folder = await self.test_service.create("folder", self.folder_stub)
         self.collection.insert_one.assert_called_once_with(self.folder_stub)
         self.assertTrue(folder)
@@ -164,7 +143,5 @@ class DatabaseTestCase(AsyncTestCase):
         """Test that read method works for folder and returns folder."""
         self.collection.find_one.return_value = futurized(self.folder_stub)
         found_folder = await self.test_service.read("folder", self.f_id_stub)
-        self.collection.find_one.assert_called_once_with({"folderId":
-                                                          self.f_id_stub},
-                                                         {'_id': False})
+        self.collection.find_one.assert_called_once_with({"folderId": self.f_id_stub}, {"_id": False})
         self.assertEqual(found_folder, self.folder_stub)

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -14,7 +14,7 @@ from metadata_backend.server import init
 class HandlersTestCase(AioHTTPTestCase):
     """Api endpoint class test cases."""
 
-    TESTFILES_ROOT = Path(__file__).parent / 'test_files'
+    TESTFILES_ROOT = Path(__file__).parent / "test_files"
 
     async def get_application(self):
         """Retrieve web Application for test."""
@@ -28,60 +28,50 @@ class HandlersTestCase(AioHTTPTestCase):
         methods.
         """
         self.test_ega_string = "EGA123456"
-        self.query_accessionId = "EDAG3991701442770179",
+        self.query_accessionId = ("EDAG3991701442770179",)
         self.page_num = 3
         self.page_size = 50
         self.total_objects = 150
-        self.metadata_json = {"study": {
-            "attributes": {
-                "centerName": "GEO",
-                "alias": "GSE10966",
-                "accession": "SRP000539"
-            },
-            "accessionId": "EDAG3991701442770179", }
+        self.metadata_json = {
+            "study": {
+                "attributes": {"centerName": "GEO", "alias": "GSE10966", "accession": "SRP000539"},
+                "accessionId": "EDAG3991701442770179",
+            }
         }
         path_to_xml_file = self.TESTFILES_ROOT / "study" / "SRP000539.xml"
         self.metadata_xml = path_to_xml_file.read_text()
         self.accession_id = "EGA123456"
         self.folder_id = "FOL12345678"
-        self.test_folder = {"folderId": self.folder_id,
-                            "name": "test",
-                            "description": "test folder",
-                            "metadata_objects": []}
+        self.test_folder = {
+            "folderId": self.folder_id,
+            "name": "test",
+            "description": "test folder",
+            "metadata_objects": [],
+        }
 
         class_parser = "metadata_backend.api.handlers.XMLToJSONParser"
         class_operator = "metadata_backend.api.handlers.Operator"
         class_xmloperator = "metadata_backend.api.handlers.XMLOperator"
         class_folderoperator = "metadata_backend.api.handlers.FolderOperator"
-        operator_config = {'read_metadata_object.side_effect':
-                           self.fake_operator_read_metadata_object,
-                           'query_metadata_database.side_effect':
-                           self.fake_operator_query_metadata_object,
-                           'create_metadata_object.side_effect':
-                           self.fake_operator_create_metadata_object,
-                           'delete_metadata_object.side_effect':
-                           self.fake_operator_delete_metadata_object,
-                           }
-        xmloperator_config = {'read_metadata_object.side_effect':
-                              self.fake_xmloperator_read_metadata_object,
-                              'create_metadata_object.side_effect':
-                              self.fake_xmloperator_create_metadata_object,
-                              }
-        folderoperator_config = {'create_folder.side_effect':
-                                 self.fake_folderoperator_create_folder,
-                                 'read_folder.side_effect':
-                                 self.fake_folderoperator_read_folder,
-                                 'delete_folder.side_effect':
-                                 self.fake_folderoperator_delete_folder,
-                                 }
+        operator_config = {
+            "read_metadata_object.side_effect": self.fake_operator_read_metadata_object,
+            "query_metadata_database.side_effect": self.fake_operator_query_metadata_object,
+            "create_metadata_object.side_effect": self.fake_operator_create_metadata_object,
+            "delete_metadata_object.side_effect": self.fake_operator_delete_metadata_object,
+        }
+        xmloperator_config = {
+            "read_metadata_object.side_effect": self.fake_xmloperator_read_metadata_object,
+            "create_metadata_object.side_effect": self.fake_xmloperator_create_metadata_object,
+        }
+        folderoperator_config = {
+            "create_folder.side_effect": self.fake_folderoperator_create_folder,
+            "read_folder.side_effect": self.fake_folderoperator_read_folder,
+            "delete_folder.side_effect": self.fake_folderoperator_delete_folder,
+        }
         self.patch_parser = patch(class_parser, spec=True)
-        self.patch_operator = patch(class_operator, **operator_config,
-                                    spec=True)
-        self.patch_xmloperator = patch(class_xmloperator, **xmloperator_config,
-                                       spec=True)
-        self.patch_folderoperator = patch(class_folderoperator,
-                                          **folderoperator_config,
-                                          spec=True)
+        self.patch_operator = patch(class_operator, **operator_config, spec=True)
+        self.patch_xmloperator = patch(class_xmloperator, **xmloperator_config, spec=True)
+        self.patch_folderoperator = patch(class_folderoperator, **folderoperator_config, spec=True)
         self.MockedParser = self.patch_parser.start()
         self.MockedOperator = self.patch_operator.start()
         self.MockedXMLOperator = self.patch_xmloperator.start()
@@ -99,30 +89,24 @@ class HandlersTestCase(AioHTTPTestCase):
         data = FormData()
         for schema, filename in files:
             path_to_file = self.TESTFILES_ROOT / schema / filename
-            data.add_field(schema.upper(),
-                           open(path_to_file.as_posix(), 'r'),
-                           filename=path_to_file.name,
-                           content_type='text/xml')
+            data.add_field(
+                schema.upper(), open(path_to_file.as_posix(), "r"), filename=path_to_file.name, content_type="text/xml"
+            )
         return data
 
-    async def fake_operator_read_metadata_object(self, schema_type,
-                                                 accession_id):
+    async def fake_operator_read_metadata_object(self, schema_type, accession_id):
         """Fake read operation to return mocked json."""
         return await futurized((self.metadata_json, "application/json"))
 
-    async def fake_operator_query_metadata_object(self, schema_type, query,
-                                                  page_num, page_size):
+    async def fake_operator_query_metadata_object(self, schema_type, query, page_num, page_size):
         """Fake query operation to return list containing mocked json."""
-        return await futurized(([self.metadata_json], self.page_num,
-                               self.page_size, self.total_objects),)
+        return await futurized(([self.metadata_json], self.page_num, self.page_size, self.total_objects),)
 
-    async def fake_xmloperator_read_metadata_object(self, schema_type,
-                                                    accession_id):
+    async def fake_xmloperator_read_metadata_object(self, schema_type, accession_id):
         """Fake read operation to return mocked xml."""
         return await futurized((self.metadata_xml, "text/xml"))
 
-    async def fake_xmloperator_create_metadata_object(self, schema_type,
-                                                      content):
+    async def fake_xmloperator_create_metadata_object(self, schema_type, content):
         """Fake create operation to return mocked accessionId."""
         return await futurized(self.test_ega_string)
 
@@ -130,8 +114,7 @@ class HandlersTestCase(AioHTTPTestCase):
         """Fake create operation to return mocked accessionId."""
         return await futurized(self.test_ega_string)
 
-    async def fake_operator_delete_metadata_object(self, schema_type,
-                                                   accession_id):
+    async def fake_operator_delete_metadata_object(self, schema_type, accession_id):
         """Fake delete operation to await nothing."""
         return await futurized(None)
 
@@ -175,8 +158,7 @@ class HandlersTestCase(AioHTTPTestCase):
 
         User should be notified for submitting too many files.
         """
-        files = [("submission", "ERA521986_valid.xml"),
-                 ("submission", "ERA521986_valid2.xml")]
+        files = [("submission", "ERA521986_valid.xml"), ("submission", "ERA521986_valid2.xml")]
         data = self.create_submission_data(files)
         response = await self.client.post("/submit", data=data)
         failure_text = "You should submit only one submission.xml file."
@@ -188,8 +170,18 @@ class HandlersTestCase(AioHTTPTestCase):
         """Test api endpoint for all schema types."""
         response = await self.client.get("/schemas")
         response_text = await response.text()
-        schema_types = ["submission", "study", "sample", "experiment", "run",
-                        "analysis", "dac", "policy", "dataset", "project"]
+        schema_types = [
+            "submission",
+            "study",
+            "sample",
+            "experiment",
+            "run",
+            "analysis",
+            "dac",
+            "policy",
+            "dataset",
+            "project",
+        ]
         for schema_type in schema_types:
             self.assertIn(schema_type, response_text)
 
@@ -226,10 +218,11 @@ class HandlersTestCase(AioHTTPTestCase):
     @unittest_run_loop
     async def test_submit_object_works_with_json(self):
         """Test that json submission is handled, operator is called."""
-        json_req = {"centerName": "GEO",
-                    "alias": "GSE10966",
-                    "descriptor": {"studyTitle": "Highly",
-                                   "studyType": "Other"}}
+        json_req = {
+            "centerName": "GEO",
+            "alias": "GSE10966",
+            "descriptor": {"studyTitle": "Highly", "studyType": "Other"},
+        }
         response = await self.client.post("/objects/study", json=json_req)
         self.assertEqual(response.status, 201)
         self.assertIn(self.test_ega_string, await response.text())
@@ -238,73 +231,73 @@ class HandlersTestCase(AioHTTPTestCase):
     @unittest_run_loop
     async def test_submit_object_missing_field_json(self):
         """Test that json has missing property."""
-        json_req = {"centerName": "GEO",
-                    "alias": "GSE10966"}
+        json_req = {"centerName": "GEO", "alias": "GSE10966"}
         response = await self.client.post("/objects/study", json=json_req)
-        reason = ("Provided input does not seem correct because: "
-                  "''descriptor' is a required property'")
+        reason = "Provided input does not seem correct because: " "''descriptor' is a required property'"
         self.assertEqual(response.status, 400)
         self.assertIn(reason, await response.text())
 
     @unittest_run_loop
     async def test_submit_object_bad_field_json(self):
         """Test that json has bad studyType."""
-        json_req = {"centerName": "GEO",
-                    "alias": "GSE10966",
-                    "descriptor": {"studyTitle": "Highly",
-                                   "studyType": "ceva"}}
+        json_req = {
+            "centerName": "GEO",
+            "alias": "GSE10966",
+            "descriptor": {"studyTitle": "Highly", "studyType": "ceva"},
+        }
         response = await self.client.post("/objects/study", json=json_req)
-        reason = ("Provided input does not seem correct for field: "
-                  "'descriptor'")
+        reason = "Provided input does not seem correct for field: " "'descriptor'"
         self.assertEqual(response.status, 400)
         self.assertIn(reason, await response.text())
 
     @unittest_run_loop
     async def test_post_object_bad_json(self):
         """Test that post json is badly formated."""
-        json_req = {"centerName": "GEO",
-                    "alias": "GSE10966",
-                    "descriptor": {"studyTitle": "Highly",
-                                   "studyType": "Other"}, }
+        json_req = {
+            "centerName": "GEO",
+            "alias": "GSE10966",
+            "descriptor": {"studyTitle": "Highly", "studyType": "Other"},
+        }
         response = await self.client.post("/objects/study", data=json_req)
-        reason = ("JSON is not correctly formatted. "
-                  "See: Expecting value: line 1 column 1")
+        reason = "JSON is not correctly formatted. " "See: Expecting value: line 1 column 1"
         self.assertEqual(response.status, 400)
         self.assertIn(reason, await response.text())
 
     @unittest_run_loop
     async def test_put_object_bad_json(self):
         """Test that put json is badly formated."""
-        json_req = {"centerName": "GEO",
-                    "alias": "GSE10966",
-                    "descriptor": {"studyTitle": "Highly",
-                                   "studyType": "Other"}, }
+        json_req = {
+            "centerName": "GEO",
+            "alias": "GSE10966",
+            "descriptor": {"studyTitle": "Highly", "studyType": "Other"},
+        }
         call = "/drafts/study/EGA123456"
         response = await self.client.put(call, data=json_req)
-        reason = ("JSON is not correctly formatted. "
-                  "See: Expecting value: line 1 column 1")
+        reason = "JSON is not correctly formatted. " "See: Expecting value: line 1 column 1"
         self.assertEqual(response.status, 400)
         self.assertIn(reason, await response.text())
 
     @unittest_run_loop
     async def test_patch_object_bad_json(self):
         """Test that patch json is badly formated."""
-        json_req = {"centerName": "GEO",
-                    "alias": "GSE10966", }
+        json_req = {
+            "centerName": "GEO",
+            "alias": "GSE10966",
+        }
         call = "/drafts/study/EGA123456"
         response = await self.client.patch(call, data=json_req)
-        reason = ("JSON is not correctly formatted. "
-                  "See: Expecting value: line 1 column 1")
+        reason = "JSON is not correctly formatted. " "See: Expecting value: line 1 column 1"
         self.assertEqual(response.status, 400)
         self.assertIn(reason, await response.text())
 
     @unittest_run_loop
     async def test_submit_draft_works_with_json(self):
         """Test that draft json submission is handled, operator is called."""
-        json_req = {"centerName": "GEO",
-                    "alias": "GSE10966",
-                    "descriptor": {"studyTitle": "Highly",
-                                   "studyType": "Other"}}
+        json_req = {
+            "centerName": "GEO",
+            "alias": "GSE10966",
+            "descriptor": {"studyTitle": "Highly", "studyType": "Other"},
+        }
         response = await self.client.post("/drafts/study", json=json_req)
         self.assertEqual(response.status, 201)
         self.assertIn(self.test_ega_string, await response.text())
@@ -313,10 +306,11 @@ class HandlersTestCase(AioHTTPTestCase):
     @unittest_run_loop
     async def test_put_draft_works_with_json(self):
         """Test that draft json put method is handled, operator is called."""
-        json_req = {"centerName": "GEO",
-                    "alias": "GSE10966",
-                    "descriptor": {"studyTitle": "Highly",
-                                   "studyType": "Other"}}
+        json_req = {
+            "centerName": "GEO",
+            "alias": "GSE10966",
+            "descriptor": {"studyTitle": "Highly", "studyType": "Other"},
+        }
         call = "/drafts/study/EGA123456"
         response = await self.client.put(call, json=json_req)
         self.assertEqual(response.status, 200)
@@ -337,8 +331,7 @@ class HandlersTestCase(AioHTTPTestCase):
     @unittest_run_loop
     async def test_patch_draft_works_with_json(self):
         """Test that draft json patch method is handled, operator is called."""
-        json_req = {"centerName": "GEO",
-                    "alias": "GSE10966"}
+        json_req = {"centerName": "GEO", "alias": "GSE10966"}
         call = "/drafts/study/EGA123456"
         response = await self.client.patch(call, json=json_req)
         self.assertEqual(response.status, 200)
@@ -357,8 +350,7 @@ class HandlersTestCase(AioHTTPTestCase):
     @unittest_run_loop
     async def test_submit_object_fails_with_too_many_files(self):
         """Test that sending two files to endpoint results failure."""
-        files = [("study", "SRP000539.xml"),
-                 ("study", "SRP000539_copy.xml")]
+        files = [("study", "SRP000539.xml"), ("study", "SRP000539_copy.xml")]
         data = self.create_submission_data(files)
         response = await self.client.post("/objects/study", data=data)
         reason = "Only one file can be sent to this endpoint at a time."
@@ -395,16 +387,14 @@ class HandlersTestCase(AioHTTPTestCase):
     @unittest_run_loop
     async def test_query_is_called_and_returns_json_in_correct_format(self):
         """Test query method calls operator and returns mocked json object."""
-        url = (f"/objects/study?studyType=foo&name=bar&page={self.page_num}"
-               f"&per_page={self.page_size}")
+        url = f"/objects/study?studyType=foo&name=bar&page={self.page_num}" f"&per_page={self.page_size}"
         response = await self.client.get(url)
         self.assertEqual(response.status, 200)
         self.assertEqual(response.content_type, "application/json")
         json_resp = await response.json()
         self.assertEqual(json_resp["page"]["page"], self.page_num)
         self.assertEqual(json_resp["page"]["size"], self.page_size)
-        self.assertEqual(json_resp["page"]["totalPages"], (self.total_objects
-                                                           / self.page_size))
+        self.assertEqual(json_resp["page"]["totalPages"], (self.total_objects / self.page_size))
         self.assertEqual(json_resp["page"]["totalObjects"], self.total_objects)
         self.assertEqual(json_resp["objects"][0], self.metadata_json)
         self.MockedOperator().query_metadata_database.assert_called_once()
@@ -429,8 +419,7 @@ class HandlersTestCase(AioHTTPTestCase):
         response = await self.client.get(url)
         json_resp = await response.json()
         self.assertEqual(response.status, 400)
-        self.assertIn("xml-formatted query results are not supported",
-                      json_resp["detail"])
+        self.assertIn("xml-formatted query results are not supported", json_resp["detail"])
 
     @unittest_run_loop
     async def test_validation_passes_for_valid_xml(self):
@@ -449,8 +438,7 @@ class HandlersTestCase(AioHTTPTestCase):
         response = await self.client.post("/validate", data=data)
         resp_dict = await response.json()
         self.assertEqual(response.status, 200)
-        self.assertIn("Faulty XML file was given, mismatched tag",
-                      resp_dict['detail']['reason'])
+        self.assertIn("Faulty XML file was given, mismatched tag", resp_dict["detail"]["reason"])
 
     @unittest_run_loop
     async def test_validation_fails_for_invalid_xml(self):
@@ -460,13 +448,12 @@ class HandlersTestCase(AioHTTPTestCase):
         response = await self.client.post("/validate", data=data)
         resp_dict = await response.json()
         self.assertEqual(response.status, 200)
-        self.assertIn("invalid value", resp_dict['detail']['reason'])
+        self.assertIn("invalid value", resp_dict["detail"]["reason"])
 
     @unittest_run_loop
     async def test_validation_fails_with_too_many_files(self):
         """Test validation endpoint for too many files."""
-        files = [("submission", "ERA521986_valid.xml"),
-                 ("submission", "ERA521986_valid2.xml")]
+        files = [("submission", "ERA521986_valid.xml"), ("submission", "ERA521986_valid2.xml")]
         data = self.create_submission_data(files)
         response = await self.client.post("/validate", data=data)
         reason = "Only one file can be sent to this endpoint at a time."
@@ -479,27 +466,27 @@ class HandlersTestCase(AioHTTPTestCase):
         get_resp = await self.client.get("/objects/bad_scehma_name/some_id")
         self.assertEqual(get_resp.status, 404)
         json_get_resp = await get_resp.json()
-        self.assertIn("Specified schema", json_get_resp['detail'])
+        self.assertIn("Specified schema", json_get_resp["detail"])
 
         post_rep = await self.client.post("/objects/bad_scehma_name")
         self.assertEqual(post_rep.status, 404)
         post_json_rep = await post_rep.json()
-        self.assertIn("Specified schema", post_json_rep['detail'])
+        self.assertIn("Specified schema", post_json_rep["detail"])
 
         get_resp = await self.client.get("/objects/bad_scehma_name")
         self.assertEqual(get_resp.status, 404)
         json_get_resp = await get_resp.json()
-        self.assertIn("Specified schema", json_get_resp['detail'])
+        self.assertIn("Specified schema", json_get_resp["detail"])
 
         get_resp = await self.client.delete("/objects/bad_scehma_name/some_id")
         self.assertEqual(get_resp.status, 404)
         json_get_resp = await get_resp.json()
-        self.assertIn("Specified schema", json_get_resp['detail'])
+        self.assertIn("Specified schema", json_get_resp["detail"])
 
         get_resp = await self.client.delete("/drafts/bad_scehma_name/some_id")
         self.assertEqual(get_resp.status, 404)
         json_get_resp = await get_resp.json()
-        self.assertIn("Specified schema", json_get_resp['detail'])
+        self.assertIn("Specified schema", json_get_resp["detail"])
 
     @unittest_run_loop
     async def test_query_with_invalid_pagination_params(self):
@@ -514,13 +501,12 @@ class HandlersTestCase(AioHTTPTestCase):
     @unittest_run_loop
     async def test_folder_creation_works(self):
         """Test that folder is created and folder ID returned."""
-        json_req = {"name": "test",
-                    "description": "test folder"}
+        json_req = {"name": "test", "description": "test folder"}
         response = await self.client.post("/folders", json=json_req)
         json_resp = await response.json()
         self.MockedFolderOperator().create_folder.assert_called_once()
         self.assertEqual(response.status, 201)
-        self.assertEqual(json_resp['folderId'], self.folder_id)
+        self.assertEqual(json_resp["folderId"], self.folder_id)
 
     @unittest_run_loop
     async def test_folder_creation_with_empty_body(self):
@@ -528,35 +514,30 @@ class HandlersTestCase(AioHTTPTestCase):
         response = await self.client.post("/folders")
         json_resp = await response.json()
         self.assertEqual(response.status, 400)
-        self.assertIn("JSON is not correctly formatted.", json_resp['detail'])
+        self.assertIn("JSON is not correctly formatted.", json_resp["detail"])
 
     @unittest_run_loop
     async def test_get_folders_with_1_folder(self):
         """Test get_folders() endpoint returns list with 1 folder."""
-        self.MockedFolderOperator().query_folders.return_value = (
-            futurized(self.test_folder))
+        self.MockedFolderOperator().query_folders.return_value = futurized(self.test_folder)
         response = await self.client.get("/folders")
         self.MockedFolderOperator().query_folders.assert_called_once()
         self.assertEqual(response.status, 200)
-        self.assertEqual(await response.json(), {'folders': self.test_folder})
+        self.assertEqual(await response.json(), {"folders": self.test_folder})
 
     @unittest_run_loop
     async def test_get_folders_with_no_folders(self):
         """Test get_folders() endpoint returns empty list."""
-        self.MockedFolderOperator().query_folders.return_value = (
-            futurized([]))
+        self.MockedFolderOperator().query_folders.return_value = futurized([])
         response = await self.client.get("/folders")
         self.MockedFolderOperator().query_folders.assert_called_once()
         self.assertEqual(response.status, 200)
-        self.assertEqual(await response.json(), {'folders': []})
+        self.assertEqual(await response.json(), {"folders": []})
 
     @unittest_run_loop
     async def test_get_folder_works(self):
         """Test folder is returned when correct folder id is given."""
-        folder = {"folderId": self.folder_id,
-                  "name": "test",
-                  "description": "test folder",
-                  "metadata_objects": []}
+        folder = {"folderId": self.folder_id, "name": "test", "description": "test folder", "metadata_objects": []}
         response = await self.client.get("/folders/FOL12345678")
         self.assertEqual(response.status, 200)
         self.MockedFolderOperator().read_folder.assert_called_once()
@@ -570,21 +551,19 @@ class HandlersTestCase(AioHTTPTestCase):
         response = await self.client.patch("/folders/FOL12345678", json=data)
         self.assertEqual(response.status, 400)
         json_resp = await response.json()
-        reason = ("Request contains '/objects' key that cannot be "
-                  "updated to folders.")
-        self.assertEqual(reason, json_resp['detail'])
+        reason = "Request contains '/objects' key that cannot be " "updated to folders."
+        self.assertEqual(reason, json_resp["detail"])
 
     @unittest_run_loop
     async def test_update_folder_passes(self):
         """Test that folder would update with correct keys."""
-        self.MockedFolderOperator().update_folder.return_value = (
-            futurized(self.folder_id))
+        self.MockedFolderOperator().update_folder.return_value = futurized(self.folder_id)
         data = [{"op": "replace", "path": "/name", "value": "test2"}]
         response = await self.client.patch("/folders/FOL12345678", json=data)
         self.MockedFolderOperator().update_folder.assert_called_once()
         self.assertEqual(response.status, 200)
         json_resp = await response.json()
-        self.assertEqual(json_resp['folderId'], self.folder_id)
+        self.assertEqual(json_resp["folderId"], self.folder_id)
 
     @unittest_run_loop
     async def test_folder_deletion_is_called(self):

--- a/tests/test_middlewares.py
+++ b/tests/test_middlewares.py
@@ -25,10 +25,9 @@ class ErrorMiddlewareTestCase(AioHTTPTestCase):
         self.assertEqual(response.status, 400)
         self.assertEqual(response.content_type, "application/problem+json")
         resp_dict = await response.json()
-        self.assertIn("Bad Request", resp_dict['title'])
-        self.assertIn("There must be a submission.xml file in submission.",
-                      resp_dict['detail'])
-        self.assertIn("/submit", resp_dict['instance'])
+        self.assertIn("Bad Request", resp_dict["title"])
+        self.assertIn("There must be a submission.xml file in submission.", resp_dict["detail"])
+        self.assertIn("/submit", resp_dict["instance"])
 
     @unittest_run_loop
     async def test_bad_url_returns_json_response(self):
@@ -37,7 +36,7 @@ class ErrorMiddlewareTestCase(AioHTTPTestCase):
         self.assertEqual(response.status, 404)
         self.assertEqual(response.content_type, "application/problem+json")
         resp_dict = await response.json()
-        self.assertIn("Not Found", resp_dict['title'])
+        self.assertIn("Not Found", resp_dict["title"])
 
 
 class AuthMiddlewareTestCase(AioHTTPTestCase):
@@ -52,117 +51,90 @@ class AuthMiddlewareTestCase(AioHTTPTestCase):
 
         Also set pem as an environment variable for the duration of the tests.
         """
-        self.header = {'alg': "HS256", 'typ': "JWT"}
-        self.payload = {
-            'sub': "test",
-            'name': "tester",
-            'iss': "haka_iss",
-            'exp': 9999999999
-        }
-        self.pem = {
-            'kty': "oct",
-            'alg': "RS256",
-            'k': "GawgguFyGrWKav7AX4VKUg"
-        }
-        os.environ['PUBLIC_KEY'] = json.dumps(self.pem)
+        self.header = {"alg": "HS256", "typ": "JWT"}
+        self.payload = {"sub": "test", "name": "tester", "iss": "haka_iss", "exp": 9999999999}
+        self.pem = {"kty": "oct", "alg": "RS256", "k": "GawgguFyGrWKav7AX4VKUg"}
+        os.environ["PUBLIC_KEY"] = json.dumps(self.pem)
 
     async def tearDownAsync(self):
         """Unset the public key."""
-        os.unsetenv('PUBLIC_KEY')
+        os.unsetenv("PUBLIC_KEY")
 
     @unittest_run_loop
     async def test_authentication_passes(self):
         """Test that JWT authenticates."""
         # Add claims to mocked token
-        token = jwt.encode(self.header, self.payload, self.pem).decode('utf-8')
+        token = jwt.encode(self.header, self.payload, self.pem).decode("utf-8")
         data = _create_improper_data()
-        response = await self.client.post("/submit", data=data,
-                                          headers={'Authorization':
-                                                   f"Bearer {token}"})
+        response = await self.client.post("/submit", data=data, headers={"Authorization": f"Bearer {token}"})
 
         # Auth passes, hence response should be 400
         self.assertEqual(response.status, 400)
         self.assertEqual(response.content_type, "application/problem+json")
         resp_dict = await response.json()
-        self.assertIn("Bad Request", resp_dict['title'])
-        os.unsetenv('PUBLIC_KEY')
+        self.assertIn("Bad Request", resp_dict["title"])
+        os.unsetenv("PUBLIC_KEY")
 
     @unittest_run_loop
     async def test_authentication_fails_with_expired_jwt(self):
         """Test that JWT does not authenticate if token has expired."""
         # Add claims to mocked token
         payload = self.payload
-        payload['exp'] = 0
-        token = jwt.encode(self.header, payload, self.pem).decode('utf-8')
+        payload["exp"] = 0
+        token = jwt.encode(self.header, payload, self.pem).decode("utf-8")
         data = _create_improper_data()
-        response = await self.client.post("/submit", data=data,
-                                          headers={'Authorization':
-                                                   f"Bearer {token}"})
+        response = await self.client.post("/submit", data=data, headers={"Authorization": f"Bearer {token}"})
 
         # Auth does not pass so response should be 401
         self.assertEqual(response.status, 401)
         self.assertEqual(response.content_type, "application/problem+json")
         resp_dict = await response.json()
-        self.assertEqual("expired_token: The token is expired",
-                         resp_dict['detail'])
+        self.assertEqual("expired_token: The token is expired", resp_dict["detail"])
 
     @unittest_run_loop
     async def test_authentication_fails_with_missing_claim(self):
         """Test JWT does not authenticate if 'iss' key is not in claims."""
         payload = self.payload
-        del payload['iss']
-        token = jwt.encode(self.header, self.payload, self.pem).decode('utf-8')
+        del payload["iss"]
+        token = jwt.encode(self.header, self.payload, self.pem).decode("utf-8")
         data = _create_improper_data()
-        response = await self.client.post("/submit", data=data,
-                                          headers={'Authorization':
-                                                   f"Bearer {token}"})
+        response = await self.client.post("/submit", data=data, headers={"Authorization": f"Bearer {token}"})
 
         # Auth does not pass so response should be 401
         self.assertEqual(response.status, 401)
         self.assertEqual(response.content_type, "application/problem+json")
         resp_dict = await response.json()
-        self.assertEqual('missing_claim: Missing "iss" claim',
-                         resp_dict['detail'])
+        self.assertEqual('missing_claim: Missing "iss" claim', resp_dict["detail"])
 
     @unittest_run_loop
     async def test_authentication_fails_with_invalid_claim(self):
         """Test JWT does not authenticate with wrong 'iss' value."""
         # Add claims to mocked token
         payload = self.payload
-        payload['iss'] = "wrong_iss"
-        token = jwt.encode(self.header, payload, self.pem).decode('utf-8')
+        payload["iss"] = "wrong_iss"
+        token = jwt.encode(self.header, payload, self.pem).decode("utf-8")
         data = _create_improper_data()
-        response = await self.client.post("/submit", data=data,
-                                          headers={'Authorization':
-                                                   f"Bearer {token}"})
+        response = await self.client.post("/submit", data=data, headers={"Authorization": f"Bearer {token}"})
 
         # Token contains incorrect info for authenticating so response is 403
         self.assertEqual(response.status, 403)
         self.assertEqual(response.content_type, "application/problem+json")
         resp_dict = await response.json()
-        self.assertIn('Token contains invalid_claim: Invalid claim "iss"',
-                      resp_dict['detail'])
+        self.assertIn('Token contains invalid_claim: Invalid claim "iss"', resp_dict["detail"])
 
     @unittest_run_loop
     async def test_bad_signature_error(self):
         """Test that altering the key raises bad signature error."""
-        otherkey = {
-            'kty': "oct",
-            'alg': "RS256",
-            'k': "hJtXIZ2uSN5kbQfbtTNWbpdmhkV8FJG"
-        }
-        token = jwt.encode(self.header, self.payload, otherkey).decode('utf-8')
+        otherkey = {"kty": "oct", "alg": "RS256", "k": "hJtXIZ2uSN5kbQfbtTNWbpdmhkV8FJG"}
+        token = jwt.encode(self.header, self.payload, otherkey).decode("utf-8")
         data = _create_improper_data()
-        response = await self.client.post("/submit", data=data,
-                                          headers={'Authorization':
-                                                   f"Bearer {token}"})
+        response = await self.client.post("/submit", data=data, headers={"Authorization": f"Bearer {token}"})
 
         # Auth does not pass so response should be 401
         self.assertEqual(response.status, 401)
         self.assertEqual(response.content_type, "application/problem+json")
         resp_dict = await response.json()
-        self.assertIn('Token signature is invalid, bad_signature:',
-                      resp_dict['detail'])
+        self.assertIn("Token signature is invalid, bad_signature:", resp_dict["detail"])
 
 
 def _create_improper_data():
@@ -172,6 +144,5 @@ def _create_improper_data():
     if 'submission' is not included on the first field of request
     """
     data = FormData()
-    data.add_field("study", "content of a file",
-                   filename='file', content_type='text/xml')
+    data.add_field("study", "content of a file", filename="file", content_type="text/xml")
     return data

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -11,8 +11,7 @@ from jsonpatch import JsonPatch
 from multidict import MultiDict, MultiDictProxy
 from pymongo.errors import ConnectionFailure
 
-from metadata_backend.api.operators import (FolderOperator, Operator,
-                                            XMLOperator)
+from metadata_backend.api.operators import FolderOperator, Operator, XMLOperator
 
 
 class MockCursor(AsyncMockIterator):
@@ -50,29 +49,34 @@ class TestOperators(AsyncTestCase):
         Monkey patches MagicMock to work with async / await, then sets up
         other patches and mocks for tests.
         """
+
         async def async_patch():
             pass
+
         MagicMock.__await__ = lambda x: async_patch().__await__()
         self.client = MagicMock()
         self.accession_id = "EGA123456"
         self.folder_id = "FOL12345678"
-        self.test_folder = {"folderId": self.folder_id,
-                            "name": "test",
-                            "description": "test folder",
-                            "metadata_objects": []}
+        self.test_folder = {
+            "folderId": self.folder_id,
+            "name": "test",
+            "description": "test folder",
+            "metadata_objects": [],
+        }
         class_dbservice = "metadata_backend.api.operators.DBService"
         self.patch_dbservice = patch(class_dbservice, spec=True)
         self.MockedDbService = self.patch_dbservice.start()
         self.patch_accession = patch(
             "metadata_backend.api.operators.Operator._generate_accession_id",
             return_value=self.accession_id,
-            autospec=True)
+            autospec=True,
+        )
         self.patch_accession.start()
         self.patch_folder = patch(
-            ("metadata_backend.api.operators.FolderOperator."
-             "_generate_folder_id"),
+            ("metadata_backend.api.operators.FolderOperator." "_generate_folder_id"),
             return_value=self.folder_id,
-            autospec=True)
+            autospec=True,
+        )
         self.patch_folder.start()
 
     def tearDown(self):
@@ -88,28 +92,28 @@ class TestOperators(AsyncTestCase):
             "dateCreated": datetime.datetime(2020, 6, 14, 0, 0),
             "dateModified": datetime.datetime(2020, 6, 14, 0, 0),
             "accessionId": "EGA123456",
-            "foo": "bar"
+            "foo": "bar",
         }
         operator.db_service.read.return_value = futurized(data)
-        read_data, c_type = await operator.read_metadata_object("sample",
-                                                                "EGA123456")
+        read_data, c_type = await operator.read_metadata_object("sample", "EGA123456")
         operator.db_service.read.assert_called_once_with("sample", "EGA123456")
         self.assertEqual(c_type, "application/json")
-        self.assertEqual(read_data, {"dateCreated": "2020-06-14T00:00:00",
-                                     "dateModified": "2020-06-14T00:00:00",
-                                     "accessionId": "EGA123456",
-                                     "foo": "bar"})
+        self.assertEqual(
+            read_data,
+            {
+                "dateCreated": "2020-06-14T00:00:00",
+                "dateModified": "2020-06-14T00:00:00",
+                "accessionId": "EGA123456",
+                "foo": "bar",
+            },
+        )
 
     async def test_reading_metadata_works_with_xml(self):
         """Test xml is read from db correctly."""
         operator = XMLOperator(self.client)
-        data = {
-            "accessionId": "EGA123456",
-            "content": "<TEST></TEST>"
-        }
+        data = {"accessionId": "EGA123456", "content": "<TEST></TEST>"}
         operator.db_service.read.return_value = futurized(data)
-        r_data, c_type = await operator.read_metadata_object("sample",
-                                                             "EGA123456")
+        r_data, c_type = await operator.read_metadata_object("sample", "EGA123456")
         operator.db_service.read.assert_called_once_with("sample", "EGA123456")
         self.assertEqual(c_type, "text/xml")
         self.assertEqual(r_data, data["content"])
@@ -134,7 +138,7 @@ class TestOperators(AsyncTestCase):
             "publishDate": datetime.datetime(2020, 6, 14, 0, 0),
             "accessionId": "EDAG3945644754983408",
             "dateCreated": datetime.datetime(2020, 6, 14, 0, 0),
-            "dateModified": datetime.datetime(2020, 6, 14, 0, 0)
+            "dateModified": datetime.datetime(2020, 6, 14, 0, 0),
         }
         result = Operator(self.client)._format_single_dict("study", study_test)
         self.assertEqual(result["publishDate"], "2020-06-14T00:00:00")
@@ -146,10 +150,7 @@ class TestOperators(AsyncTestCase):
     async def test_json_create_passes_and_returns_accessionId(self):
         """Test create method for json works."""
         operator = Operator(self.client)
-        data = {"centerName": "GEO",
-                "alias": "GSE10966",
-                "descriptor": {"studyTitle": "Highly",
-                               "studyType": "Other"}}
+        data = {"centerName": "GEO", "alias": "GSE10966", "descriptor": {"studyTitle": "Highly", "studyType": "Other"}}
         operator.db_service.create.return_value = futurized(True)
         accession = await operator.create_metadata_object("study", data)
         operator.db_service.create.assert_called_once()
@@ -158,10 +159,7 @@ class TestOperators(AsyncTestCase):
     async def test_json_replace_passes_and_returns_accessionId(self):
         """Test replace method for json works."""
         accession = "EGA123456"
-        data = {"centerName": "GEO",
-                "alias": "GSE10966",
-                "descriptor": {"studyTitle": "Highly",
-                               "studyType": "Other"}}
+        data = {"centerName": "GEO", "alias": "GSE10966", "descriptor": {"studyTitle": "Highly", "studyType": "Other"}}
         operator = Operator(self.client)
         operator.db_service.exists.return_value = futurized(True)
         operator.db_service.replace.return_value = futurized(True)
@@ -191,12 +189,12 @@ class TestOperators(AsyncTestCase):
     async def test_json_update_passes_and_returns_accessionId(self):
         """Test update method for json works."""
         accession = "EGA123456"
-        data = {"centerName": "GEOM",
-                "alias": "GSE10967"}
-        db_data = {"centerName": "GEO",
-                   "alias": "GSE10966",
-                   "descriptor": {"studyTitle": "Highly",
-                                  "studyType": "Other"}}
+        data = {"centerName": "GEOM", "alias": "GSE10967"}
+        db_data = {
+            "centerName": "GEO",
+            "alias": "GSE10966",
+            "descriptor": {"studyTitle": "Highly", "studyType": "Other"},
+        }
         operator = Operator(self.client)
         operator.db_service.read.return_value = futurized(db_data)
         operator.db_service.exists.return_value = futurized(True)
@@ -229,119 +227,136 @@ class TestOperators(AsyncTestCase):
         operator = XMLOperator(self.client)
         operator.db_service.db_client = self.client
         operator.db_service.create.return_value = futurized(True)
-        with patch(("metadata_backend.api.operators.Operator."
-                    "_format_data_to_create_and_add_to_db"),
-                   return_value=futurized(self.accession_id)):
+        with patch(
+            ("metadata_backend.api.operators.Operator." "_format_data_to_create_and_add_to_db"),
+            return_value=futurized(self.accession_id),
+        ):
             with patch("metadata_backend.api.operators.XMLToJSONParser"):
-                accession = await operator.create_metadata_object(
-                    "study", "<TEST></TEST>")
+                accession = await operator.create_metadata_object("study", "<TEST></TEST>")
         operator.db_service.create.assert_called_once()
         self.assertEqual(accession, self.accession_id)
 
     async def test_correct_data_is_set_to_json_when_creating(self):
         """Test operator creates object and adds necessary info."""
         operator = Operator(self.client)
-        with patch(("metadata_backend.api.operators.Operator."
-                    "_insert_formatted_object_to_db"),
-                   return_value=futurized(self.accession_id)) as mocked_insert:
+        with patch(
+            ("metadata_backend.api.operators.Operator." "_insert_formatted_object_to_db"),
+            return_value=futurized(self.accession_id),
+        ) as mocked_insert:
             with patch("metadata_backend.api.operators.datetime") as m_date:
                 m_date.utcnow.return_value = datetime.datetime(2020, 4, 14)
-                acc = await (operator._format_data_to_create_and_add_to_db(
-                    "study", {}))
+                acc = await (operator._format_data_to_create_and_add_to_db("study", {}))
                 mocked_insert.assert_called_once_with(
-                    "study", {"accessionId": self.accession_id,
-                              "dateCreated": datetime.datetime(2020, 4, 14),
-                              "dateModified": datetime.datetime(2020, 4, 14),
-                              "publishDate": datetime.datetime(2020, 6, 14)})
+                    "study",
+                    {
+                        "accessionId": self.accession_id,
+                        "dateCreated": datetime.datetime(2020, 4, 14),
+                        "dateModified": datetime.datetime(2020, 4, 14),
+                        "publishDate": datetime.datetime(2020, 6, 14),
+                    },
+                )
             self.assertEqual(acc, self.accession_id)
 
     async def test_wront_data_is_set_to_json_when_replacing(self):
         """Test operator replace catches error."""
         accession = "EGA123456"
         operator = Operator(self.client)
-        with patch(("metadata_backend.api.operators.Operator."
-                    "_replace_object_from_db"),
-                   return_value=futurized(self.accession_id)):
+        with patch(
+            ("metadata_backend.api.operators.Operator." "_replace_object_from_db"),
+            return_value=futurized(self.accession_id),
+        ):
             with patch("metadata_backend.api.operators.datetime") as m_date:
                 m_date.utcnow.return_value = datetime.datetime(2020, 4, 14)
                 with self.assertRaises(HTTPBadRequest):
-                    await (operator._format_data_to_replace_and_add_to_db(
-                        "study", accession,
-                        {"accessionId": self.accession_id,
-                         "dateCreated": datetime.datetime(2020, 4, 14),
-                         "dateModified": datetime.datetime(2020, 4, 14),
-                         "publishDate": datetime.datetime(2020, 6, 14)}))
+                    await (
+                        operator._format_data_to_replace_and_add_to_db(
+                            "study",
+                            accession,
+                            {
+                                "accessionId": self.accession_id,
+                                "dateCreated": datetime.datetime(2020, 4, 14),
+                                "dateModified": datetime.datetime(2020, 4, 14),
+                                "publishDate": datetime.datetime(2020, 6, 14),
+                            },
+                        )
+                    )
 
     async def test_correct_data_is_set_to_json_when_replacing(self):
         """Test operator replaces object and adds necessary info."""
         accession = "EGA123456"
         operator = Operator(self.client)
-        with patch(("metadata_backend.api.operators.Operator."
-                    "_replace_object_from_db"),
-                   return_value=futurized(self.accession_id)) as mocked_insert:
+        with patch(
+            ("metadata_backend.api.operators.Operator." "_replace_object_from_db"),
+            return_value=futurized(self.accession_id),
+        ) as mocked_insert:
             with patch("metadata_backend.api.operators.datetime") as m_date:
                 m_date.utcnow.return_value = datetime.datetime(2020, 4, 14)
-                acc = await (operator._format_data_to_replace_and_add_to_db(
-                    "study", accession, {}))
+                acc = await (operator._format_data_to_replace_and_add_to_db("study", accession, {}))
                 mocked_insert.assert_called_once_with(
-                    "study", accession,
-                    {"accessionId": self.accession_id,
-                     "dateModified": datetime.datetime(2020, 4, 14)})
+                    "study",
+                    accession,
+                    {"accessionId": self.accession_id, "dateModified": datetime.datetime(2020, 4, 14)},
+                )
             self.assertEqual(acc, self.accession_id)
 
     async def test_correct_data_is_set_to_json_when_updating(self):
         """Test operator updates object and adds necessary info."""
         accession = "EGA123456"
         operator = Operator(self.client)
-        with patch(("metadata_backend.api.operators.Operator."
-                    "_update_object_from_db"),
-                   return_value=futurized(self.accession_id)) as mocked_insert:
+        with patch(
+            ("metadata_backend.api.operators.Operator." "_update_object_from_db"),
+            return_value=futurized(self.accession_id),
+        ) as mocked_insert:
             with patch("metadata_backend.api.operators.datetime") as m_date:
                 m_date.utcnow.return_value = datetime.datetime(2020, 4, 14)
-                acc = await (operator._format_data_to_update_and_add_to_db(
-                    "study", accession, {}))
+                acc = await (operator._format_data_to_update_and_add_to_db("study", accession, {}))
                 mocked_insert.assert_called_once_with(
-                    "study", accession,
-                    {"accessionId": self.accession_id,
-                     "dateModified": datetime.datetime(2020, 4, 14)})
+                    "study",
+                    accession,
+                    {"accessionId": self.accession_id, "dateModified": datetime.datetime(2020, 4, 14)},
+                )
             self.assertEqual(acc, self.accession_id)
 
     async def test_wrong_data_is_set_to_json_when_updating(self):
         """Test operator update catches error."""
         accession = "EGA123456"
         operator = Operator(self.client)
-        with patch(("metadata_backend.api.operators.Operator."
-                    "_update_object_from_db"),
-                   return_value=futurized(self.accession_id)):
+        with patch(
+            ("metadata_backend.api.operators.Operator." "_update_object_from_db"),
+            return_value=futurized(self.accession_id),
+        ):
             with patch("metadata_backend.api.operators.datetime") as m_date:
                 m_date.utcnow.return_value = datetime.datetime(2020, 4, 14)
                 with self.assertRaises(HTTPBadRequest):
-                    await (operator._format_data_to_update_and_add_to_db(
-                        "study", accession,
-                        {"accessionId": self.accession_id,
-                         "dateCreated": datetime.datetime(2020, 4, 14),
-                         "dateModified": datetime.datetime(2020, 4, 14),
-                         "publishDate": datetime.datetime(2020, 6, 14)}))
+                    await (
+                        operator._format_data_to_update_and_add_to_db(
+                            "study",
+                            accession,
+                            {
+                                "accessionId": self.accession_id,
+                                "dateCreated": datetime.datetime(2020, 4, 14),
+                                "dateModified": datetime.datetime(2020, 4, 14),
+                                "publishDate": datetime.datetime(2020, 6, 14),
+                            },
+                        )
+                    )
 
     async def test_correct_data_is_set_to_xml_when_creating(self):
         """Test XMLoperator creates object and adds necessary info."""
         operator = XMLOperator(self.client)
         operator.db_service.db_client = self.client
         xml_data = "<TEST></TEST>"
-        with patch(("metadata_backend.api.operators.Operator."
-                    "_format_data_to_create_and_add_to_db"),
-                   return_value=futurized(self.accession_id)):
-            with patch(("metadata_backend.api.operators.XMLOperator."
-                        "_insert_formatted_object_to_db"),
-                       return_value=futurized(self.accession_id)) as m_insert:
+        with patch(
+            ("metadata_backend.api.operators.Operator." "_format_data_to_create_and_add_to_db"),
+            return_value=futurized(self.accession_id),
+        ):
+            with patch(
+                ("metadata_backend.api.operators.XMLOperator." "_insert_formatted_object_to_db"),
+                return_value=futurized(self.accession_id),
+            ) as m_insert:
                 with patch("metadata_backend.api.operators.XMLToJSONParser"):
-                    acc = await (operator.
-                                 _format_data_to_create_and_add_to_db("study",
-                                                                      xml_data)
-                                 )
-                    m_insert.assert_called_once_with("study", {
-                        "accessionId": self.accession_id,
-                        "content": xml_data})
+                    acc = await (operator._format_data_to_create_and_add_to_db("study", xml_data))
+                    m_insert.assert_called_once_with("study", {"accessionId": self.accession_id, "content": xml_data})
                     self.assertEqual(acc, self.accession_id)
 
     async def test_correct_data_is_set_to_xml_when_replacing(self):
@@ -350,19 +365,19 @@ class TestOperators(AsyncTestCase):
         operator = XMLOperator(self.client)
         operator.db_service.db_client = self.client
         xml_data = "<TEST></TEST>"
-        with patch(("metadata_backend.api.operators.Operator."
-                    "_format_data_to_replace_and_add_to_db"),
-                   return_value=futurized(self.accession_id)):
-            with patch(("metadata_backend.api.operators.XMLOperator."
-                        "_replace_object_from_db"),
-                       return_value=futurized(self.accession_id)) as m_insert:
+        with patch(
+            ("metadata_backend.api.operators.Operator." "_format_data_to_replace_and_add_to_db"),
+            return_value=futurized(self.accession_id),
+        ):
+            with patch(
+                ("metadata_backend.api.operators.XMLOperator." "_replace_object_from_db"),
+                return_value=futurized(self.accession_id),
+            ) as m_insert:
                 with patch("metadata_backend.api.operators.XMLToJSONParser"):
-                    acc = await (
-                        operator._format_data_to_replace_and_add_to_db(
-                            "study", accession, xml_data))
-                    m_insert.assert_called_once_with("study", accession, {
-                        "accessionId": self.accession_id,
-                        "content": xml_data})
+                    acc = await (operator._format_data_to_replace_and_add_to_db("study", accession, xml_data))
+                    m_insert.assert_called_once_with(
+                        "study", accession, {"accessionId": self.accession_id, "content": xml_data}
+                    )
                     self.assertEqual(acc, self.accession_id)
 
     async def test_deleting_metadata_deletes_json_and_xml(self):
@@ -384,45 +399,48 @@ class TestOperators(AsyncTestCase):
         with self.assertRaises(HTTPNotFound):
             await operator.delete_metadata_object("sample", "EGA123456")
             self.assertEqual(operator.db_service.delete.call_count, 2)
-            operator.db_service.delete.assert_called_with("sample",
-                                                          "EGA123456")
+            operator.db_service.delete.assert_called_with("sample", "EGA123456")
 
     async def test_working_query_params_are_passed_to_db_query(self):
         """Test that database is called with correct query."""
         operator = Operator(self.client)
-        study_test = [{
-            "publishDate": datetime.datetime(2020, 6, 14, 0, 0),
-            "accessionId": "EDAG3945644754983408",
-            "dateCreated": datetime.datetime(2020, 6, 14, 0, 0),
-            "dateModified": datetime.datetime(2020, 6, 14, 0, 0)
-        }]
+        study_test = [
+            {
+                "publishDate": datetime.datetime(2020, 6, 14, 0, 0),
+                "accessionId": "EDAG3945644754983408",
+                "dateCreated": datetime.datetime(2020, 6, 14, 0, 0),
+                "dateModified": datetime.datetime(2020, 6, 14, 0, 0),
+            }
+        ]
         operator.db_service.query.return_value = MockCursor(study_test)
         query = MultiDictProxy(MultiDict([("studyAttributes", "foo")]))
         await operator.query_metadata_database("study", query, 1, 10)
         operator.db_service.query.assert_called_once_with(
-            'study', {'$or': [
-                {'studyAttributes.tag':
-                 re.compile('.*foo.*', re.IGNORECASE)},
-                {'studyAttributes.value':
-                 re.compile('.*foo.*', re.IGNORECASE)}
-            ]}
+            "study",
+            {
+                "$or": [
+                    {"studyAttributes.tag": re.compile(".*foo.*", re.IGNORECASE)},
+                    {"studyAttributes.value": re.compile(".*foo.*", re.IGNORECASE)},
+                ]
+            },
         )
 
     async def test_non_working_query_params_are_not_passed_to_db_query(self):
         """Test that database with empty query, when url params are wrong."""
         operator = Operator(self.client)
-        study_test = [{
-            "publishDate": datetime.datetime(2020, 6, 14, 0, 0),
-            "accessionId": "EDAG3945644754983408",
-            "dateCreated": datetime.datetime(2020, 6, 14, 0, 0),
-            "dateModified": datetime.datetime(2020, 6, 14, 0, 0)
-        }]
+        study_test = [
+            {
+                "publishDate": datetime.datetime(2020, 6, 14, 0, 0),
+                "accessionId": "EDAG3945644754983408",
+                "dateCreated": datetime.datetime(2020, 6, 14, 0, 0),
+                "dateModified": datetime.datetime(2020, 6, 14, 0, 0),
+            }
+        ]
         operator.db_service.query.return_value = MockCursor(study_test)
         query = MultiDictProxy(MultiDict([("swag", "littinen")]))
-        with patch("metadata_backend.api.operators.Operator._format_read_data",
-                   return_value=futurized(study_test)):
+        with patch("metadata_backend.api.operators.Operator._format_read_data", return_value=futurized(study_test)):
             await operator.query_metadata_database("study", query, 1, 10)
-        operator.db_service.query.assert_called_once_with('study', {})
+        operator.db_service.query.assert_called_once_with("study", {})
 
     async def test_query_result_is_parsed_correctly(self):
         """Test json is read and correct pagination values are returned."""
@@ -432,19 +450,19 @@ class TestOperators(AsyncTestCase):
                 "dateCreated": datetime.datetime(2020, 6, 14, 0, 0),
                 "dateModified": datetime.datetime(2020, 6, 14, 0, 0),
                 "accessionId": "EGA123456",
-                "foo": "bar"
-            }, {
+                "foo": "bar",
+            },
+            {
                 "dateCreated": datetime.datetime(2020, 6, 14, 0, 0),
                 "dateModified": datetime.datetime(2020, 6, 14, 0, 0),
                 "accessionId": "EGA123456",
-                "foo": "bar"
-            }
+                "foo": "bar",
+            },
         ]
         operator.db_service.query.return_value = MockCursor(multiple_result)
         operator.db_service.get_count.return_value = futurized(100)
         query = MultiDictProxy(MultiDict([]))
-        parsed, page_num, page_size, total_objects = (
-            await operator.query_metadata_database("sample", query, 1, 10))
+        parsed, page_num, page_size, total_objects = await operator.query_metadata_database("sample", query, 1, 10)
         for doc in parsed:
             self.assertEqual(doc["dateCreated"], "2020-06-14T00:00:00")
             self.assertEqual(doc["dateModified"], "2020-06-14T00:00:00")
@@ -458,8 +476,7 @@ class TestOperators(AsyncTestCase):
         operator = Operator(self.client)
         operator.db_service.query = MagicMock()
         query = MultiDictProxy(MultiDict([]))
-        with patch("metadata_backend.api.operators.Operator._format_read_data",
-                   return_value=futurized([])):
+        with patch("metadata_backend.api.operators.Operator._format_read_data", return_value=futurized([])):
             with self.assertRaises(HTTPNotFound):
                 await operator.query_metadata_database("study", query, 1, 10)
 
@@ -469,8 +486,7 @@ class TestOperators(AsyncTestCase):
         data = {"foo": "bar"}
         cursor = MockCursor([])
         operator.db_service.query.return_value = cursor
-        with patch("metadata_backend.api.operators.Operator._format_read_data",
-                   return_value=futurized(data)):
+        with patch("metadata_backend.api.operators.Operator._format_read_data", return_value=futurized(data)):
             await operator.query_metadata_database("sample", {}, 3, 50)
             self.assertEqual(cursor._skip, 100)
             self.assertEqual(cursor._limit, 50)
@@ -509,13 +525,12 @@ class TestOperators(AsyncTestCase):
         operator.db_service.read.return_value = futurized(self.test_folder)
         read_data = await operator.read_folder(self.folder_id)
         operator.db_service.exists.assert_called_once()
-        operator.db_service.read.assert_called_once_with("folder",
-                                                         self.folder_id)
+        operator.db_service.read.assert_called_once_with("folder", self.folder_id)
         self.assertEqual(read_data, self.test_folder)
 
     async def test_folder_update_passes_and_returns_id(self):
         """Test update method for folders works."""
-        patch = JsonPatch([{'op': "add", 'path': "/name", 'value': "test2"}])
+        patch = JsonPatch([{"op": "add", "path": "/name", "value": "test2"}])
         operator = FolderOperator(self.client)
         operator.db_service.exists.return_value = futurized(True)
         operator.db_service.read.return_value = futurized(self.test_folder)
@@ -524,11 +539,11 @@ class TestOperators(AsyncTestCase):
         operator.db_service.exists.assert_called_once()
         operator.db_service.read.assert_called_once()
         operator.db_service.update.assert_called_once()
-        self.assertEqual(folder['folderId'], self.folder_id)
+        self.assertEqual(folder["folderId"], self.folder_id)
 
     async def test_folder_update_fails_with_bad_patch(self):
         """Test folder update raises error with improper JSON Patch."""
-        patch = JsonPatch([{'op': "replace", 'path': "nothing"}])
+        patch = JsonPatch([{"op": "replace", "path": "nothing"}])
         operator = FolderOperator(self.client)
         operator.db_service.exists.return_value = futurized(True)
         operator.db_service.read.return_value = futurized(self.test_folder)
@@ -547,5 +562,5 @@ class TestOperators(AsyncTestCase):
         operator.db_service.delete.assert_called_with("folder", "FOL12345678")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -10,7 +10,7 @@ from metadata_backend.helpers.parser import XMLToJSONParser
 class ParserTestCase(unittest.TestCase):
     """Api endpoint class test cases."""
 
-    TESTFILES_ROOT = Path(__file__).parent / 'test_files'
+    TESTFILES_ROOT = Path(__file__).parent / "test_files"
 
     def setUp(self):
         """Configure variables for tests."""
@@ -28,10 +28,8 @@ class ParserTestCase(unittest.TestCase):
         """
         study_xml = self.load_xml_from_file("study", "SRP000539.xml")
         study_json = self.parser.parse("study", study_xml)
-        self.assertIn("Highly integrated epigenome maps in Arabidopsis",
-                      study_json['descriptor']['studyTitle'])
-        self.assertIn("18423832", study_json['studyLinks']['xrefLinks']
-                      [0]['id'])
+        self.assertIn("Highly integrated epigenome maps in Arabidopsis", study_json["descriptor"]["studyTitle"])
+        self.assertIn("18423832", study_json["studyLinks"]["xrefLinks"][0]["id"])
 
     def test_sample_is_parsed(self):
         """Test that sample is parsed correctly and accessionId is set.
@@ -40,10 +38,8 @@ class ParserTestCase(unittest.TestCase):
         """
         sample_xml = self.load_xml_from_file("sample", "SRS001433.xml")
         sample_json = self.parser.parse("sample", sample_xml)
-        self.assertIn("Human HapMap individual NA18758",
-                      sample_json['description'])
-        self.assertIn("Homo sapiens",
-                      sample_json['sampleName']['scientificName'])
+        self.assertIn("Human HapMap individual NA18758", sample_json["description"])
+        self.assertIn("Homo sapiens", sample_json["sampleName"]["scientificName"])
 
     def test_experiment_is_parsed(self):
         """Test that experiment is parsed correctly and accessionId is set.
@@ -52,8 +48,9 @@ class ParserTestCase(unittest.TestCase):
         """
         experiment_xml = self.load_xml_from_file("experiment", "ERX000119.xml")
         experiment_json = self.parser.parse("experiment", experiment_xml)
-        self.assertIn("SOLiD sequencing of Human HapMap individual NA18504",
-                      experiment_json['design']['designDescription'])
+        self.assertIn(
+            "SOLiD sequencing of Human HapMap individual NA18504", experiment_json["design"]["designDescription"]
+        )
 
     def test_run_is_parsed(self):
         """Test that run is parsed correctly and accessionId is set.
@@ -62,9 +59,8 @@ class ParserTestCase(unittest.TestCase):
         """
         run_xml = self.load_xml_from_file("run", "ERR000076.xml")
         run_json = self.parser.parse("run", run_xml)
-        self.assertIn("ERA000/ERA000014/srf/BGI-FC304RWAAXX_5.srf",
-                      run_json['files'][0]['file']['filename'])
-        self.assertIn("ERX000037", run_json['experimentRef']['accessionId'])
+        self.assertIn("ERA000/ERA000014/srf/BGI-FC304RWAAXX_5.srf", run_json["files"][0]["file"]["filename"])
+        self.assertIn("ERX000037", run_json["experimentRef"]["accessionId"])
 
     def test_analysis_is_parsed(self):
         """Test that run is parsed correctly and accessionId is set.
@@ -73,8 +69,9 @@ class ParserTestCase(unittest.TestCase):
         """
         analysis_xml = self.load_xml_from_file("analysis", "ERZ266973.xml")
         analysis_json = self.parser.parse("analysis", analysis_xml)
-        self.assertIn("GCA_000001405.1", analysis_json['analysisType'][
-            'processedReads']['assembly']['standard']['accessionId'])
+        self.assertIn(
+            "GCA_000001405.1", analysis_json["analysisType"]["processedReads"]["assembly"]["standard"]["accessionId"]
+        )
 
     def test_error_raised_when_schema_not_found(self):
         """Test 400 is returned when schema."""

--- a/tests/test_schema_loader.py
+++ b/tests/test_schema_loader.py
@@ -3,9 +3,7 @@ import unittest
 
 import xmlschema
 
-from metadata_backend.helpers.schema_loader import (JSONSchemaLoader,
-                                                    SchemaNotFoundException,
-                                                    XMLSchemaLoader)
+from metadata_backend.helpers.schema_loader import JSONSchemaLoader, SchemaNotFoundException, XMLSchemaLoader
 
 
 class TestXMLSchemaLoader(unittest.TestCase):
@@ -22,8 +20,7 @@ class TestXMLSchemaLoader(unittest.TestCase):
         """Test non-existent schemas is reported as error."""
         schema_name = "NULL"
         schemaloader = XMLSchemaLoader()
-        self.assertRaises(SchemaNotFoundException, schemaloader.get_schema,
-                          schema_name)
+        self.assertRaises(SchemaNotFoundException, schemaloader.get_schema, schema_name)
 
 
 class TestJSONSchemaLoader(unittest.TestCase):
@@ -40,9 +37,8 @@ class TestJSONSchemaLoader(unittest.TestCase):
         """Test non-existent schemas is reported as error."""
         schema_name = "NULL"
         schemaloader = JSONSchemaLoader()
-        self.assertRaises(SchemaNotFoundException, schemaloader.get_schema,
-                          schema_name)
+        self.assertRaises(SchemaNotFoundException, schemaloader.get_schema, schema_name)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -14,15 +14,15 @@ from metadata_backend.server import init, main
 class TestBasicFunctionsApp(unittest.TestCase):
     """Test basic functions from web app."""
 
-    @patch('metadata_backend.server.web')
-    @patch('metadata_backend.server.init')
+    @patch("metadata_backend.server.web")
+    @patch("metadata_backend.server.init")
     def test_main(self, mock_init, mock_webapp):
         """Should start the webapp."""
         main()
         mock_webapp.run_app.assert_called()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py36, py37, flake8,  mypy, docs
 skipsdist = True
 
 [flake8]
+max-line-length = 120
 ignore = D203,D212,D213,D404,W503,ANN101
 exclude = .git/, ./venv/, ./.tox/, build/, metadata_backend.egg-info/
 # Not using type hints in tests, ignore all errors

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, flake8,  mypy, docs
+envlist = py36, py37, flake8, mypy, docs, black
 skipsdist = True
 
 [flake8]
@@ -33,6 +33,12 @@ deps =
 # Alternative to ignoring imports would be to write custom stub files, which
 # could be done at some point.
 commands = mypy --ignore-missing-imports metadata_backend/
+
+[testenv:black]
+skip_install = true
+deps =
+    black
+commands = black . -l 120 --check
 
 [testenv]
 passenv = COVERALLS_REPO_TOKEN

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, flake8, isort, mypy, docs
+envlist = py36, py37, flake8,  mypy, docs
 skipsdist = True
 
 [flake8]
@@ -23,12 +23,6 @@ deps =
     flake8-annotations
 commands = flake8 .
 
-[testenv:isort]
-skip_install = true
-deps =
-    isort
-commands = isort metadata_backend/ tests/ setup.py -c
-
 [testenv:mypy]
 skip_install = true
 deps =
@@ -51,4 +45,4 @@ commands = py.test -x --cov=metadata_backend tests/
 [gh-actions]
 python =
     3.6: py36
-    3.7: flake8, py37, docs, isort, mypy
+    3.7: flake8, py37, docs, mypy

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skipsdist = True
 
 [flake8]
 max-line-length = 120
-ignore = D203,D212,D213,D404,W503,ANN101
+ignore = D202, D203,D212,D213,D404,W503,ANN101
 exclude = .git/, ./venv/, ./.tox/, build/, metadata_backend.egg-info/
 # Not using type hints in tests, ignore all errors
 per-file-ignores =


### PR DESCRIPTION
## Description

This PR adds [black](https://github.com/psf/black) code formatter rules, tox checks, github actions and removes isort (as its now quite redundant). Also some black style choises that are checked by flake8 are ignored now (such as D202, E203, W503).

### Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Testing 
- [x] Tests do not apply