### PR TITLE
enable PATCH for objects

### DIFF
--- a/metadata_backend/server.py
+++ b/metadata_backend/server.py
@@ -68,6 +68,7 @@ async def init() -> web.Application:
         web.get("/drafts/{schema}/{accessionId}", rest_handler.get_object),
         web.put("/drafts/{schema}/{accessionId}", rest_handler.put_object),
         web.patch("/drafts/{schema}/{accessionId}", rest_handler.patch_object),
+        web.patch("/objects/{schema}/{accessionId}", rest_handler.patch_object),
         web.delete("/drafts/{schema}/{accessionId}", rest_handler.delete_object),
         web.post("/drafts/{schema}", rest_handler.post_object),
         web.get("/folders", rest_handler.get_folders),

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -43,7 +43,7 @@ class AppTestCase(AioHTTPTestCase):
     async def test_api_routes_are_set(self):
         """Test correct amount of api (no frontend) routes is set."""
         server = await self.get_application()
-        self.assertIs(len(server.router.resources()), 16)
+        self.assertIs(len(server.router.resources()), 18)
 
     @unittest_run_loop
     async def test_frontend_routes_are_set(self):


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
Enable HTTP `PATCH` for `objects
### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
https://github.com/CSCfi/metadata-submitter-frontend/issues/144
### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->


- [x] New feature (non-breaking change which adds functionality)


### Changes Made

<!-- List changes made. -->
1. Enable HTTP `PATCH` for `objects` in `server.py`

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
