### PR TITLE
Refactor/draft folders

### DIFF
--- a/docs/specification.yml
+++ b/docs/specification.yml
@@ -899,6 +899,43 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/403Forbidden"
+  /publish/{folderId}:
+    patch:
+      tags:
+        - Manage
+      summary: Update object folder into published state.
+      parameters:
+        - name: folderId
+          in: path
+          description: ID of the object folder.
+          schema:
+            type: string
+          required: true
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FolderCreated"
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/400BadRequest"
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/401Unauthorized"
+        403:
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/403Forbidden"
   /users/{userId}:
     get:
       tags:

--- a/docs/specification.yml
+++ b/docs/specification.yml
@@ -1195,6 +1195,7 @@ components:
         - description
         - published
         - metadataObjects
+        - drafts
       additionalProperties: false
       properties:
         folderId:
@@ -1210,6 +1211,21 @@ components:
           type: boolean
           description: If folder is published or not
         metadataObjects:
+          type: array
+          items:
+            type: object
+            required:
+              - accessionId
+              - schema
+            additionalProperties: false
+            properties:
+              accessionId:
+                type: string
+                description: Accession id generated to identify an object
+              schema:
+                type: string
+                description: type of schema this Accession ID relates to and was added in submit
+        drafts:
           type: array
           items:
             type: object

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -352,7 +352,7 @@ class RESTApiHandler:
 
         # Check patch operations in request are valid
         patch_ops = await self._get_data(req)
-        allowed_paths = ["/name", "/description", "/metadataObjects", "/published"]
+        allowed_paths = ["/name", "/description", "/metadataObjects", "/published", "/drafts"]
         for op in patch_ops:
             if all(i not in op["path"] for i in allowed_paths):
                 reason = f"Request contains '{op['path']}' key that cannot be updated to folders."

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -386,7 +386,10 @@ class RESTApiHandler:
             accession_id = await Operator(db_client).delete_metadata_object(collection, accession_id)
             LOG.info(f"DELETE draft with accession ID {accession_id} in schema {collection} was successful.")
 
-        patch = [{"op": "replace", "path": "/publish", "value": True}, {"op": "remove", "path": "/drafts"}]
+        patch = [
+            {"op": "replace", "path": "/published", "value": True},
+            {"op": "replace", "path": "/drafts", "value": []},
+        ]
         new_folder = await operator.update_folder(folder_id, JsonPatch(patch))
         body = json.dumps({"folderId": new_folder})
         LOG.info(f"PATCH folder with ID {new_folder} was successful.")

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -206,7 +206,7 @@ class RESTApiHandler:
         body = json.dumps({"accessionId": accession_id})
         url = f"{req.scheme}://{req.host}{req.path}"
         location_headers = CIMultiDict(Location=f"{url}{accession_id}")
