### PR TITLE
allow tags un folder objects & specify submissionType tag

### DIFF
--- a/docs/specification.yml
+++ b/docs/specification.yml
@@ -1262,6 +1262,15 @@ components:
               schema:
                 type: string
                 description: type of schema this Accession ID relates to and was added in submit
+              tags:
+                type: object
+                description: Different tags to describe the object.
+                additionalProperties: true
+                properties:
+                  submissionType:
+                    type: string
+                    description: Type of submission
+                    enum: ["XML", "Form"]
         drafts:
           type: array
           items:
@@ -1277,6 +1286,15 @@ components:
               schema:
                 type: string
                 description: type of schema this Accession ID relates to and was added in submit
+              tags:
+                type: object
+                description: Different tags to describe the object.
+                additionalProperties: true
+                properties:
+                  submissionType:
+                    type: string
+                    description: Type of submission
+                    enum: ["XML", "Form"]
     FolderList:
       type: object
       required:

--- a/metadata_backend/helpers/schemas/folders.json
+++ b/metadata_backend/helpers/schemas/folders.json
@@ -29,8 +29,8 @@
         "type": "object",
         "title": "Folder objects",
         "required": [
-            "accessionId",
-            "schema"
+          "accessionId",
+          "schema"
         ],
         "properties": {
           "accessionId": {
@@ -40,6 +40,21 @@
           "schema": {
             "type": "string",
             "title": "Object's schema"
+          },
+          "tags": {
+            "type": "object",
+            "title": "Different tags to describe the object.",
+            "additionalProperties": true,
+            "properties": {
+              "submissionType": {
+                "type": "string",
+                "title": "Type of submission",
+                "enum": [
+                  "XML",
+                  "Form"
+                ]
+              }
+            }
           }
         }
       }
@@ -51,8 +66,8 @@
         "type": "object",
         "title": "Folder objects",
         "required": [
-            "accessionId",
-            "schema"
+          "accessionId",
+          "schema"
         ],
         "properties": {
           "accessionId": {
@@ -62,6 +77,21 @@
           "schema": {
             "type": "string",
             "title": "Draft bbject's schema"
+          },
+          "tags": {
+            "type": "object",
+            "title": "Different tags to describe the object.",
+            "additionalProperties": true,
+            "properties": {
+              "submissionType": {
+                "type": "string",
+                "title": "Type of submission",
+                "enum": [
+                  "XML",
+                  "Form"
+                ]
+              }
+            }
           }
         }
       }

--- a/metadata_backend/helpers/validator.py
+++ b/metadata_backend/helpers/validator.py
@@ -139,12 +139,12 @@ class JSONValidator:
             raise web.HTTPBadRequest(reason=reason)
         except ValidationError as e:
             if len(e.path) > 0:
-                reason = f"Provided input " f"does not seem correct for field: '{e.path[0]}'"
+                reason = f"Provided input does not seem correct for field: '{e.path[0]}'"
                 LOG.debug(f"Provided json input: '{e.instance}'")
                 LOG.error(reason)
                 raise web.HTTPBadRequest(reason=reason)
             else:
-                reason = f"Provided input " f"does not seem correct because: '{e.message}'"
+                reason = f"Provided input does not seem correct because: '{e.message}'"
                 LOG.debug(f"Provided json input: '{e.instance}'")
                 LOG.error(reason)
                 raise web.HTTPBadRequest(reason=reason)

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -494,7 +494,6 @@ async def test_crud_folders_works(sess):
     async with sess.get(f"{users_url}/current") as resp:
         LOG.debug(f"Checking that folder {folder_id} was deleted from current user")
         res = await resp.json()
-        print(res)
         expected_true = not any(d == accession_id for d in res["folders"])
         assert expected_true, "folder still exists at user"
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -98,14 +98,24 @@ class ParserTestCase(unittest.TestCase):
     def test_json_patch_mongo_conversion(self):
         """Test json patch to mongo query conversion."""
         json_patch = [
-            {"op": "add", "path": "/metadataObjects/-", "value": {"accessionId": "id", "schema": "study"}},
+            {
+                "op": "add",
+                "path": "/metadataObjects/-",
+                "value": {"accessionId": "id", "schema": "study", "tags": {"submissionType": "XML"}},
+            },
             {"op": "add", "path": "/drafts", "value": []},
             {"op": "replace", "path": "/published", "value": True},
         ]
         expected_mongo = [
             UpdateOne(
                 {"accessionId": "id"},
-                {"$addToSet": {"metadataObjects": {"$each": [{"accessionId": "id", "schema": "study"}]}}},
+                {
+                    "$addToSet": {
+                        "metadataObjects": {
+                            "$each": [{"accessionId": "id", "schema": "study", "tags": {"submissionType": "XML"}}]
+                        }
+                    }
+                },
                 False,
                 None,
                 None,
@@ -116,5 +126,4 @@ class ParserTestCase(unittest.TestCase):
         ]
 
         result = jsonpatch_mongo({"accessionId": "id"}, json_patch)
-        print(result)
         self.assertEqual(result, expected_mongo)


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

https://github.com/CSCfi/metadata-submitter-frontend/issues/94

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)


### Changes Made

<!-- List changes made. -->
I added something like this to `metadataObjects` and `drafts` in `fodlers` to make it more extensible. Notice the `tags` key where anything can be added and used by front-end but by default only `submissionType` can take either `XML` or `Form`

```
"metadataObjects": [{"accessionId": "id", "schema": "study", "tags": {"submissionType": "XML"}}]

```
Update can happen like
```
{
                "op": "add",
                "path": "/metadataObjects/-",
                "value": {"accessionId": "id", "schema": "study", "tags": {"submissionType": "XML"}},
}
```

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
