### PR TITLE
Single db make it work

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ For more detailed setup, do following:
     - `MONGO_USERNAME`, username for connecting to mondogdb instance
     - `MONGO_PASSWORD`, password for connecting to mondogdb instance
     - `MONGO_HOST`, host and port for mongodb instance (e.g. `localhost:27017`)
+    - `MONGO_DATABASE`, If a specific database is to be used, set the name here. 
+    - `MONGO_AUTHDB`, if `MONGO_DATABASE` is set and the user doesn't exists in the database, set this to the database where the user exists (e.g. `admin`)
   - Out of the box, metadata submitter is configured with default values from MongoDB Docker image
   - Suitable mongodb instance can be launched with Docker by running `docker-compose up database`
 - After installing and setting up database, server can be launched with `metadata_submitter`

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ For more detailed setup, do following:
 - Install project by running: `pip install .` in project root
 - Setup mongodb and env variables via desired way, details:
   - Server expects to find mongodb instance running, specified with following environment variables:
-    - `MONGO_INITDB_ROOT_USERNAME`, username for admin user to mondogdb instance
-    - `MONGO_INITDB_ROOT_PASSWORD`, password for admin user to mondogdb instance
+    - `MONGO_USERNAME`, username for connecting to mondogdb instance
+    - `MONGO_PASSWORD`, password for connecting to mondogdb instance
     - `MONGO_HOST`, host and port for mongodb instance (e.g. `localhost:27017`)
   - Out of the box, metadata submitter is configured with default values from MongoDB Docker image
   - Suitable mongodb instance can be launched with Docker by running `docker-compose up database`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,8 @@ services:
       - "AUTH_REFERER=http://mockauth:8000"
       - "JWK_URL=http://mockauth:8000/keyset"
       - "LOG_LEVEL=DEBUG"
+      - "MONGO_DATABASE=default"
+      - "MONGO_AUTHDB=admin"
   database:
     image: "mongo"
     container_name: "metadata_submitter_database_dev"

--- a/docs/submitter.rst
+++ b/docs/submitter.rst
@@ -18,13 +18,16 @@ the table below.
 +--------------------------------+-------------------------------+-----------------------------------------------------------------------------------+
 | ENV                            | Default                       | Description                                                                       |
 +--------------------------------+-------------------------------+-----------------------------------------------------------------------------------+
-| ``MONGO_HOST``                 | ``localhost:27017``           | Mongodb server hostname, with port specified if needed.                           |
+| ``MONGO_HOST``                 | ``localhost:27017``           | MongoDB server hostname, with port specified if needed.                           |
 +--------------------------------+-------------------------------+-----------------------------------------------------------------------------------+
-| ``MONGO_AUTHDB``               | ``-``                         | Mongodb authentication database.                                                  |
+| ``MONGO_AUTHDB``               | ``-``                         | MongoDB authentication database.                                                  |
 +--------------------------------+-------------------------------+-----------------------------------------------------------------------------------+
-| ``MONGO_INITDB_ROOT_USERNAME`` | ``admin``                     | Admin username for mongodb.                                                       |
+| ``MONGO_DATABASE``             | ``default``                   | MongoDB default database, will be used as authentication database if              |
+|                                |                               | ``MONGO_AUTHDB`` is not set.                                                      |
 +--------------------------------+-------------------------------+-----------------------------------------------------------------------------------+
-| ``MONGO_INITDB_ROOT_PASSWORD`` | ``admin``                     | Admin password for mongodb.                                                       |
+| ``MONGO_USERNAME``             | ``admin``                     | Admin username for MongoDB.                                                       |
++--------------------------------+-------------------------------+-----------------------------------------------------------------------------------+
+| ``MONGO_PASSWORD``             | ``admin``                     | Admin password for MongoDB.                                                       |
 +--------------------------------+-------------------------------+-----------------------------------------------------------------------------------+
 | ``MONGO_SSL``                  | ``-``                         | Set to True to enable MONGO TLS connection url.                                   |
 +--------------------------------+-------------------------------+-----------------------------------------------------------------------------------+
