### PR TITLE
Bugfix/small typo fixes

### DIFF
--- a/metadata_backend/api/operators.py
+++ b/metadata_backend/api/operators.py
@@ -628,6 +628,8 @@ class FolderOperator:
             upd_content = patch.apply(folder)
             JSONValidator(upd_content, "folders").validate
             update_success = await self.db_service.update("folder", folder_id, upd_content)
+            sanity_check = await self.db_service.read("folder", folder_id)
+            JSONValidator(sanity_check, "folders").validate
         except (ConnectionFailure, OperationFailure) as error:
             reason = f"Error happened while getting folder: {error}"
             LOG.error(reason)

--- a/metadata_backend/api/operators.py
+++ b/metadata_backend/api/operators.py
@@ -625,8 +625,8 @@ class FolderOperator:
         await self._check_folder_exists(self.db_service, folder_id)
         try:
             folder = await self.db_service.read("folder", folder_id)
-            JSONValidator(folder, "folders").validate
             upd_content = patch.apply(folder)
+            JSONValidator(upd_content, "folders").validate
             update_success = await self.db_service.update("folder", folder_id, upd_content)
         except (ConnectionFailure, OperationFailure) as error:
             reason = f"Error happened while getting folder: {error}"

--- a/metadata_backend/api/operators.py
+++ b/metadata_backend/api/operators.py
@@ -660,9 +660,13 @@ class FolderOperator:
             LOG.error(reason)
             raise web.HTTPBadRequest(reason=reason)
         if not delete_success:
-            reason = "Deleting for {folder_id} from database failed."
+            reason = f"Deleting for {folder_id} from database failed."
             LOG.error(reason)
             raise web.HTTPBadRequest(reason=reason)
+        else:
+            LOG.info(f"Deleting folder with id {folder_id} to database succeeded.")
+            return folder_id
+
 
     async def _check_folder_exists(self, db: DBService, id: str) -> None:
         """Check the existance of a folder by its id in the database."""

--- a/metadata_backend/api/operators.py
+++ b/metadata_backend/api/operators.py
@@ -646,7 +646,7 @@ class FolderOperator:
             LOG.info(f"Updating folder with id {folder_id} to database " "succeeded.")
             return folder_id
 
-    async def delete_folder(self, folder_id: str) -> None:
+    async def delete_folder(self, folder_id: str) -> str:
         """Delete object folder from database.
 
         :param folder_id: ID of the folder to delete.
@@ -666,7 +666,6 @@ class FolderOperator:
         else:
             LOG.info(f"Deleting folder with id {folder_id} to database succeeded.")
             return folder_id
-
 
     async def _check_folder_exists(self, db: DBService, id: str) -> None:
         """Check the existance of a folder by its id in the database."""

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -519,7 +519,7 @@ class TestOperators(AsyncTestCase):
         operator.db_service.query.assert_called_once()
         self.assertEqual(folders, [{"name": "folder"}])
 
-    async def test_reading_foldre_works(self):
+    async def test_reading_folder_works(self):
         """Test folder is read from db correctly."""
         operator = FolderOperator(self.client)
         operator.db_service.exists.return_value = futurized(True)
@@ -538,8 +538,8 @@ class TestOperators(AsyncTestCase):
         operator.db_service.update.return_value = futurized(True)
         folder = await operator.update_folder(self.test_folder, patch)
         operator.db_service.exists.assert_called_once()
-        operator.db_service.read.assert_called_once()
         operator.db_service.update.assert_called_once()
+        self.assertEqual(len(operator.db_service.read.mock_calls), 2)
         self.assertEqual(folder["folderId"], self.folder_id)
 
     async def test_folder_update_fails_with_bad_patch(self):
@@ -548,7 +548,6 @@ class TestOperators(AsyncTestCase):
         operator = FolderOperator(self.client)
         operator.db_service.exists.return_value = futurized(True)
         operator.db_service.read.return_value = futurized(self.test_folder)
-        # operator.db_service.update.return_value = futurized(True)
         with self.assertRaises(HTTPBadRequest):
             await operator.update_folder(self.test_folder, patch)
             operator.db_service.exists.assert_called_once()


### PR DESCRIPTION
### Description

Couple of small bugfixes

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made
- Fix bug where folder id wasn't returned after succesful deletion, resulting logging of "None" instead of if
- FIx bug where validation was run for folder read from database instead of patched version of folder, making it possible to patch folders to non-valid state, thus failing validation on following patches