-        LOG.info(f"POST object with accesssion ID {accession_id} " f"in schema {collection} was successful.")
+        LOG.info(f"POST object with accesssion ID {accession_id} in schema {collection} was successful.")
         return web.Response(
             body=body,
             status=201,
@@ -237,7 +237,7 @@ class RESTApiHandler:
         accession_id = req.match_info["accessionId"]
         db_client = req.app["db_client"]
         accession_id = await Operator(db_client).delete_metadata_object(collection, accession_id)
-        LOG.info(f"DELETE object with accession ID {accession_id} " f"in schema {collection} was successful.")
+        LOG.info(f"DELETE object with accession ID {accession_id} in schema {collection} was successful.")
         return web.Response(status=204)
 
     async def put_object(self, req: Request) -> Response:
@@ -267,7 +267,7 @@ class RESTApiHandler:
             operator = Operator(db_client)
         accession_id = await operator.replace_metadata_object(collection, accession_id, content)
         body = json.dumps({"accessionId": accession_id})
-        LOG.info(f"PUT object with accession ID {accession_id} " f"in schema {collection} was successful.")
+        LOG.info(f"PUT object with accession ID {accession_id} in schema {collection} was successful.")
         return web.Response(body=body, status=200, content_type="application/json")
 
     async def patch_object(self, req: Request) -> Response:
@@ -293,7 +293,7 @@ class RESTApiHandler:
             operator = Operator(db_client)
         accession_id = await operator.update_metadata_object(collection, accession_id, content)
         body = json.dumps({"accessionId": accession_id})
-        LOG.info(f"PATCH object with accession ID {accession_id} " f"in schema {collection} was successful.")
+        LOG.info(f"PATCH object with accession ID {accession_id} in schema {collection} was successful.")
         return web.Response(body=body, status=200, content_type="application/json")
 
     async def get_folders(self, req: Request) -> Response:
@@ -373,7 +373,24 @@ class RESTApiHandler:
         :raises: HTTP 400 if something fails during processing the request
         :returns: JSON response containing folder ID for updated folder
         """
-        return web.HTTPNotImplemented()
+        folder_id = req.match_info["folderId"]
+        db_client = req.app["db_client"]
+        operator = FolderOperator(db_client)
+        old_folder = await operator.read_folder(folder_id)
+        LOG.info(f"GET folder with ID {folder_id} was successful.")
+
+        for draft in old_folder["drafts"]:
+            schema_type, accession_id = draft["schema"], draft["accessionId"]
+            collection = f"draft-{schema_type}"
+            self._check_schema_exists(schema_type)
+            accession_id = await Operator(db_client).delete_metadata_object(collection, accession_id)
+            LOG.info(f"DELETE draft with accession ID {accession_id} in schema {collection} was successful.")
+
+        patch = [{"op": "replace", "path": "/publish", "value": True}, {"op": "remove", "path": "/drafts"}]
+        new_folder = await operator.update_folder(folder_id, JsonPatch(patch))
+        body = json.dumps({"folderId": new_folder})
+        LOG.info(f"PATCH folder with ID {new_folder} was successful.")
+        return web.Response(body=body, status=200, content_type="application/json")
 
     async def delete_folder(self, req: Request) -> Response:
         """Delete object folder from database.

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -379,6 +379,7 @@ class RESTApiHandler:
         old_folder = await operator.read_folder(folder_id)
         LOG.info(f"GET folder with ID {folder_id} was successful.")
 
+        # Delete the drafts within the folder from the database
         for draft in old_folder["drafts"]:
             schema_type, accession_id = draft["schema"], draft["accessionId"]
             collection = f"draft-{schema_type}"
@@ -386,13 +387,14 @@ class RESTApiHandler:
             accession_id = await Operator(db_client).delete_metadata_object(collection, accession_id)
             LOG.info(f"DELETE draft with accession ID {accession_id} in schema {collection} was successful.")
 
+        # Patch the folder into a published state
         patch = [
             {"op": "replace", "path": "/published", "value": True},
             {"op": "replace", "path": "/drafts", "value": []},
         ]
         new_folder = await operator.update_folder(folder_id, JsonPatch(patch))
         body = json.dumps({"folderId": new_folder})
-        LOG.info(f"PATCH folder with ID {new_folder} was successful.")
+        LOG.info(f"Patching folder with ID {new_folder} was successful.")
         return web.Response(body=body, status=200, content_type="application/json")
 
     async def delete_folder(self, req: Request) -> Response:

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -366,6 +366,15 @@ class RESTApiHandler:
         LOG.info(f"PATCH folder with ID {folder} was successful.")
         return web.Response(body=body, status=200, content_type="application/json")
 
+    async def publish_folder(self, req: Request) -> Response:
+        """Update object folder specifically into published state.
+
+        :param req: PATCH request
+        :raises: HTTP 400 if something fails during processing the request
+        :returns: JSON response containing folder ID for updated folder
+        """
+        return web.HTTPNotImplemented()
+
     async def delete_folder(self, req: Request) -> Response:
         """Delete object folder from database.
 

--- a/metadata_backend/api/operators.py
+++ b/metadata_backend/api/operators.py
@@ -574,6 +574,7 @@ class FolderOperator:
         folder_id = self._generate_folder_id()
         data["folderId"] = folder_id
         data["published"] = False
+        data["metadataObjects"], data["drafts"] = [], []
         try:
             insert_success = await self.db_service.create("folder", data)
         except (ConnectionFailure, OperationFailure) as error:

--- a/metadata_backend/helpers/schemas/folders.json
+++ b/metadata_backend/helpers/schemas/folders.json
@@ -43,6 +43,28 @@
           }
         }
       }
+    },
+    "drafts": {
+      "type": "array",
+      "title": "The drafts schema",
+      "items": {
+        "type": "object",
+        "title": "Folder objects",
+        "required": [
+            "accessionId",
+            "schema"
+        ],
+        "properties": {
+          "accessionId": {
+            "type": "string",
+            "title": "Accession Id"
+          },
+          "schema": {
+            "type": "string",
+            "title": "Draft bbject's schema"
+          }
+        }
+      }
     }
   },
   "additionalProperties": false

--- a/metadata_backend/server.py
+++ b/metadata_backend/server.py
@@ -72,7 +72,7 @@ async def init() -> web.Application:
         web.get("/folders/{folderId}", rest_handler.get_folder),
         web.patch("/folders/{folderId}", rest_handler.patch_folder),
         web.delete("/folders/{folderId}", rest_handler.delete_folder),
-        web.get("/folders/publish/{folderId}", rest_handler.publish_folder),
+        web.patch("/publish/{folderId}", rest_handler.publish_folder),
         web.get("/users/{userId}", rest_handler.get_user),
         web.patch("/users/{userId}", rest_handler.patch_user),
         web.delete("/users/{userId}", rest_handler.delete_user),

--- a/metadata_backend/server.py
+++ b/metadata_backend/server.py
@@ -72,6 +72,7 @@ async def init() -> web.Application:
         web.get("/folders/{folderId}", rest_handler.get_folder),
         web.patch("/folders/{folderId}", rest_handler.patch_folder),
         web.delete("/folders/{folderId}", rest_handler.delete_folder),
+        web.get("/folders/publish/{folderId}", rest_handler.publish_folder),
         web.get("/users/{userId}", rest_handler.get_user),
         web.patch("/users/{userId}", rest_handler.patch_user),
         web.delete("/users/{userId}", rest_handler.delete_user),

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -406,9 +406,7 @@ async def test_crud_folders_works():
 
         # Create draft from test XML file and patch the draft into the newly created folder
         draft_id = await post_draft(sess, "sample", "SRS001433.xml")
-        patch1 = [
-            {"op": "add", "path": "/drafts", "value": [{"accessionId": draft_id, "schema": "sample"}]}
-        ]
+        patch1 = [{"op": "add", "path": "/drafts", "value": [{"accessionId": draft_id, "schema": "sample"}]}]
         folder_id = await patch_folder(sess, folder_id, patch1)
         async with sess.get(f"{folders_url}/{folder_id}") as resp:
             LOG.debug(f"Checking that folder {folder_id} was patched")
@@ -423,7 +421,7 @@ async def test_crud_folders_works():
         # Get the draft from the collection within this session and post it to objects collection
         draft = await get_draft(sess, "sample", draft_id)
         async with sess.post(f"{base_url}/sample", data=draft) as resp:
-            LOG.debug(f"Adding draft to actual objects")
+            LOG.debug("Adding draft to actual objects")
             assert resp.status == 201, "HTTP Status code error"
             ans = await resp.json()
             assert ans["accessionId"] != draft_id, "content mismatch"
@@ -432,7 +430,7 @@ async def test_crud_folders_works():
         # Patch folder so that original draft is moved to objects array
         patch2 = [
             {"op": "add", "path": "/metadataObjects", "value": [{"accessionId": accession_id, "schema": "sample"}]},
-            {"op": "remove", "path": "/drafts/0"}
+            {"op": "remove", "path": "/drafts/0"},
         ]
         folder_id = await patch_folder(sess, folder_id, patch2)
         async with sess.get(f"{folders_url}/{folder_id}") as resp:

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -44,6 +44,7 @@ drafts_url = "http://localhost:5430/drafts"
 folders_url = "http://localhost:5430/folders"
 users_url = "http://localhost:5430/users"
 submit_url = "http://localhost:5430/submit"
+publish_url = "http://localhost:5430/publish"
 
 user_id = "USR12345678"
 test_user = {
@@ -194,7 +195,7 @@ async def patch_folder(sess, folder_id, patch):
 
 async def publish_folder(sess, folder_id):
     """Publish one object folder within session, return folderId."""
-    async with sess.get(f"{folders_url}/publish/{folder_id}") as resp:
+    async with sess.patch(f"{publish_url}/{folder_id}") as resp:
         LOG.debug(f"Publishing folder {folder_id}")
         assert resp.status == 200, "HTTP Status code error"
         ans = await resp.json()

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -613,6 +613,17 @@ class HandlersTestCase(AioHTTPTestCase):
         self.assertEqual(json_resp["folderId"], self.folder_id)
 
     @unittest_run_loop
+    async def test_folder_is_published(self):
+        """Test that folder would be published."""
+        self.MockedFolderOperator().update_folder.return_value = futurized(self.folder_id)
+        response = await self.client.get("/folders/publish/FOL12345678")
+        self.MockedFolderOperator().read_folder.assert_called_once()
+        self.MockedFolderOperator().update_folder.assert_called_once()
+        self.assertEqual(response.status, 200)
+        json_resp = await response.json()
+        self.assertEqual(json_resp["folderId"], self.folder_id)
+
+    @unittest_run_loop
     async def test_folder_deletion_is_called(self):
         """Test that folder would be deleted."""
         response = await self.client.delete("/folders/FOL12345678")

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -48,6 +48,7 @@ class HandlersTestCase(AioHTTPTestCase):
             "description": "test folder",
             "published": False,
             "metadataObjects": [],
+            "drafts": [],
         }
         self.user_id = "USR12345678"
         self.test_user = {

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -616,7 +616,7 @@ class HandlersTestCase(AioHTTPTestCase):
     async def test_folder_is_published(self):
         """Test that folder would be published."""
         self.MockedFolderOperator().update_folder.return_value = futurized(self.folder_id)
-        response = await self.client.get("/folders/publish/FOL12345678")
+        response = await self.client.patch("/publish/FOL12345678")
         self.MockedFolderOperator().read_folder.assert_called_once()
         self.MockedFolderOperator().update_folder.assert_called_once()
         self.assertEqual(response.status, 200)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -43,7 +43,7 @@ class AppTestCase(AioHTTPTestCase):
     async def test_api_routes_are_set(self):
         """Test correct amount of api (no frontend) routes is set."""
         server = await self.get_application()
-        self.assertIs(len(server.router.resources()), 14)
+        self.assertIs(len(server.router.resources()), 15)
 
     @unittest_run_loop
     async def test_frontend_routes_are_set(self):


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
As discussed, a refactoring to the way drafts are stored in folders was in place. The current idea with the `publish_folder` endpoint in this PR is that the drafts in the `drafts` key of the folder that is to be published are removed from the database and the folder is simultaneously patched so that the drafts are removed from the folder.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Breaking change (or not exactly breaking but somewhat altering and requires a change to frontend)

### Changes Made

<!-- List changes made. -->

- added `drafts` key to the folders
- updated to the OpenApi specs and json schema
- created new endpoint for publishing a folder
- updated the existing integration test for folders
- other general style fixes 

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests
- [x] Integration Tests

