### PR TITLE
Feature/move to only37

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -8,7 +8,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.6, 3.7]
+        python-version: [3.7]
     
     runs-on: ${{ matrix.os }}
 
@@ -26,9 +26,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install tox tox-gh-actions
-    - name: Run unit tests for python 3.6
-      if: ${{ matrix.python-version == '3.6' }}
-      run: tox -e py36
     - name: Run unit tests for python 3.7
       if: ${{ matrix.python-version == '3.7' }}
       env:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Service also validates submitted metadata objects against EGA XSD metadata model
 ## Install and run
 
 Requirements:
-- Python 3.6+
+- Python 3.7+
 - Mongodb
 - Docker + docker-compose
 

--- a/docs/submitter.rst
+++ b/docs/submitter.rst
@@ -6,7 +6,7 @@ Install and run
 
 .. note:: Requirements:
 
-  - Python 3.6+
+  - Python 3.7+
   - Mongodb
   - Docker + docker-compose
 

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -10,6 +10,7 @@ from typing import Dict, List, Tuple, Union, cast
 
 from aiohttp import BodyPartReader, web, BasicAuth, ClientSession
 from aiohttp.web import Request, Response
+from multidict import CIMultiDict
 from aiohttp_session import get_session
 from jsonpatch import JsonPatch
 from xmlschema import XMLSchemaException
@@ -36,7 +37,7 @@ class RESTApiHandler:
             LOG.error(reason)
             raise web.HTTPNotFound(reason=reason)
 
-    def _header_links(self, url: str, page: int, size: int, total_objects: int) -> Dict[str, str]:
+    def _header_links(self, url: str, page: int, size: int, total_objects: int) -> CIMultiDict[str]:
         """Create link header for pagination.
 
         :param url: base url for request
@@ -52,7 +53,7 @@ class RESTApiHandler:
         comma = ", " if page > 1 and page < total_pages else ""
         first_link = f'<{url}?page=1&per_page={size}>; rel="first"{comma}' if page > 1 else ""
         links = f"{prev_link}{next_link}{first_link}{last_link}"
-        link_headers = {"Link": f"{links}"}
+        link_headers = CIMultiDict(Link=f"{links}")
         LOG.debug("Link headers created")
         return link_headers
 
@@ -205,7 +206,7 @@ class RESTApiHandler:
         accession_id = await operator.create_metadata_object(collection, content)
         body = json.dumps({"accessionId": accession_id})
         url = f"{req.scheme}://{req.host}{req.path}"
-        location_headers = {"Location": f"{url}{accession_id}"}
+        location_headers = CIMultiDict(Location=f"{url}{accession_id}")
         LOG.info(f"POST object with accesssion ID {accession_id} " f"in schema {collection} was successful.")
         return web.Response(
             body=body,
@@ -322,7 +323,7 @@ class RESTApiHandler:
         folder = await operator.create_folder(content)
         body = json.dumps({"folderId": folder})
         url = f"{req.scheme}://{req.host}{req.path}"
-        location_headers = {"Location": f"{url}/{folder}"}
+        location_headers = CIMultiDict(Location=f"{url}/{folder}")
         LOG.info(f"POST new folder with ID {folder} was successful.")
         return web.Response(body=body, status=201, headers=location_headers, content_type="application/json")
 

--- a/metadata_backend/api/middlewares.py
+++ b/metadata_backend/api/middlewares.py
@@ -6,6 +6,7 @@ from typing import Callable, Dict
 from aiohttp import web, ClientSession
 from aiohttp.web import Request, Response, middleware, StreamResponse
 from aiohttp_session import get_session
+from multidict import CIMultiDict
 from yarl import URL
 import os
 
@@ -69,7 +70,7 @@ async def get_userinfo(req: Request) -> Dict[str, str]:
         raise web.HTTPBadRequest(reason="Could not get a proper session.")
 
     try:
-        headers = {"Authorization": f"Bearer {token}"}
+        headers = CIMultiDict({"Authorization": f"Bearer {token}"})
         async with ClientSession(headers=headers) as sess:
             async with sess.get(f"{aai_config['user_info']}") as resp:
                 result = await resp.json()

--- a/metadata_backend/api/operators.py
+++ b/metadata_backend/api/operators.py
@@ -304,7 +304,7 @@ class Operator(BaseOperator):
         :returns: Query result with pagination numbers
         """
         # Generate mongodb query from query parameters
-        mongo_query: Dict = {}
+        mongo_query: Dict[Any, Any] = {}
         for query, value in que.items():
             if query in query_map:
                 regx = re.compile(f".*{value}.*", re.IGNORECASE)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, flake8, mypy, docs, black
+envlist = py37, flake8, mypy, docs, black
 skipsdist = True
 
 [flake8]
@@ -51,5 +51,4 @@ commands = py.test -x --cov=metadata_backend tests/
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: flake8, py37, docs, mypy, black


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->

Move to only 3.7 which will allow use to use move precise typing with Python.
These changes break 3.6 compatibility.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->


- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


### Changes Made

<!-- List changes made. -->
- use CIMultiDict for headers
- remove use of 3.6

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply
