### PR TITLE
Add folder POST schema

### DIFF
--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -304,6 +304,7 @@ class RESTApiHandler:
         """
         db_client = req.app["db_client"]
         content = await self._get_data(req)
+        JSONValidator(content, "folders").validate
         operator = FolderOperator(db_client)
         folder = await operator.create_folder(content)
         body = json.dumps({"folderId": folder})

--- a/metadata_backend/api/operators.py
+++ b/metadata_backend/api/operators.py
@@ -569,7 +569,8 @@ class FolderOperator:
         :returns: Folder id for the folder inserted to database
         """
         folder_id = self._generate_folder_id()
-        data["folderId"] = folder_id
+        data['folderId'] = folder_id
+        data['published'] = False
         try:
             insert_success = await self.db_service.create("folder", data)
         except (ConnectionFailure, OperationFailure) as error:

--- a/metadata_backend/api/operators.py
+++ b/metadata_backend/api/operators.py
@@ -624,6 +624,7 @@ class FolderOperator:
         await self._check_folder_exists(self.db_service, folder_id)
         try:
             folder = await self.db_service.read("folder", folder_id)
+            JSONValidator(folder, "folders").validate
             upd_content = patch.apply(folder)
             update_success = await self.db_service.update("folder", folder_id, upd_content)
         except (ConnectionFailure, OperationFailure) as error:

--- a/metadata_backend/helpers/schemas/folders.json
+++ b/metadata_backend/helpers/schemas/folders.json
@@ -1,38 +1,40 @@
 {
   "type": "object",
+  "title": "The root schema",
+  "required": [
+    "name",
+    "description"
+  ],
   "properties": {
-    "folderId": {
-      "type": "string"
-    },
     "name": {
-      "type": "string"
+      "type": "string",
+      "title": "The name schema"
     },
     "description": {
-      "type": "string"
+      "type": "string",
+      "title": "The description schema"
     },
     "metadataObjects": {
       "type": "array",
-      "items": [
-        {
-          "type": "object",
-          "properties": {
-            "accessionID": {
-              "type": "string"
-            },
-            "schema": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "accessionID",
+      "title": "The metadataObjects schema",
+      "items": {
+        "type": "object",
+        "title": "The items schema",
+        "required": [
+            "accessionId",
             "schema"
-          ]
+        ],
+        "properties": {
+          "accessionId": {
+            "type": "string",
+            "title": "The accessionId schema"
+          },
+          "schema": {
+            "type": "string",
+            "title": "The schema schema"
+          }
         }
-      ]
+      }
     }
-  },
-  "required": [
-    "name",
-    "description",
-  ]
+  }
 }

--- a/metadata_backend/helpers/schemas/folders.json
+++ b/metadata_backend/helpers/schemas/folders.json
@@ -16,7 +16,7 @@
     },
     "description": {
       "type": "string",
-      "title": "The description schema"
+      "title": "Folder Description"
     },
     "published": {
       "type": "boolean",

--- a/metadata_backend/helpers/schemas/folders.json
+++ b/metadata_backend/helpers/schemas/folders.json
@@ -6,6 +6,10 @@
     "description"
   ],
   "properties": {
+    "folderId": {
+      "type": "string",
+      "title": "The id schema"
+    },
     "name": {
       "type": "string",
       "title": "The name schema"
@@ -13,6 +17,10 @@
     "description": {
       "type": "string",
       "title": "The description schema"
+    },
+    "published": {
+      "type": "boolean",
+      "title": "The published schema"
     },
     "metadataObjects": {
       "type": "array",
@@ -36,5 +44,6 @@
         }
       }
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/metadata_backend/helpers/schemas/folders.json
+++ b/metadata_backend/helpers/schemas/folders.json
@@ -1,6 +1,6 @@
 {
   "type": "object",
-  "title": "The root schema",
+  "title": "Folder schema containing submitted metadata objects",
   "required": [
     "name",
     "description"

--- a/metadata_backend/helpers/schemas/folders.json
+++ b/metadata_backend/helpers/schemas/folders.json
@@ -27,7 +27,7 @@
       "title": "The metadataObjects schema",
       "items": {
         "type": "object",
-        "title": "The items schema",
+        "title": "Folder objects",
         "required": [
             "accessionId",
             "schema"

--- a/metadata_backend/helpers/schemas/folders.json
+++ b/metadata_backend/helpers/schemas/folders.json
@@ -35,7 +35,7 @@
         "properties": {
           "accessionId": {
             "type": "string",
-            "title": "The accessionId schema"
+            "title": "Accession Id"
           },
           "schema": {
             "type": "string",

--- a/metadata_backend/helpers/schemas/folders.json
+++ b/metadata_backend/helpers/schemas/folders.json
@@ -39,7 +39,7 @@
           },
           "schema": {
             "type": "string",
-            "title": "The schema schema"
+            "title": "Object's schema"
           }
         }
       }

--- a/metadata_backend/helpers/schemas/folders.json
+++ b/metadata_backend/helpers/schemas/folders.json
@@ -1,0 +1,38 @@
+{
+  "type": "object",
+  "properties": {
+    "folderId": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "metadataObjects": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "accessionID": {
+              "type": "string"
+            },
+            "schema": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "accessionID",
+            "schema"
+          ]
+        }
+      ]
+    }
+  },
+  "required": [
+    "name",
+    "description",
+  ]
+}

