### PR TITLE
allow put XML objects

### DIFF
--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -404,9 +404,7 @@ class RESTApiHandler:
             if not req.path.startswith("/drafts"):
                 reason = "Replacing objects only allowed for XML."
                 LOG.error(reason)
-                raise web.HTTPMethodNotAllowed(
-                    method="PUT", allowed_methods=["POST", "GET", "PATCH", "DELETE"], reason=reason
-                )
+                raise web.HTTPUnsupportedMediaType(reason=reason)
             operator = Operator(db_client)
 
         await operator.check_exists(collection, accession_id)

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -402,7 +402,11 @@ class RESTApiHandler:
         else:
             content = await self._get_data(req)
             if not req.path.startswith("/drafts"):
-                JSONValidator(content, schema_type).validate
+                reason = "Replacing objects only allowed for XML."
+                LOG.error(reason)
+                raise web.HTTPMethodNotAllowed(
+                    method="PUT", allowed_methods=["POST", "GET", "PATCH", "DELETE"], reason=reason
+                )
             operator = Operator(db_client)
 
         await operator.check_exists(collection, accession_id)

--- a/metadata_backend/server.py
+++ b/metadata_backend/server.py
@@ -65,6 +65,7 @@ async def init() -> web.Application:
         web.delete("/objects/{schema}/{accessionId}", rest_handler.delete_object),
         web.get("/objects/{schema}", rest_handler.query_objects),
         web.post("/objects/{schema}", rest_handler.post_object),
+        web.put("/objects/{schema}/{accessionId}", rest_handler.put_object),
         web.get("/drafts/{schema}/{accessionId}", rest_handler.get_object),
         web.put("/drafts/{schema}/{accessionId}", rest_handler.put_object),
         web.patch("/drafts/{schema}/{accessionId}", rest_handler.patch_object),

--- a/tests/test_files/study/SRP000539_put.xml
+++ b/tests/test_files/study/SRP000539_put.xml
@@ -1,0 +1,34 @@
+<STUDY_SET>
+    <STUDY center_name="GEO" alias="GSE10966">
+        <IDENTIFIERS>
+            <PRIMARY_ID>SRP000539</PRIMARY_ID>
+            <EXTERNAL_ID namespace="BioProject" label="primary">PRJNA108793</EXTERNAL_ID>
+            <EXTERNAL_ID namespace="GEO">GSE10966</EXTERNAL_ID>
+        </IDENTIFIERS>
+        <DESCRIPTOR>
+            <STUDY_TITLE>Highly integrated epigenome maps in Arabidopsis - whole genome shotgun bisulfite sequencing
+            </STUDY_TITLE>
+            <STUDY_TYPE existing_study_type="Other"/>
+            <STUDY_ABSTRACT>Part of a set of highly integrated epigenome maps for Arabidopsis thaliana. Keywords:
+                Illumina high-throughput bisulfite sequencing Overall design: Whole genome shotgun bisulfite sequencing
+                of wildtype Arabidopsis plants (Columbia-0), and met1, drm1 drm2 cmt3, and ros1 dml2 dml3 null mutants
+                using the Illumina Genetic Analyzer.
+            </STUDY_ABSTRACT>
+            <CENTER_PROJECT_NAME>GSE10966</CENTER_PROJECT_NAME>
+        </DESCRIPTOR>
+        <STUDY_LINKS>
+            <STUDY_LINK>
+                <XREF_LINK>
+                    <DB>pubmed</DB>
+                    <ID>18423832</ID>
+                </XREF_LINK>
+            </STUDY_LINK>
+        </STUDY_LINKS>
+        <STUDY_ATTRIBUTES>
+            <STUDY_ATTRIBUTE>
+                <TAG>parent_bioproject</TAG>
+                <VALUE>PRJNA107265</VALUE>
+            </STUDY_ATTRIBUTE>
+        </STUDY_ATTRIBUTES>
+    </STUDY>
+</STUDY_SET>

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -43,7 +43,7 @@ class AppTestCase(AioHTTPTestCase):
     async def test_api_routes_are_set(self):
         """Test correct amount of api (no frontend) routes is set."""
         server = await self.get_application()
-        self.assertIs(len(server.router.resources()), 18)
+        self.assertIs(len(server.router.resources()), 19)
 
     @unittest_run_loop
     async def test_frontend_routes_are_set(self):


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->

reintroduce `PUT` for `objects` but allow only for XMLs required in Front-end for https://github.com/CSCfi/metadata-submitter-frontend/issues/144

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

<!-- List changes made. -->
1. reintroduce `PUT` for `objects` but allow only for XMLs
2. add integration test for new functionality
3. refactor some variable names to make them clearer

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Integration Tests


### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
