### PR TITLE
Include DOI information in the folder schema

### DIFF
--- a/docs/specification.yml
+++ b/docs/specification.yml
@@ -1290,7 +1290,8 @@ components:
         - published
         - metadataObjects
         - drafts
-        - doi
+        - doiInfo
+        - extraInfo
       additionalProperties: false
       properties:
         folderId:
@@ -1305,38 +1306,13 @@ components:
         published:
           type: boolean
           description: If folder is published or not
-        doi:
+        doiInfo:
           type: object
           required:
-            - identifier
-            - url
             - creators
             - titles
-            - publisher
             - subjects
-            - publicationYear
-            - resourceType
           properties:
-            identifier:
-              type: object
-              description: DOI id generated according to DOI recommendations
-              required:
-                - identifierType
-              properties:
-                identifierType:
-                  type: string
-                  example: "DOI"
-                doi:
-                  type: string
-                  description: Character string of DOI handle
-                  example: "prefix/suffix"
-                id:
-                  type: string
-                  description: Display url for DOI id
-                  example: "https://doi.org/prefix/suffix"
-            url:
-              type: string
-              description: URL of the digital location of the object
             creators:
               type: array
               items:
@@ -1366,23 +1342,6 @@ components:
                     type: array
                     items:
                       type: object
-            titles:
-              type: array
-              items:
-                type: object
-                properties:
-                  lang:
-                    type: string
-                    description: Language of the title
-                    example: "en"
-                  title:
-                    type: string
-                    description: Full title
-                  titleType:
-                    type: string
-            publisher:
-              type: string
-              description: Full name of publisher from Research Organization Registry
             subjects:
               type: array
               items:
@@ -1396,10 +1355,37 @@ components:
                     type: string
                     description: Subject scheme name
                     example: "Fields of Science and Technology (FOS)"
-            publicationYear:
-              type: integer
-              description: Year of publication
-              example: 2021
+        extraInfo:
+          type: object
+          required:
+            - identifier
+            - url
+            - resourceType
+            - publisher
+          properties:
+            identifier:
+              type: object
+              description: DOI id generated according to DOI recommendations
+              required:
+                - identifierType
+              properties:
+                identifierType:
+                  type: string
+                  example: "DOI"
+                doi:
+                  type: string
+                  description: Character string of DOI handle
+                  example: "prefix/suffix"
+                id:
+                  type: string
+                  description: Display url for DOI id
+                  example: "https://doi.org/prefix/suffix"
+            url:
+              type: string
+              description: URL of the digital location of the object
+            publisher:
+              type: string
+              description: Full name of publisher from Research Organization Registry
             resourceType:
               type: object
               required:

--- a/docs/specification.yml
+++ b/docs/specification.yml
@@ -1290,6 +1290,7 @@ components:
         - published
         - metadataObjects
         - drafts
+        - doi
       additionalProperties: false
       properties:
         folderId:
@@ -1304,6 +1305,113 @@ components:
         published:
           type: boolean
           description: If folder is published or not
+        doi:
+          type: object
+          required:
+            - identifier
+            - url
+            - creators
+            - titles
+            - publisher
+            - subjects
+            - publicationYear
+            - resourceType
+          properties:
+            identifier:
+              type: object
+              description: DOI id generated according to DOI recommendations
+              required:
+                - identifierType
+              properties:
+                identifierType:
+                  type: string
+                  example: "DOI"
+                doi:
+                  type: string
+                  description: Character string of DOI handle
+                  example: "prefix/suffix"
+                id:
+                  type: string
+                  description: Display url for DOI id
+                  example: "https://doi.org/prefix/suffix"
+            url:
+              type: string
+              description: URL of the digital location of the object
+            creators:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    description: Full name
+                    example: "Last name, First name"
+                  nameType:
+                    type: string
+                    description: Type of name
+                    example: "Personal"
+                  givenName:
+                    type: string
+                    description: Official first name
+                    example: "First name"
+                  familyName:
+                    type: string
+                    description: Official last name
+                    example: "Last name"
+                  nameIdentifiers:
+                    type: array
+                    items:
+                      type: object
+                  affiliation:
+                    type: array
+                    items:
+                      type: object
+            titles:
+              type: array
+              items:
+                type: object
+                properties:
+                  lang:
+                    type: string
+                    description: Language of the title
+                    example: "en"
+                  title:
+                    type: string
+                    description: Full title
+                  titleType:
+                    type: string
+            publisher:
+              type: string
+              description: Full name of publisher from Research Organization Registry
+            subjects:
+              type: array
+              items:
+                type: object
+                properties:
+                  subject:
+                    type: string
+                    description: FOS defined subject name
+                    example: "FOS: field"
+                  subjectScheme:
+                    type: string
+                    description: Subject scheme name
+                    example: "Fields of Science and Technology (FOS)"
+            publicationYear:
+              type: integer
+              description: Year of publication
+              example: 2021
+            resourceType:
+              type: object
+              required:
+                - resourceTypeGeneral
+              properties:
+                resourceTypeGeneral:
+                  type: string
+                  description: Mandatory general type name
+                  example: "Dataset"
+                type:
+                  type: string
+                  description: Name of resource type
         metadataObjects:
           type: array
           items:

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -501,7 +501,7 @@ class FolderAPIHandler(RESTAPIHandler):
                     raise web.HTTPBadRequest(reason=reason)
                 pass
             else:
-                if all(i not in op["path"] for i in _required_paths + _arrays):
+                if all(i not in op["path"] for i in _required_paths + _arrays + ["/doi"]):
                     reason = f"Request contains '{op['path']}' key that cannot be updated to folders."
                     LOG.error(reason)
                     raise web.HTTPBadRequest(reason=reason)

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -501,7 +501,7 @@ class FolderAPIHandler(RESTAPIHandler):
                     raise web.HTTPBadRequest(reason=reason)
                 pass
             else:
-                if all(i not in op["path"] for i in _required_paths + _arrays + ["/doi"]):
+                if all(i not in op["path"] for i in _required_paths + _arrays + ["/doiInfo"]):
                     reason = f"Request contains '{op['path']}' key that cannot be updated to folders."
                     LOG.error(reason)
                     raise web.HTTPBadRequest(reason=reason)
@@ -645,9 +645,9 @@ class FolderAPIHandler(RESTAPIHandler):
 
         # Validate against folders schema if DOI is being added
         for op in patch_ops:
-            if op["path"] == "/doi":
+            if op["path"] == "/doiInfo":
                 curr_folder = await operator.read_folder(folder_id)
-                curr_folder["doi"] = op["value"]
+                curr_folder["doiInfo"] = op["value"]
                 JSONValidator(curr_folder, "folders").validate
 
         await self._handle_check_ownedby_user(req, "folders", folder_id)

--- a/metadata_backend/api/handlers.py
+++ b/metadata_backend/api/handlers.py
@@ -489,7 +489,7 @@ class FolderAPIHandler(RESTAPIHandler):
         """
         _required_paths = ["/name", "/description"]
         _required_values = ["schema", "accessionId"]
-        _arrays = ["/metadataObjects/-", "/drafts/-"]
+        _arrays = ["/metadataObjects/-", "/drafts/-", "/doiInfo"]
         _tags = re.compile("^/(metadataObjects|drafts)/[0-9]*/(tags)$")
 
         for op in patch_ops:
@@ -501,7 +501,7 @@ class FolderAPIHandler(RESTAPIHandler):
                     raise web.HTTPBadRequest(reason=reason)
                 pass
             else:
-                if all(i not in op["path"] for i in _required_paths + _arrays + ["/doiInfo"]):
+                if all(i not in op["path"] for i in _required_paths + _arrays):
                     reason = f"Request contains '{op['path']}' key that cannot be updated to folders."
                     LOG.error(reason)
                     raise web.HTTPBadRequest(reason=reason)
@@ -513,7 +513,7 @@ class FolderAPIHandler(RESTAPIHandler):
                     reason = f"{op['op']} on {op['path']}; replacing all objects is not allowed."
                     LOG.error(reason)
                     raise web.HTTPUnauthorized(reason=reason)
-                if op["path"] in _arrays:
+                if op["path"] in _arrays and op["path"] != "/doiInfo":
                     _ops = op["value"] if isinstance(op["value"], list) else [op["value"]]
                     for item in _ops:
                         if not all(key in item.keys() for key in _required_values):

--- a/metadata_backend/helpers/schemas/folders.json
+++ b/metadata_backend/helpers/schemas/folders.json
@@ -26,6 +26,157 @@
       "type": "boolean",
       "title": "Published Folder"
     },
+    "doi": {
+      "type": "object",
+      "title": "The DOI schema",
+      "required": [
+        "identifier",
+        "url",
+        "creators",
+        "titles",
+        "publisher",
+        "subjects",
+        "publicationYear",
+        "resourceType",
+      ],
+      "properties": {
+        "identifier": {
+          "type": "object",
+          "title": "DOI id generated according to DOI recommendations",
+          "required": [
+            "identifierType"
+          ],
+          "properties": {
+            "identifierType": {
+              "type": "string",
+              "title": "Type of identifier (= DOI)"
+            },
+            "doi": {
+              "type": "string",
+              "title": "Character string of DOI handle"
+            },
+            "id": {
+              "type": "string",
+              "title": "Display url for DOI id"
+            }
+          }
+        },
+        "url": {
+          "type": "string",
+          "title": "URL of the digital location of the object"
+        },
+        "creators": {
+          "type": "array",
+          "title": "List of creators",
+          "items": {
+            "type": "object",
+            "title": "Creator objects",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Full name"
+              },
+              "nameType": {
+                "type": "string",
+                "title": "Type of name"
+              },
+              "givenName": {
+                "type": "string",
+                "title": "First name"
+              },
+              "familyName": {
+                "type": "string",
+                "title": "Last name"
+              },
+              "nameIdentifiers": {
+                "type": "array",
+                "title": "List of name identifiers",
+                "items": {
+                  "type": "object",
+                  "title": "Name identifier object"
+                }
+              },
+              "affiliation": {
+                "type": "array",
+                "title": "List of affiliations",
+                "items": {
+                  "type": "object",
+                  "title": "Name affiliation object"
+                }
+              },
+            }
+          },
+          "uniqueItems": true
+        },
+        "titles": {
+          "type": "array",
+          "title": "List of titles (in different languages)",
+          "items": {
+            "type": "object",
+            "title": "Title objects",
+            "properties": {
+              "lang": {
+                "type": "string",
+                "title": "Language of the title"
+              },
+              "title": {
+                "type": "string",
+                "title": "Full title"
+              },
+              "titleType": {
+                "type": "string",
+                "title": "Type of title"
+              }
+            }
+          },
+          "uniqueItems": true
+        },
+        "publisher": {
+          "type": "string",
+          "title": "Full name of publisher from Research Organization Registry"
+        },
+        "subjects": {
+          "type": "array",
+          "title": "List of subjects specified by FOS",
+          "items": {
+            "type": "object",
+            "title": "Subject objects",
+            "properties": {
+              "subject": {
+                "type": "string",
+                "title": "FOS defined subject name"
+              },
+              "subjectScheme": {
+                "type": "string",
+                "title": "Subject scheme name"
+              }
+            }
+          },
+          "uniqueItems": true
+        },
+        "publicationYear": {
+          "type": "integer",
+          "title": "Year of publication"
+        },
+        "resourceType": {
+          "type": "object",
+          "title": "Type info of the resource",
+          "required": [
+            "resourceTypeGeneral"
+          ],
+          "properties": {
+            "resourceTypeGeneral": {
+              "type": "string",
+              "title": "Mandatory general type name"
+            },
+            "type": {
+              "type": "string",
+              "title": "Name of resource type"
+            }
+          }
+        }
+      }
+    },
     "metadataObjects": {
       "type": "array",
       "title": "The metadataObjects schema",

--- a/metadata_backend/helpers/schemas/folders.json
+++ b/metadata_backend/helpers/schemas/folders.json
@@ -19,7 +19,7 @@
       "title": "Folder Description"
     },
     "dateCreated": {
-      "type": "int",
+      "type": "integer",
       "title": "Unix time stamp of creation, used for indexing"
     },
     "published": {

--- a/metadata_backend/helpers/schemas/folders.json
+++ b/metadata_backend/helpers/schemas/folders.json
@@ -93,15 +93,15 @@
                   "title": "Name identifier object",
                   "properties": {
                     "schemeUri": {
-                      "type": "string",
+                      "type": ["string", "null"],
                       "title": "URI (location) of the name identifier scheme"
                     },
                     "nameIdentifier": {
-                      "type": "string",
+                      "type": ["string", "null"],
                       "title": "URI (location) of name identifier"
                     },
                     "nameIdentifierScheme": {
-                      "type": "string",
+                      "type": ["string", "null"],
                       "title": "Name of name identifier scheme"
                     }
                   }
@@ -156,7 +156,7 @@
                 "title": "A name or title by which a resource is known"
               },
               "titleType": {
-                "type": "string",
+                "type": ["string", "null"],
                 "title": "Type of title"
               }
             },
@@ -252,15 +252,15 @@
                   "title": "Name identifier object",
                   "properties": {
                     "schemeUri": {
-                      "type": "string",
+                      "type": ["string", "null"],
                       "title": "URI (location) of the name identifier scheme"
                     },
                     "nameIdentifier": {
-                      "type": "string",
+                      "type": ["string", "null"],
                       "title": "Location of name identifier"
                     },
                     "nameIdentifierScheme": {
-                      "type": "string",
+                      "type": ["string", "null"],
                       "title": "Name of name identifier scheme"
                     }
                   }
@@ -570,19 +570,19 @@
                 "title": "Type of identifier for funding entity"
               },
               "schemeUri": {
-                "type": "string",
+                "type": ["string", "null"],
                 "title": "URI (location) of scheme for funder identifier"
               },
               "awardNumber": {
-                "type": "string",
+                "type": ["string", "null"],
                 "title": "The code assigned by the funder to a sponsored award"
               },
               "awardTitle": {
-                "type": "string",
+                "type": ["string", "null"],
                 "title": "The human readable title of the award"
               },
               "awardUri": {
-                "type": "string",
+                "type": ["string", "null"],
                 "title": "URI (location) of the award"
               }
             },

--- a/metadata_backend/helpers/schemas/folders.json
+++ b/metadata_backend/helpers/schemas/folders.json
@@ -26,42 +26,14 @@
       "type": "boolean",
       "title": "Published Folder"
     },
-    "doi": {
+    "doiInfo": {
       "type": "object",
-      "title": "The DOI schema",
+      "title": "The DOI info schema",
       "required": [
-        "identifier",
-        "url",
         "creators",
-        "titles",
-        "publisher",
-        "subjects",
-        "publicationYear",
-        "resourceType"
+        "subjects"
       ],
       "properties": {
-        "identifier": {
-          "type": "object",
-          "title": "identifier object",
-          "required": [
-            "identifierType",
-            "doi"
-          ],
-          "properties": {
-            "identifierType": {
-              "type": "string",
-              "title": "Type of identifier (= DOI)"
-            },
-            "doi": {
-              "type": "string",
-              "title": "A persistent identifier for a resource"
-            }
-          }
-        },
-        "url": {
-          "type": "string",
-          "title": "URL of the digital location of the object"
-        },
         "creators": {
           "type": "array",
           "title": "List of creators",
@@ -140,34 +112,6 @@
           },
           "uniqueItems": true
         },
-        "titles": {
-          "type": "array",
-          "title": "List of titles",
-          "items": {
-            "type": "object",
-            "title": "Title objects",
-            "properties": {
-              "lang": {
-                "type": "string",
-                "title": "Language code of the title"
-              },
-              "title": {
-                "type": "string",
-                "title": "A name or title by which a resource is known"
-              },
-              "titleType": {
-                "type": ["string", "null"],
-                "title": "Type of title"
-              }
-            },
-            "additionalProperties": false
-          },
-          "uniqueItems": true
-        },
-        "publisher": {
-          "type": "string",
-          "title": "Full name of publisher from Research Organization Registry"
-        },
         "subjects": {
           "type": "array",
           "title": "List of subject identifiers specified by FOS",
@@ -190,29 +134,6 @@
             "additionalProperties": true
           },
           "uniqueItems": true
-        },
-        "publicationYear": {
-          "type": "integer",
-          "title": "Year when the data is made publicly available"
-        },
-        "resourceType": {
-          "type": "object",
-          "title": "Type info of the resource",
-          "required": [
-            "type",
-            "resourceTypeGeneral"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "title": "Name of resource type"
-            },
-            "resourceTypeGeneral": {
-              "type": "string",
-              "title": "Mandatory general type name"
-            }
-          },
-          "additionalProperties": false
         },
         "contributors": {
           "type": "array",
@@ -509,42 +430,6 @@
             "title": "Technical format of the resource"
           }
         },
-        "version": {
-          "type": "string",
-          "title": "Version number of the resource"
-        },
-        "rightsList": {
-          "type": "array",
-          "title": "List of any rights information",
-          "items": {
-            "type": "object",
-            "title": "Any rights information about the resource",
-            "properties": {
-              "lang": {
-                "type": "string",
-                "title": "Language code of the referenced rights"
-              },
-              "rightsUri": {
-                "type": "string",
-                "title": "URI (location) of the referenced rights"
-              },
-              "rightsIdentifier": {
-                "type": "string",
-                "title": "Title of the rights identifier"
-              },
-              "rightsIdentifierScheme": {
-                "type": "string",
-                "title": "Title of rights identifier scheme"
-              },
-              "schemeUri": {
-                "type": "string",
-                "title": "URI (location) of the scheme for rights"
-              }
-            },
-            "additionalProperties": false
-          },
-          "uniqueItems": true
-        },
         "fundingReferences": {
           "type": "array",
           "title": "List of funding references",
@@ -589,6 +474,62 @@
             "additionalProperties": false
           },
           "uniqueItems": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "extraInfo": {
+      "type": "object",
+      "title": "The extra DOI info schema",
+      "properties": {
+        "identifier": {
+          "type": "object",
+          "title": "identifier object",
+          "required": [
+            "identifierType",
+            "doi"
+          ],
+          "properties": {
+            "identifierType": {
+              "type": "string",
+              "title": "Type of identifier (= DOI)"
+            },
+            "doi": {
+              "type": "string",
+              "title": "A persistent identifier for a resource"
+            }
+          }
+        },
+        "publisher": {
+          "type": "string",
+          "title": "Full name of publisher from Research Organization Registry"
+        },
+        "resourceType": {
+          "type": "object",
+          "title": "Type info of the resource",
+          "required": [
+            "type",
+            "resourceTypeGeneral"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "title": "Name of resource type"
+            },
+            "resourceTypeGeneral": {
+              "type": "string",
+              "title": "Mandatory general type name"
+            }
+          },
+          "additionalProperties": false
+        },
+        "url": {
+          "type": "string",
+          "title": "URL of the digital location of the object"
+        },
+        "version": {
+          "type": "string",
+          "title": "Version number of the resource"
         }
       },
       "additionalProperties": false

--- a/metadata_backend/helpers/schemas/folders.json
+++ b/metadata_backend/helpers/schemas/folders.json
@@ -74,7 +74,7 @@
             "properties": {
               "name": {
                 "type": "string",
-                "title": "Full name"
+                "title": "Full name of creator"
               },
               "nameType": {
                 "type": "string",
@@ -93,7 +93,21 @@
                 "title": "List of name identifiers",
                 "items": {
                   "type": "object",
-                  "title": "Name identifier object"
+                  "title": "Name identifier object",
+                  "properties": {
+                    "schemeUri": {
+                      "type": "string",
+                      "title": "URI of the name identifier scheme"
+                    },
+                    "nameIdentifier": {
+                      "type": "string",
+                      "title": "Location of name identifier"
+                    },
+                    "nameIdentifierScheme": {
+                      "type": "string",
+                      "title": "Name of name identifier scheme"
+                    }
+                  }
                 }
               },
               "affiliation": {
@@ -101,7 +115,25 @@
                 "title": "List of affiliations",
                 "items": {
                   "type": "object",
-                  "title": "Name affiliation object"
+                  "title": "Name affiliation object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "title": "Name of the place of affiliation"
+                    },
+                    "schemeUri": {
+                      "type": "string",
+                      "title": "URI of the affiliation scheme"
+                    },
+                    "affiliationIdentifier": {
+                      "type": "string",
+                      "title": "Location of affiliation identifier"
+                    },
+                    "affiliationIdentifierScheme": {
+                      "type": "string",
+                      "title": "Name of affiliation identifier scheme"
+                    }
+                  }
                 }
               }
             }
@@ -110,7 +142,7 @@
         },
         "titles": {
           "type": "array",
-          "title": "List of titles (in different languages)",
+          "title": "List of titles",
           "items": {
             "type": "object",
             "title": "Title objects",
@@ -144,7 +176,7 @@
             "properties": {
               "subject": {
                 "type": "string",
-                "title": "FOS defined subject name"
+                "title": "FOS identifier"
               },
               "subjectScheme": {
                 "type": "string",
@@ -172,6 +204,196 @@
             "type": {
               "type": "string",
               "title": "Name of resource type"
+            }
+          }
+        },
+        "contributors": {
+          "type": "array",
+          "title": "List of contributors",
+          "items": {
+            "type": "object",
+            "title": "Contributor object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Full name of contributor"
+              },
+              "nameType": {
+                "type": "string",
+                "title": "Type of name"
+              },
+              "givenName": {
+                "type": "string",
+                "title": "First name"
+              },
+              "familyName": {
+                "type": "string",
+                "title": "Last name"
+              },
+              "contributorType": {
+                "type": "string",
+                "title": "Type of contributor"
+              },
+              "nameIdentifiers": {
+                "type": "array",
+                "title": "List of name identifiers",
+                "items": {
+                  "type": "object",
+                  "title": "Name identifier object",
+                  "properties": {
+                    "schemeUri": {
+                      "type": "string",
+                      "title": "URI of the name identifier scheme"
+                    },
+                    "nameIdentifier": {
+                      "type": "string",
+                      "title": "Location of name identifier"
+                    },
+                    "nameIdentifierScheme": {
+                      "type": "string",
+                      "title": "Name of name identifier scheme"
+                    }
+                  }
+                }
+              },
+              "affiliation": {
+                "type": "array",
+                "title": "List of affiliations",
+                "items": {
+                  "type": "object",
+                  "title": "Name affiliation object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "title": "Name of the place of affiliation"
+                    },
+                    "schemeUri": {
+                      "type": "string",
+                      "title": "URI of the affiliation scheme"
+                    },
+                    "affiliationIdentifier": {
+                      "type": "string",
+                      "title": "Location of affiliation identifier"
+                    },
+                    "affiliationIdentifierScheme": {
+                      "type": "string",
+                      "title": "Name of affiliation identifier scheme"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "dates": {
+          "type": "array",
+          "title": "List of relevant dates to publication",
+          "items": {
+            "type": "object",
+            "title": "Date object",
+            "properties": {
+              "date": {
+                "type": "string",
+                "title": "The date value"
+              },
+              "dateType": {
+                "type": "string",
+                "title": "Relevance of the date"
+              },
+              "dateInformation": {
+                "type": "string",
+                "title": "Specific event of the date"
+              }
+            }
+          }
+        },
+        "descriptions": {
+          "type": "array",
+          "title": "List of descriptions",
+          "items": {
+            "type": "object",
+            "title": "Description object",
+            "properties": {
+              "lang": {
+                "type": "string",
+                "title": "Language of the description"
+              },
+              "description": {
+                "type": "string",
+                "title": "Full description"
+              },
+              "descriptionType": {
+                "type": "string",
+                "title": "Type of description"
+              }
+            }
+          }
+        },
+        "geoLocations": {
+          "type": "array",
+          "title": "List of GeoLocations",
+          "items": {
+            "type": "object",
+            "title": "GeoLocation object",
+            "properties": {
+              "geoLocationPlace": {
+                "type": "string",
+                "title": "Name of GeoLocation"
+              },
+              "geoLocationPoint": {
+                "type": "object",
+                "title": "GeoLocation point object",
+                "properties": {
+                  "pointLongitude": {
+                    "type": "string",
+                    "title": "Longitude coordinate"
+                  },
+                  "pointLatitude": {
+                    "type": "string",
+                    "title": "Latitude coordinate"
+                  }
+                }
+              },
+              "geoLocationBox": {
+                "type": "object",
+                "title": "GeoLocation box object",
+                "properties": {
+                  "westBoundLongitude": {
+                    "type": "string",
+                    "title": "Longitude coordinate of west bound"
+                  },
+                  "eastBoundLongitude": {
+                    "type": "string",
+                    "title": "Longitude coordinate of east bound"
+                  },
+                  "southBoundLatitude": {
+                    "type": "string",
+                    "title": "Latitude coordinate of south bound"
+                  },
+                  "northBoundLatitude": {
+                    "type": "string",
+                    "title": "Latitude coordinate of north bound"
+                  }
+                }
+              },
+              "geoLocationPolygon": {
+                "type": "array",
+                "title": "List of polygon points",
+                "items": {
+                  "type": "object",
+                  "title": "Polygon point object",
+                  "properties": {
+                    "pointLongitude": {
+                      "type": "string",
+                      "title": "Longitude coordinate"
+                    },
+                    "pointLatitude": {
+                      "type": "string",
+                      "title": "Latitude coordinate"
+                    }
+                  }
+                }
+              }
             }
           }
         }

--- a/metadata_backend/helpers/schemas/folders.json
+++ b/metadata_backend/helpers/schemas/folders.json
@@ -42,9 +42,10 @@
       "properties": {
         "identifier": {
           "type": "object",
-          "title": "DOI id generated according to DOI recommendations",
+          "title": "identifier object",
           "required": [
-            "identifierType"
+            "identifierType",
+            "doi"
           ],
           "properties": {
             "identifierType": {
@@ -53,11 +54,7 @@
             },
             "doi": {
               "type": "string",
-              "title": "Character string of DOI handle"
-            },
-            "id": {
-              "type": "string",
-              "title": "Display url for DOI id"
+              "title": "A persistent identifier for a resource"
             }
           }
         },
@@ -70,11 +67,11 @@
           "title": "List of creators",
           "items": {
             "type": "object",
-            "title": "Creator objects",
+            "title": "Main researchers involved with data or the authors of the publication",
             "properties": {
               "name": {
                 "type": "string",
-                "title": "Full name of creator"
+                "title": "Full name of creator (format: Family, Given)"
               },
               "nameType": {
                 "type": "string",
@@ -108,7 +105,8 @@
                       "title": "Name of name identifier scheme"
                     }
                   }
-                }
+                },
+                "uniqueItems": true
               },
               "affiliation": {
                 "type": "array",
@@ -134,9 +132,11 @@
                       "title": "Name of affiliation identifier scheme"
                     }
                   }
-                }
+                },
+                "uniqueItems": true
               }
-            }
+            },
+            "additionalProperties": false
           },
           "uniqueItems": true
         },
@@ -149,17 +149,18 @@
             "properties": {
               "lang": {
                 "type": "string",
-                "title": "Language of the title"
+                "title": "Language code of the title"
               },
               "title": {
                 "type": "string",
-                "title": "Full title"
+                "title": "A name or title by which a resource is known"
               },
               "titleType": {
                 "type": "string",
                 "title": "Type of title"
               }
-            }
+            },
+            "additionalProperties": false
           },
           "uniqueItems": true
         },
@@ -169,10 +170,13 @@
         },
         "subjects": {
           "type": "array",
-          "title": "List of subjects specified by FOS",
+          "title": "List of subject identifiers specified by FOS",
           "items": {
             "type": "object",
             "title": "Subject objects",
+            "required": [
+              "subject"
+            ],
             "properties": {
               "subject": {
                 "type": "string",
@@ -182,41 +186,47 @@
                 "type": "string",
                 "title": "Subject scheme name"
               }
-            }
+            },
+            "additionalProperties": true
           },
           "uniqueItems": true
         },
         "publicationYear": {
           "type": "integer",
-          "title": "Year of publication"
+          "title": "Year when the data is made publicly available"
         },
         "resourceType": {
           "type": "object",
           "title": "Type info of the resource",
           "required": [
+            "type",
             "resourceTypeGeneral"
           ],
           "properties": {
-            "resourceTypeGeneral": {
-              "type": "string",
-              "title": "Mandatory general type name"
-            },
             "type": {
               "type": "string",
               "title": "Name of resource type"
+            },
+            "resourceTypeGeneral": {
+              "type": "string",
+              "title": "Mandatory general type name"
             }
-          }
+          },
+          "additionalProperties": false
         },
         "contributors": {
           "type": "array",
           "title": "List of contributors",
           "items": {
             "type": "object",
-            "title": "Contributor object",
+            "title": "The institution or person responsible for contributing to the developement of the dataset",
+            "required": [
+              "contributorType"
+            ],
             "properties": {
               "name": {
                 "type": "string",
-                "title": "Full name of contributor"
+                "title": "Full name of contributor (format: Family, Given)"
               },
               "nameType": {
                 "type": "string",
@@ -282,8 +292,10 @@
                   }
                 }
               }
-            }
-          }
+            },
+            "additionalProperties": false
+          },
+          "uniqueItems": true
         },
         "dates": {
           "type": "array",
@@ -291,10 +303,14 @@
           "items": {
             "type": "object",
             "title": "Date object",
+            "required": [
+              "date",
+              "dateType"
+            ],
             "properties": {
               "date": {
                 "type": "string",
-                "title": "The date value"
+                "title": "A standard format for a date value"
               },
               "dateType": {
                 "type": "string",
@@ -304,8 +320,10 @@
                 "type": "string",
                 "title": "Specific event of the date"
               }
-            }
-          }
+            },
+            "additionalProperties": false
+          },
+          "uniqueItems": true
         },
         "descriptions": {
           "type": "array",
@@ -316,18 +334,20 @@
             "properties": {
               "lang": {
                 "type": "string",
-                "title": "Language of the description"
+                "title": "Language code of the description"
               },
               "description": {
                 "type": "string",
-                "title": "Full description"
+                "title": "Additional information that does not fit in any of the other categories"
               },
               "descriptionType": {
                 "type": "string",
                 "title": "Type of description"
               }
-            }
-          }
+            },
+            "additionalProperties": false
+          },
+          "uniqueItems": true
         },
         "geoLocations": {
           "type": "array",
@@ -338,11 +358,11 @@
             "properties": {
               "geoLocationPlace": {
                 "type": "string",
-                "title": "Name of GeoLocation"
+                "title": "Spatial region or named place where the data was gathered"
               },
               "geoLocationPoint": {
                 "type": "object",
-                "title": "GeoLocation point object",
+                "title": "A point containing a single latitude-longitude pair",
                 "properties": {
                   "pointLongitude": {
                     "type": "string",
@@ -352,11 +372,12 @@
                     "type": "string",
                     "title": "Latitude coordinate"
                   }
-                }
+                },
+                "additionalProperties": false
               },
               "geoLocationBox": {
                 "type": "object",
-                "title": "GeoLocation box object",
+                "title": "A box determined by two longitude and two latitude borders",
                 "properties": {
                   "westBoundLongitude": {
                     "type": "string",
@@ -378,7 +399,7 @@
               },
               "geoLocationPolygon": {
                 "type": "array",
-                "title": "List of polygon points",
+                "title": "A drawn polygon area, defined by a set of polygon points",
                 "items": {
                   "type": "object",
                   "title": "Polygon point object",
@@ -394,19 +415,25 @@
                   }
                 }
               }
-            }
-          }
+            },
+            "additionalProperties": false
+          },
+          "uniqueItems": true
         },
         "language": {
           "type": "string",
-          "title": "Language code"
+          "title": "Code of the primary language of the resource"
         },
         "alternateIdentifiers": {
           "type": "array",
           "title": "List of alternate identifiers",
           "items": {
             "type": "object",
-            "title": "Alternate identifier object",
+            "title": "An identifier or identifiers other than the primary Identifier of the resource",
+            "required": [
+              "alternateIdentifier",
+              "alternateIdentifierType"
+            ],
             "properties": {
               "alternateIdentifier": {
                 "type": "string",
@@ -416,15 +443,22 @@
                 "type": "string",
                 "title": "Type of alternate identifier"
               }
-            }
-          }
+            },
+            "additionalProperties": false
+          },
+          "uniqueItems": true
         },
         "relatedIdentifiers": {
           "type": "array",
           "title": "List of related identifiers",
           "items": {
             "type": "object",
-            "title": "Related identifier object",
+            "title": "Identifier of related resources",
+            "required": [
+              "relatedIdentifier",
+              "relatedIdentifierType",
+              "relationType"
+            ],
             "properties": {
               "relatedIdentifier": {
                 "type": "string",
@@ -454,15 +488,17 @@
                 "type": "string",
                 "title": "Optional general type name"
               }
-            }
-          }
+            },
+            "additionalProperties": false
+          },
+          "uniqueItems": true
         },
         "sizes": {
           "type": "array",
           "title": "List of sizes",
           "items": {
             "type": "string",
-            "title": "Size or duration info about the resource"
+            "title": "Unstructured size information about the resource"
           }
         },
         "formats": {
@@ -482,7 +518,7 @@
           "title": "List of any rights information",
           "items": {
             "type": "object",
-            "title": "Rights object",
+            "title": "Any rights information about the resource",
             "properties": {
               "lang": {
                 "type": "string",
@@ -504,15 +540,17 @@
                 "type": "string",
                 "title": "URI (location) of the scheme for rights"
               }
-            }
-          }
+            },
+            "additionalProperties": false
+          },
+          "uniqueItems": true
         },
         "fundingReferences": {
           "type": "array",
           "title": "List of funding references",
           "itmes": {
             "type": "object",
-            "title": "Funding reference object",
+            "title": "Information about financial support for the resource",
             "required": [
               "funderName",
               "funderIdentifier",
@@ -547,8 +585,10 @@
                 "type": "string",
                 "title": "URI (location) of the award"
               }
-            }
-          }
+            },
+            "additionalProperties": false
+          },
+          "uniqueItems": true
         }
       },
       "additionalProperties": false

--- a/metadata_backend/helpers/schemas/folders.json
+++ b/metadata_backend/helpers/schemas/folders.json
@@ -97,11 +97,11 @@
                   "properties": {
                     "schemeUri": {
                       "type": "string",
-                      "title": "URI of the name identifier scheme"
+                      "title": "URI (location) of the name identifier scheme"
                     },
                     "nameIdentifier": {
                       "type": "string",
-                      "title": "Location of name identifier"
+                      "title": "URI (location) of name identifier"
                     },
                     "nameIdentifierScheme": {
                       "type": "string",
@@ -123,7 +123,7 @@
                     },
                     "schemeUri": {
                       "type": "string",
-                      "title": "URI of the affiliation scheme"
+                      "title": "URI (location) of the affiliation scheme"
                     },
                     "affiliationIdentifier": {
                       "type": "string",
@@ -243,7 +243,7 @@
                   "properties": {
                     "schemeUri": {
                       "type": "string",
-                      "title": "URI of the name identifier scheme"
+                      "title": "URI (location) of the name identifier scheme"
                     },
                     "nameIdentifier": {
                       "type": "string",
@@ -269,7 +269,7 @@
                     },
                     "schemeUri": {
                       "type": "string",
-                      "title": "URI of the affiliation scheme"
+                      "title": "URI (location) of the affiliation scheme"
                     },
                     "affiliationIdentifier": {
                       "type": "string",
@@ -396,8 +396,162 @@
               }
             }
           }
+        },
+        "language": {
+          "type": "string",
+          "title": "Language code"
+        },
+        "alternateIdentifiers": {
+          "type": "array",
+          "title": "List of alternate identifiers",
+          "items": {
+            "type": "object",
+            "title": "Alternate identifier object",
+            "properties": {
+              "alternateIdentifier": {
+                "type": "string",
+                "title": "Alternate identifier info"
+              },
+              "alternateIdentifierType": {
+                "type": "string",
+                "title": "Type of alternate identifier"
+              }
+            }
+          }
+        },
+        "relatedIdentifiers": {
+          "type": "array",
+          "title": "List of related identifiers",
+          "items": {
+            "type": "object",
+            "title": "Related identifier object",
+            "properties": {
+              "relatedIdentifier": {
+                "type": "string",
+                "title": "Related identifier info"
+              },
+              "relatedIdentifierType": {
+                "type": "string",
+                "title": "Type of related identifier"
+              },
+              "relationType": {
+                "type": "string",
+                "title": "Specification of the relation"
+              },
+              "relatedMetadataScheme": {
+                "type": "string",
+                "title": "Scheme of related metadata"
+              },
+              "schemeUri": {
+                "type": "string",
+                "title": "URI (location) of the related metadata scheme"
+              },
+              "schemeType": {
+                "type": "string",
+                "title": "Type of the related metadata scheme"
+              },
+              "resourceTypeGeneral": {
+                "type": "string",
+                "title": "Optional general type name"
+              }
+            }
+          }
+        },
+        "sizes": {
+          "type": "array",
+          "title": "List of sizes",
+          "items": {
+            "type": "string",
+            "title": "Size or duration info about the resource"
+          }
+        },
+        "formats": {
+          "type": "array",
+          "title": "List of formats",
+          "items": {
+            "type": "string",
+            "title": "Technical format of the resource"
+          }
+        },
+        "version": {
+          "type": "string",
+          "title": "Version number of the resource"
+        },
+        "rightsList": {
+          "type": "array",
+          "title": "List of any rights information",
+          "items": {
+            "type": "object",
+            "title": "Rights object",
+            "properties": {
+              "lang": {
+                "type": "string",
+                "title": "Language code of the referenced rights"
+              },
+              "rightsUri": {
+                "type": "string",
+                "title": "URI (location) of the referenced rights"
+              },
+              "rightsIdentifier": {
+                "type": "string",
+                "title": "Title of the rights identifier"
+              },
+              "rightsIdentifierScheme": {
+                "type": "string",
+                "title": "Title of rights identifier scheme"
+              },
+              "schemeUri": {
+                "type": "string",
+                "title": "URI (location) of the scheme for rights"
+              }
+            }
+          }
+        },
+        "fundingReferences": {
+          "type": "array",
+          "title": "List of funding references",
+          "itmes": {
+            "type": "object",
+            "title": "Funding reference object",
+            "required": [
+              "funderName",
+              "funderIdentifier",
+              "funderIdentifierType"
+            ],
+            "properties": {
+              "funderName": {
+                "type": "string",
+                "title": "Name of the funding provider"
+              },
+              "funderIdentifier": {
+                "type": "string",
+                "title": "Unique identifier for funding entity"
+              },
+              "funderIdentifierType": {
+                "type": "string",
+                "title": "Type of identifier for funding entity"
+              },
+              "schemeUri": {
+                "type": "string",
+                "title": "URI (location) of scheme for funder identifier"
+              },
+              "awardNumber": {
+                "type": "string",
+                "title": "The code assigned by the funder to a sponsored award"
+              },
+              "awardTitle": {
+                "type": "string",
+                "title": "The human readable title of the award"
+              },
+              "awardUri": {
+                "type": "string",
+                "title": "URI (location) of the award"
+              }
+            }
+          }
         }
-      }
+      },
+      "additionalProperties": false
     },
     "metadataObjects": {
       "type": "array",

--- a/metadata_backend/helpers/schemas/folders.json
+++ b/metadata_backend/helpers/schemas/folders.json
@@ -37,7 +37,7 @@
         "publisher",
         "subjects",
         "publicationYear",
-        "resourceType",
+        "resourceType"
       ],
       "properties": {
         "identifier": {
@@ -103,7 +103,7 @@
                   "type": "object",
                   "title": "Name affiliation object"
                 }
-              },
+              }
             }
           },
           "uniqueItems": true

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -760,7 +760,7 @@ async def test_adding_doi_info_to_folder_works(sess):
     # Get correctly formatted DOI info and patch it into the new folder successfully
     doi_data_raw = await create_request_json_data("doi", "test_doi.json")
     doi_data = json.loads(doi_data_raw)
-    patch_add_doi = [{"op": "add", "path": "/doi", "value": doi_data}]
+    patch_add_doi = [{"op": "add", "path": "/doiInfo", "value": doi_data}]
     folder_id = await patch_folder(sess, folder_id, patch_add_doi)
 
     async with sess.get(f"{folders_url}/{folder_id}") as resp:
@@ -770,21 +770,29 @@ async def test_adding_doi_info_to_folder_works(sess):
         assert res["name"] == folder_data["name"], "expected folder name does not match"
         assert res["description"] == folder_data["description"], "folder description content mismatch"
         assert res["published"] is False, "folder is published, expected False"
-        assert res["doi"] == doi_data, "folder doi does not match"
+        assert res["doiInfo"] == doi_data, "folder doi does not match"
 
     # Test that an incomplete DOI object fails to patch into the folder
-    patch_add_bad_doi = [{"op": "add", "path": "/doi", "value": {"identifier": {}}}]
+    patch_add_bad_doi = [{"op": "replace", "path": "/doiInfo", "value": {"identifier": {}}}]
     async with sess.patch(f"{folders_url}/{folder_id}", data=json.dumps(patch_add_bad_doi)) as resp:
         LOG.debug(f"Tried updating folder {folder_id}")
         assert resp.status == 400, "HTTP Status code error"
         res = await resp.json()
-        assert res["detail"] == "Provided input does not seem correct for field: 'doi'", "expected error does not match"
+        assert res["detail"] == "Provided input does not seem correct for field: 'doiInfo'", "expected error mismatch"
 
     # Check the existing DOI info is not altered
     async with sess.get(f"{folders_url}/{folder_id}") as resp:
         LOG.debug(f"Checking that folder {folder_id} was not patched with bad DOI")
         res = await resp.json()
-        assert res["doi"] == doi_data, "folder doi does not match"
+        assert res["doiInfo"] == doi_data, "folder doi does not match"
+
+    # Test that extraInfo cannot be altered
+    patch_add_bad_doi = [{"op": "add", "path": "/extraInfo", "value": {"publisher": "something"}}]
+    async with sess.patch(f"{folders_url}/{folder_id}", data=json.dumps(patch_add_bad_doi)) as resp:
+        LOG.debug(f"Tried updating folder {folder_id}")
+        assert resp.status == 400, "HTTP Status code error"
+        res = await resp.json()
+        assert res["detail"] == "Request contains '/extraInfo' key that cannot be updated to folders.", "error mismatch"
 
     # Delete folder
     await delete_folder(sess, folder_id)

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -773,7 +773,7 @@ async def test_adding_doi_info_to_folder_works(sess):
         assert res["doiInfo"] == doi_data, "folder doi does not match"
 
     # Test that an incomplete DOI object fails to patch into the folder
-    patch_add_bad_doi = [{"op": "replace", "path": "/doiInfo", "value": {"identifier": {}}}]
+    patch_add_bad_doi = [{"op": "add", "path": "/doiInfo", "value": {"identifier": {}}}]
     async with sess.patch(f"{folders_url}/{folder_id}", data=json.dumps(patch_add_bad_doi)) as resp:
         LOG.debug(f"Tried updating folder {folder_id}")
         assert resp.status == 400, "HTTP Status code error"

--- a/tests/test_files/doi/test_doi.json
+++ b/tests/test_files/doi/test_doi.json
@@ -1,0 +1,67 @@
+{
+  "identifier": {
+    "doi": "10.xxxx/test",
+    "identifierType": "DOI"
+  },
+  "url": "https://some.test.url",
+  "resourceType": {
+    "type": "XML",
+    "resourceTypeGeneral": "Dataset"
+  },
+  "creators": [
+    {
+      "name": "Creator, Test",
+      "nameType": "Personal",
+      "givenName": "Test",
+      "familyName": "Creator",
+      "affiliation": [
+        {
+          "name": "affiliation place",
+          "schemeUri": "https://ror.org",
+          "affiliationIdentifier": "https://ror.org/test1",
+          "affiliationIdentifierScheme": "ROR"
+        }
+      ],
+      "nameIdentifiers": []
+    }
+  ],
+  "titles": [
+    {
+      "lang": "en",
+      "title": "Test resource",
+      "titleType": null
+    }
+  ],
+  "publisher": "Test publisher",
+  "subjects": [
+    {
+      "subject": "FOS: Computer and information sciences",
+      "subjectScheme": "Fields of Science and Technology (FOS)"
+    }
+  ],
+  "publicationYear": 2021,
+  "contributors": [
+    {
+      "name": "Contributor, Test",
+      "nameType": "Personal",
+      "givenName": "Test",
+      "familyName": "contributor",
+      "affiliation": [
+        {
+          "name": "affiliation place",
+          "schemeUri": "https://ror.org",
+          "affiliationIdentifier": "https://ror.org/test2",
+          "affiliationIdentifierScheme": "ROR"
+        }
+      ],
+      "contributorType": "Researcher",
+      "nameIdentifiers": [
+        {
+          "schemeUri": null,
+          "nameIdentifier": null,
+          "nameIdentifierScheme": null
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_files/doi/test_doi.json
+++ b/tests/test_files/doi/test_doi.json
@@ -1,13 +1,4 @@
 {
-  "identifier": {
-    "doi": "10.xxxx/test",
-    "identifierType": "DOI"
-  },
-  "url": "https://some.test.url",
-  "resourceType": {
-    "type": "XML",
-    "resourceTypeGeneral": "Dataset"
-  },
   "creators": [
     {
       "name": "Creator, Test",
@@ -25,21 +16,12 @@
       "nameIdentifiers": []
     }
   ],
-  "titles": [
-    {
-      "lang": "en",
-      "title": "Test resource",
-      "titleType": null
-    }
-  ],
-  "publisher": "Test publisher",
   "subjects": [
     {
       "subject": "FOS: Computer and information sciences",
       "subjectScheme": "Fields of Science and Technology (FOS)"
     }
   ],
-  "publicationYear": 2021,
   "contributors": [
     {
       "name": "Contributor, Test",


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
PR adds the capability to include `"doiInfo"` and `"extraInfo"` object in folders. The DOI properties are set according to [DataCite Schema](http://schema.datacite.org/meta/kernel-4.3/) with some own adjustments.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
Fixes #205 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

<!-- List changes made. -->
- Modified `folders.json` to include DOI information
- Modified OpenAPI specs to include the same
- Modified `patch_folder` to handle adding DOI
- Added integration test and file with test DOI info

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Integration Tests