--- a/metadata_backend/helpers/schemas/folders.json
+++ b/metadata_backend/helpers/schemas/folders.json
@@ -8,7 +8,7 @@
   "properties": {
     "folderId": {
       "type": "string",
-      "title": "The id schema"
+      "title": "Folder Id"
     },
     "name": {
       "type": "string",

--- a/metadata_backend/helpers/schemas/folders.json
+++ b/metadata_backend/helpers/schemas/folders.json
@@ -20,7 +20,7 @@
     },
     "published": {
       "type": "boolean",
-      "title": "The published schema"
+      "title": "Published Folder"
     },
     "metadataObjects": {
       "type": "array",

--- a/metadata_backend/helpers/schemas/folders.json
+++ b/metadata_backend/helpers/schemas/folders.json
@@ -12,7 +12,7 @@
     },
     "name": {
       "type": "string",
-      "title": "The name schema"
+      "title": "Folder Name"
     },
     "description": {
       "type": "string",

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -42,12 +42,11 @@ class HandlersTestCase(AioHTTPTestCase):
         self.metadata_xml = path_to_xml_file.read_text()
         self.accession_id = "EGA123456"
         self.folder_id = "FOL12345678"
-        self.test_folder = {
-            "folderId": self.folder_id,
-            "name": "test",
-            "description": "test folder",
-            "metadata_objects": [],
-        }
+        self.test_folder = {"folderId": self.folder_id,
+                            "name": "test",
+                            "description": "test folder",
+                            "published": False,
+                            "metadataObjects": []}
 
         class_parser = "metadata_backend.api.handlers.XMLToJSONParser"
         class_operator = "metadata_backend.api.handlers.Operator"
@@ -502,8 +501,7 @@ class HandlersTestCase(AioHTTPTestCase):
     async def test_folder_creation_works(self):
         """Test that folder is created and folder ID returned."""
         json_req = {"name": "test",
-                    "description": "test folder",
-                    "metadataObjects": []}
+                    "description": "test folder"}
         response = await self.client.post("/folders", json=json_req)
         json_resp = await response.json()
         self.MockedFolderOperator().create_folder.assert_called_once()
@@ -548,12 +546,11 @@ class HandlersTestCase(AioHTTPTestCase):
     @unittest_run_loop
     async def test_get_folder_works(self):
         """Test folder is returned when correct folder id is given."""
-        folder = {"folderId": self.folder_id, "name": "test", "description": "test folder", "metadata_objects": []}
         response = await self.client.get("/folders/FOL12345678")
         self.assertEqual(response.status, 200)
         self.MockedFolderOperator().read_folder.assert_called_once()
         json_resp = await response.json()
-        self.assertEqual(folder, json_resp)
+        self.assertEqual(self.test_folder, json_resp)
 
     @unittest_run_loop
     async def test_update_folder_fails_with_wrong_key(self):

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -501,7 +501,9 @@ class HandlersTestCase(AioHTTPTestCase):
     @unittest_run_loop
     async def test_folder_creation_works(self):
         """Test that folder is created and folder ID returned."""
-        json_req = {"name": "test", "description": "test folder"}
+        json_req = {"name": "test",
+                    "description": "test folder",
+                    "metadataObjects": []}
         response = await self.client.post("/folders", json=json_req)
         json_resp = await response.json()
         self.MockedFolderOperator().create_folder.assert_called_once()
@@ -509,7 +511,16 @@ class HandlersTestCase(AioHTTPTestCase):
         self.assertEqual(json_resp["folderId"], self.folder_id)
 
     @unittest_run_loop
-    async def test_folder_creation_with_empty_body(self):
+    async def test_folder_creation_with_missing_data_fails(self):
+        """Test that folder creation fails when missing data in request."""
+        json_req = {"description": "test folder"}
+        response = await self.client.post("/folders", json=json_req)
+        json_resp = await response.json()
+        self.assertEqual(response.status, 400)
+        self.assertIn("'name' is a required property", json_resp['detail'])
+
+    @unittest_run_loop
+    async def test_folder_creation_with_empty_body_fails(self):
         """Test that folder creation fails when no data in request."""
         response = await self.client.post("/folders")
         json_resp = await response.json()

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -57,12 +57,11 @@ class TestOperators(AsyncTestCase):
         self.client = MagicMock()
         self.accession_id = "EGA123456"
         self.folder_id = "FOL12345678"
-        self.test_folder = {
-            "folderId": self.folder_id,
-            "name": "test",
-            "description": "test folder",
-            "metadata_objects": [],
-        }
+        self.test_folder = {"folderId": self.folder_id,
+                            "name": "test",
+                            "description": "test folder",
+                            "published": False,
+                            "metadataObjects": []}
         class_dbservice = "metadata_backend.api.operators.DBService"
         self.patch_dbservice = patch(class_dbservice, spec=True)
         self.MockedDbService = self.patch_dbservice.start()


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
PR includes schema to validate for POST folder requests.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
Fixes #113 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

<!-- List changes made. -->
- added JSON schema for folders
- added `JSONValidator().validate` calls to appropriate places
- established `"published"` key for folders, which aims to solve [the additional issue raised by](https://github.com/CSCfi/metadata-submitter/issues/113#issuecomment-670513122) @blankdots 

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests
- [x] Tests do not apply
