### PR TITLE
Feature/find folder by date

### DIFF
--- a/.github/workflows/int.yml
+++ b/.github/workflows/int.yml
@@ -43,6 +43,9 @@ jobs:
       env:
         BASE_URL: http://localhost:5430
         ISS_URL: http://localhost:8000
+        MONGO_HOST: localhost:27017
+        MONGO_DATABASE: default
+        MONGO_AUTHDB: admin
 
     - name: Collect logs from docker
       if: ${{ failure() }}
@@ -82,7 +85,8 @@ jobs:
       env:
         BASE_URL: http://localhost:5430
         ISS_URL: http://localhost:8000
-
+        MONGO_SSL: True
+        
     - name: Collect logs from docker
       if: ${{ failure() }}
       run: docker-compose logs --no-color -t > tests/dockerlogs || true

--- a/docs/specification.yml
+++ b/docs/specification.yml
@@ -897,13 +897,30 @@ paths:
           name: published
           schema:
             type: string
+          example: true
           description: Return folders based on the folder published value. Should be 'true' or 'false'
         - in: query
           name: name
           schema:
             type: string
-          description: Return folders containing filtered string[s] in their name
           example: test folder
+          description: Return folders containing filtered string[s] in their name
+        - in: query
+          name: date_created_start
+          schema:
+            type: string
+          example: "2015-01-01"
+          description: |
+            Returns folders created between provided dates.
+            MUST be used with parameter 'date_created_end'.
+        - in: query
+          name: date_created_end
+          schema:
+            type: string
+          example: "2015-12-31"
+          description: |
+            Returns folders created between provided dates.
+            MUST be used with parameter 'date_created_start'.
       responses:
         200:
           description: OK

--- a/docs/test.rst
+++ b/docs/test.rst
@@ -42,8 +42,10 @@ Integration tests required a running backend, follow the instructions in :ref:`d
 After the backend has been successfully set up, run the following in the backend repository root directory: ``python tests/integration/run_tests.py``.
 This command will run a series of integration tests.
 
-To clean db before or after each integration tests run: ``python tests/integration/clean_db.py`` (``--tls``
-argument can be added if Mongodb is started via ``docker-compose-tls.yml``.
+To clean db before or after each integration tests run: ``python tests/integration/clean_db.py`` (``--tls`` argument
+can be added if Mongodb is started via ``docker-compose-tls.yml``). Script clean_db.py will delete all documents in all collections in the database.
+To erase the database run: ``python tests/integration/clean_db.py --purge``. After that indexes need to be recreated.
+To do that run: ``python tests/integration/mongo_indexes.py`` (``--tls`` argument can be added if Mongodb is started via ``docker-compose-tls.yml``).
 
 
 Performance Testing


### PR DESCRIPTION
### Description

Adds functionality to query folders by creation date between two dates provided.
Parameters to use in the query are date_created_start and date_created_end
and the format must be `%Y-%m-%d` eg. '2021-12-31'.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
Feature #280
- Filter folders by name

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

Add folder querying by date.

### Testing

- [x] Integration Tests
