### PR TITLE
adjust replace json patch to replace elements in folders

### DIFF
--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -367,7 +367,7 @@ class RESTApiHandler:
             current_user = req.app["Session"]["user_info"]
             check_user = await user_op.check_user_has_doc(collection, current_user, accession_id)
             if check_user:
-                collection = "drafts"
+                await user_op.remove_objects(current_user, "drafts", [accession_id])
             else:
                 reason = "This object does not seem to belong to anything."
                 LOG.error(reason)
@@ -728,7 +728,7 @@ class RESTApiHandler:
 
         for folder_id in user["folders"]:
             _folder = await fold_ops.read_folder(folder_id)
-            if not _folder["published"]:
+            if "published" in _folder and not _folder["published"]:
                 for obj in _folder["drafts"] + _folder["metadataObjects"]:
                     await obj_ops.delete_metadata_object(obj["schema"], obj["accessionId"])
                 await fold_ops.delete_folder(folder_id)

--- a/metadata_backend/helpers/parser.py
+++ b/metadata_backend/helpers/parser.py
@@ -258,9 +258,9 @@ def jsonpatch_mongo(identifier: Dict, json_patch: List[Dict[str, Any]]) -> List:
                     )
                 )
             else:
-                queries.append(UpdateOne(identifier, {"$set": {op["path"][1:]: op["value"]}}))
+                queries.append(UpdateOne(identifier, {"$set": {op["path"][1:].replace("/", "."): op["value"]}}))
         elif op["op"] == "replace":
-            path = op["path"][1:-2] if op["path"].endswith("/-") else op["path"][1:]
+            path = op["path"][1:-2] if op["path"].endswith("/-") else op["path"][1:].replace("/", ".")
             queries.append(UpdateOne(identifier, {"$set": {path: op["value"]}}))
 
     return queries

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -802,6 +802,38 @@ async def test_get_folders_objects(sess, folder_id: str):
         response = await resp.json()
         assert len(response["folders"]) == 1
         assert response["folders"][0]["metadataObjects"][0]["accessionId"] == accession_id
+        assert "tags" not in response["folders"][0]["metadataObjects"][0]
+    patch_add_more_object = [
+        {
+            "op": "add",
+            "path": "/metadataObjects/0/tags",
+            "value": {"submissionType": "Form"},
+        }
+    ]
+    await patch_folder(sess, folder_id, patch_add_more_object)
+    async with sess.get(f"{folders_url}") as resp:
+        LOG.debug(f"Reading folder {folders_url}")
+        assert resp.status == 200, "HTTP Status code error"
+        response = await resp.json()
+        assert len(response["folders"]) == 1
+        assert response["folders"][0]["metadataObjects"][0]["accessionId"] == accession_id
+        assert response["folders"][0]["metadataObjects"][0]["tags"]["submissionType"] == "Form"
+
+    patch_change_tags_object = [
+        {
+            "op": "replace",
+            "path": "/metadataObjects/0/tags",
+            "value": {"submissionType": "XML"},
+        }
+    ]
+    await patch_folder(sess, folder_id, patch_change_tags_object)
+    async with sess.get(f"{folders_url}") as resp:
+        LOG.debug(f"Reading folder {folders_url}")
+        assert resp.status == 200, "HTTP Status code error"
+        response = await resp.json()
+        assert len(response["folders"]) == 1
+        assert response["folders"][0]["metadataObjects"][0]["accessionId"] == accession_id
+        assert response["folders"][0]["metadataObjects"][0]["tags"]["submissionType"] == "XML"
 
 
 async def test_submissions_work(sess, folder_id):

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -958,7 +958,7 @@ class TestOperators(AsyncTestCase):
         operator = UserOperator(self.client)
         operator.db_service.exists.return_value = futurized(True)
         operator.db_service.remove.return_value = futurized(self.test_user)
-        await operator.remove_objects(self.user_generated_id, "study", [])
+        await operator.remove_objects(self.user_generated_id, "study", ["id"])
         operator.db_service.exists.assert_called_once()
         operator.db_service.remove.assert_called_once()
         self.assertEqual(len(operator.db_service.remove.mock_calls), 1)
@@ -969,7 +969,7 @@ class TestOperators(AsyncTestCase):
         operator.db_service.exists.return_value = futurized(True)
         operator.db_service.remove.side_effect = ConnectionFailure
         with self.assertRaises(HTTPBadRequest):
-            await operator.remove_objects(self.user_generated_id, "study", [])
+            await operator.remove_objects(self.user_generated_id, "study", ["id"])
 
     async def test_user_objects_append_passes(self):
         """Test append objects method for users works."""


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->

Add option to replace `tags` in object added in folder

to patch items in folders you need to know the position of the element you are trying to patch in the array of `metadataObjects` or `drafts`:
currently it is enabled for `tags` add:
```
  {
            "op": "add",
            "path": "/metadataObjects/0/tags",
            "value": {"submissionType": "Form"},
        }
```

replace:

```
{
            "op": "replace",
            "path": "/metadataObjects/0/tags",
            "value": {"submissionType": "XML"},
        }
```


### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
https://github.com/CSCfi/metadata-submitter-frontend/issues/144

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Changes Made

<!-- List changes made. -->
1. Add option to replace `tags` content element
2. fix bug, that prevented drafts been deleted correctly from users, and added tests for it.
3. make assert fail messages clearer in integration tests

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->


- [x] Integration Tests

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