@@ -75,6 +78,12 @@ the table below.
 |                                |                               | for more information.                                                             |
 +--------------------------------+-------------------------------+-----------------------------------------------------------------------------------+
 
+
+.. note:: If just ``MONGO_DATABASE`` is specified it will autenticate the user against it.
+          If just ``MONGO_AUTHDB`` is specified it will autenticate the user against it.
+          If both ``MONGO_DATABASE`` and ``MONGO_AUTHDB`` are specified, the client will attempt to authenticate the specified user to the MONGO_AUTHDB database.
+          If both ``MONGO_DATABASE`` and ``MONGO_AUTHDB`` are unspecified, the client will attempt to authenticate the specified user to the admin database.
+
 Install and run
 ---------------
 
@@ -87,11 +96,11 @@ For installing ``metadata-submitter`` backend do the following:
 
 .. hint:: Before running the application have MongoDB running.
 
-    MongoDB Server expects to find mongodb instance running, spesified with following environmental variables:
+    MongoDB Server expects to find MongoDB instance running, spesified with following environmental variables:
 
     - ``MONGO_INITDB_ROOT_USERNAME`` (username for admin user to mondogdb instance)
     - ``MONGO_INITDB_ROOT_PASSWORD`` (password for admin user to mondogdb instance)
-    - ``MONGO_HOST`` (host and port for mongodb instancem, e.g. `localhost:27017`)
+    - ``MONGO_HOST`` (host and port for MongoDB instance, e.g. `localhost:27017`)
 
 To run the backend from command line use:
 

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -270,6 +270,7 @@ class RESTApiHandler:
         req_format = req.query.get("format", "json").lower()
         db_client = req.app["db_client"]
         operator = XMLOperator(db_client) if req_format == "xml" else Operator(db_client)
+        type_collection = f"backup-{collection}" if req_format == "xml" else collection
 
         await operator.check_exists(collection, accession_id)
 
@@ -279,7 +280,7 @@ class RESTApiHandler:
             LOG.error(reason)
             raise web.HTTPUnauthorized(reason=reason)
 
-        data, content_type = await operator.read_metadata_object(collection, accession_id)
+        data, content_type = await operator.read_metadata_object(type_collection, accession_id)
 
         data = data if req_format == "xml" else json.dumps(data)
         LOG.info(f"GET object with accesssion ID {accession_id} from schema {collection}.")

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -270,7 +270,7 @@ class RESTApiHandler:
         req_format = req.query.get("format", "json").lower()
         db_client = req.app["db_client"]
         operator = XMLOperator(db_client) if req_format == "xml" else Operator(db_client)
-        type_collection = f"backup-{collection}" if req_format == "xml" else collection
+        type_collection = f"xml-{collection}" if req_format == "xml" else collection
 
         await operator.check_exists(collection, accession_id)
 

--- a/metadata_backend/api/operators.py
+++ b/metadata_backend/api/operators.py
@@ -534,8 +534,10 @@ class XMLOperator(BaseOperator):
         schema = schema_type[6:] if schema_type.startswith("draft") else schema_type
         data_as_json = XMLToJSONParser().parse(schema, data)
         accession_id = await Operator(db_client)._format_data_to_create_and_add_to_db(schema_type, data_as_json)
