### PR TITLE
set defaults to mock auth instead of leaving empty

### DIFF
--- a/tests/integration/mock_auth.py
+++ b/tests/integration/mock_auth.py
@@ -30,12 +30,12 @@ def generate_token() -> Tuple:
     return (public_jwk, private_jwk)
 
 
-nonce = ""
+nonce = "defaultnonce"
 jwk_pair = generate_token()
 
-user_eppn = ""
-user_given_name = ""
-user_family_name = ""
+user_eppn = "default@user.smth"
+user_given_name = "default"
+user_family_name = "user"
 
 header = {"jku": "http://mockauth:8000/jwk", "kid": "rsa1", "alg": "RS256", "typ": "JWT"}
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->

instead of leaving info empty use some default values. Not really a bug but can be treated as one if frontend is not properly set.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

The previous values will display notthing in the frontend if a user is not set using `/setmock` endpoint

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


### Changes Made

<!-- List changes made. -->
1. change to default values for jwt payload

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->


- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