-        LOG.debug(f"XMLOperator formatted data for {schema_type} to add to DB")
-        return await self._insert_formatted_object_to_db(schema_type, {"accessionId": accession_id, "content": data})
+        LOG.debug(f"XMLOperator formatted data for backup-{schema_type} to add to DB")
+        return await self._insert_formatted_object_to_db(
+            f"backup-{schema_type}", {"accessionId": accession_id, "content": data}
+        )
 
     async def _format_data_to_replace_and_add_to_db(self, schema_type: str, accession_id: str, data: str) -> str:
         """Format XML metadata object and add it to db.
@@ -555,9 +557,9 @@ class XMLOperator(BaseOperator):
         accession_id = await Operator(db_client)._format_data_to_replace_and_add_to_db(
             schema_type, accession_id, data_as_json
         )
-        LOG.debug(f"XMLOperator formatted data for {schema_type} to add to DB")
+        LOG.debug(f"XMLOperator formatted data for backup-{schema_type} to add to DB")
         return await self._replace_object_from_db(
-            schema_type, accession_id, {"accessionId": accession_id, "content": data}
+            f"backup-{schema_type}", accession_id, {"accessionId": accession_id, "content": data}
         )
 
     async def _format_data_to_update_and_add_to_db(self, schema_type: str, accession_id: str, data: str) -> str:

--- a/metadata_backend/api/operators.py
+++ b/metadata_backend/api/operators.py
@@ -11,7 +11,7 @@ from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorCursor
 from multidict import MultiDictProxy
 from pymongo.errors import ConnectionFailure, OperationFailure
 
-from ..conf.conf import query_map
+from ..conf.conf import query_map, mongo_database
 from ..database.db_service import DBService, auto_reconnect
 from ..helpers.logger import LOG
 from ..helpers.parser import XMLToJSONParser
@@ -297,7 +297,7 @@ class Operator(BaseOperator):
         running on same loop with aiohttp, so needs to be passed from aiohttp
         Application.
         """
-        super().__init__("objects", "application/json", db_client)
+        super().__init__(mongo_database, "application/json", db_client)
 
     async def query_metadata_database(
         self, schema_type: str, que: MultiDictProxy, page_num: int, page_size: int, filter_objects: List
@@ -517,7 +517,7 @@ class XMLOperator(BaseOperator):
         running on same loop with aiohttp, so needs to be passed from aiohttp
         Application.
         """
-        super().__init__("backups", "text/xml", db_client)
+        super().__init__(mongo_database, "text/xml", db_client)
 
     async def _format_data_to_create_and_add_to_db(self, schema_type: str, data: str) -> str:
         """Format XML metadata object and add it to db.
@@ -596,7 +596,7 @@ class FolderOperator:
         running on same loop with aiohttp, so needs to be passed from aiohttp
         Application.
         """
-        self.db_service = DBService("folders", db_client)
+        self.db_service = DBService(mongo_database, db_client)
 
     async def check_object_in_folder(self, collection: str, accession_id: str) -> Tuple[bool, str, bool]:
         """Check a object/draft is in a folder.
@@ -824,7 +824,7 @@ class UserOperator:
         running on same loop with aiohttp, so needs to be passed from aiohttp
         Application.
         """
-        self.db_service = DBService("users", db_client)
+        self.db_service = DBService(mongo_database, db_client)
 
     async def check_user_has_doc(self, collection: str, user_id: str, accession_id: str) -> bool:
         """Check a folder/draft belongs to user.

--- a/metadata_backend/api/operators.py
+++ b/metadata_backend/api/operators.py
@@ -534,9 +534,9 @@ class XMLOperator(BaseOperator):
         schema = schema_type[6:] if schema_type.startswith("draft") else schema_type
         data_as_json = XMLToJSONParser().parse(schema, data)
         accession_id = await Operator(db_client)._format_data_to_create_and_add_to_db(schema_type, data_as_json)
-        LOG.debug(f"XMLOperator formatted data for backup-{schema_type} to add to DB")
+        LOG.debug(f"XMLOperator formatted data for xml-{schema_type} to add to DB")
         return await self._insert_formatted_object_to_db(
-            f"backup-{schema_type}", {"accessionId": accession_id, "content": data}
+            f"xml-{schema_type}", {"accessionId": accession_id, "content": data}
         )
 
     async def _format_data_to_replace_and_add_to_db(self, schema_type: str, accession_id: str, data: str) -> str:
@@ -557,9 +557,9 @@ class XMLOperator(BaseOperator):
         accession_id = await Operator(db_client)._format_data_to_replace_and_add_to_db(
             schema_type, accession_id, data_as_json
         )
-        LOG.debug(f"XMLOperator formatted data for backup-{schema_type} to add to DB")
+        LOG.debug(f"XMLOperator formatted data for xml-{schema_type} to add to DB")
         return await self._replace_object_from_db(
-            f"backup-{schema_type}", accession_id, {"accessionId": accession_id, "content": data}
+            f"xml-{schema_type}", accession_id, {"accessionId": accession_id, "content": data}
         )
 
     async def _format_data_to_update_and_add_to_db(self, schema_type: str, accession_id: str, data: str) -> str:

--- a/metadata_backend/conf/conf.py
+++ b/metadata_backend/conf/conf.py
@@ -46,16 +46,31 @@ from ..helpers.logger import LOG
 mongo_user = os.getenv("MONGO_USERNAME", "admin")
 mongo_password = os.getenv("MONGO_PASSWORD", "admin")
 mongo_host = os.getenv("MONGO_HOST", "localhost:27017")
-mongo_authdb = os.getenv("MONGO_AUTHDB", "")
-_base = f"mongodb://{mongo_user}:{mongo_password}@{mongo_host}/{mongo_authdb}"
+mongo_database = os.getenv("MONGO_DATABASE", "")
+_base = f"mongodb://{mongo_user}:{mongo_password}@{mongo_host}/{mongo_database}"
 if bool(os.getenv("MONGO_SSL", None)):
     _ca = os.getenv("MONGO_SSL_CA", None)
     _key = os.getenv("MONGO_SSL_CLIENT_KEY", None)
     _cert = os.getenv("MONGO_SSL_CLIENT_CERT", None)
     tls = f"?tls=true&tlsCAFile={_ca}&ssl_keyfile={_key}&ssl_certfile={_cert}"
     url = f"{_base}{tls}"
+elif bool(os.getenv("MONGO_SSL", None)) and os.getenv("MONGO_AUTHDB", "") != "":
+    _ca = os.getenv("MONGO_SSL_CA", None)
+    _key = os.getenv("MONGO_SSL_CLIENT_KEY", None)
+    _cert = os.getenv("MONGO_SSL_CLIENT_CERT", None)
+    tls = f"?tls=true&tlsCAFile={_ca}&ssl_keyfile={_key}&ssl_certfile={_cert}"
+    _authdb = os.getenv("MONGO_AUTHDB", "")
+    auth = f"&authSource={_authdb}"
+    url = f"{_base}{tls}{auth}"
+elif os.getenv("MONGO_AUTHDB", "") != "":
+    _authdb = os.getenv("MONGO_AUTHDB", "")
+    auth = f"?authSource={_authdb}"
+    url = f"{_base}{auth}"
 else:
     url = _base
+
+if os.getenv("MONGO_DATABASE", "") == "":
+    mongo_database = "test"
 
 LOG.debug(f"mongodb connection string is {url}")
 

--- a/metadata_backend/conf/conf.py
+++ b/metadata_backend/conf/conf.py
@@ -34,6 +34,7 @@ and inserted here in projects Dockerfile.
 import json
 import os
 from pathlib import Path
+from distutils.util import strtobool
 
 from motor.motor_asyncio import AsyncIOMotorClient
 
@@ -55,13 +56,13 @@ mongo_password = os.getenv("MONGO_PASSWORD", "admin")
 mongo_host = os.getenv("MONGO_HOST", "localhost:27017")
 mongo_database = os.getenv("MONGO_DATABASE", "")
 _base = f"mongodb://{mongo_user}:{mongo_password}@{mongo_host}/{mongo_database}"
-if bool(os.getenv("MONGO_SSL", None)):
+if strtobool(os.getenv("MONGO_SSL", "False")):
     _ca = os.getenv("MONGO_SSL_CA", None)
     _key = os.getenv("MONGO_SSL_CLIENT_KEY", None)
     _cert = os.getenv("MONGO_SSL_CLIENT_CERT", None)
     tls = f"?tls=true&tlsCAFile={_ca}&ssl_keyfile={_key}&ssl_certfile={_cert}"
     url = f"{_base}{tls}"
-elif bool(os.getenv("MONGO_SSL", None)) and bool(os.getenv("MONGO_AUTHDB")):
+elif strtobool(os.getenv("MONGO_SSL", "False")) and bool(os.getenv("MONGO_AUTHDB")):
     _ca = os.getenv("MONGO_SSL_CA", None)
     _key = os.getenv("MONGO_SSL_CLIENT_KEY", None)
     _cert = os.getenv("MONGO_SSL_CLIENT_CERT", None)

--- a/metadata_backend/conf/conf.py
+++ b/metadata_backend/conf/conf.py
@@ -5,8 +5,8 @@ You need to specify the necessary environment variables for connecting to
 MongoDB.
 Currently in use:
 
-- ``MONGO_INITDB_ROOT_USERNAME`` - Admin username for mongodb
-- ``MONGO_INITDB_ROOT_PASSWORD`` - Admin password for mongodb
+- ``MONGO_USERNAME`` - Username for mongodb
+- ``MONGO_PASSWORD`` - Password for mongodb
 - ``MONGO_HOST`` - Mongodb server hostname, with port specified
 
 Admin access is needed in order to create new databases during runtime.
@@ -43,8 +43,8 @@ from ..helpers.logger import LOG
 # Set custom timeouts and other parameters here so they can be imported to
 # other modules if needed.
 
-mongo_user = os.getenv("MONGO_INITDB_ROOT_USERNAME", "admin")
-mongo_password = os.getenv("MONGO_INITDB_ROOT_PASSWORD", "admin")
+mongo_user = os.getenv("MONGO_USERNAME", "admin")
+mongo_password = os.getenv("MONGO_PASSWORD", "admin")
 mongo_host = os.getenv("MONGO_HOST", "localhost:27017")
 mongo_authdb = os.getenv("MONGO_AUTHDB", "")
 _base = f"mongodb://{mongo_user}:{mongo_password}@{mongo_host}/{mongo_authdb}"

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -376,7 +376,7 @@ class TestOperators(AsyncTestCase):
                 with patch("metadata_backend.api.operators.XMLToJSONParser"):
                     acc = await (operator._format_data_to_create_and_add_to_db("study", xml_data))
                     m_insert.assert_called_once_with(
-                        "backup-study", {"accessionId": self.accession_id, "content": xml_data}
+                        "xml-study", {"accessionId": self.accession_id, "content": xml_data}
                     )
                     self.assertEqual(acc, self.accession_id)
 
@@ -396,7 +396,7 @@ class TestOperators(AsyncTestCase):
                 with patch("metadata_backend.api.operators.XMLToJSONParser"):
                     acc = await (operator._format_data_to_replace_and_add_to_db("study", self.accession_id, xml_data))
                     m_insert.assert_called_once_with(
-                        "backup-study",
+                        "xml-study",
                         self.accession_id,
                         {"accessionId": self.accession_id, "content": xml_data},
                     )

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -375,7 +375,9 @@ class TestOperators(AsyncTestCase):
             ) as m_insert:
                 with patch("metadata_backend.api.operators.XMLToJSONParser"):
                     acc = await (operator._format_data_to_create_and_add_to_db("study", xml_data))
-                    m_insert.assert_called_once_with("study", {"accessionId": self.accession_id, "content": xml_data})
+                    m_insert.assert_called_once_with(
+                        "backup-study", {"accessionId": self.accession_id, "content": xml_data}
+                    )
                     self.assertEqual(acc, self.accession_id)
 
     async def test_correct_data_is_set_to_xml_when_replacing(self):
@@ -394,7 +396,7 @@ class TestOperators(AsyncTestCase):
                 with patch("metadata_backend.api.operators.XMLToJSONParser"):
                     acc = await (operator._format_data_to_replace_and_add_to_db("study", self.accession_id, xml_data))
                     m_insert.assert_called_once_with(
-                        "study",
+                        "backup-study",
                         self.accession_id,
                         {"accessionId": self.accession_id, "content": xml_data},
                     )


### PR DESCRIPTION
### Description

Not only makes using a single database logical sense it also makes it easier to perform backups of the database backend.

* Uses a dedicated database to store the metadata with the option to use a different database for authentication.
### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


### Changes Made

<!-- List changes made. -->
1. use one db and adjust for it
2. introduce configuration parameters for mongodb as described at: https://docs.mongodb.com/manual/reference/connection-string/
3. update documentation
4. 

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply
they still need to pass. and seems to work with current version of frontend `develop` branch


### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
Optimisations will be done in a follow-up PR.
thanks @jbygdell for starting this.