### PR TITLE
oidcp does not allow empty values

### DIFF
--- a/tests/integration/mock_auth.py
+++ b/tests/integration/mock_auth.py
@@ -37,12 +37,12 @@ iat = int(time())
 ttl = 3600
 exp = iat + ttl
 
-nonce = ""
+nonce = "nonce"
 jwk_pair = generate_token()
 
-user_sub = ""
-user_given_name = ""
-user_family_name = ""
+user_sub = "test@test.example"
+user_given_name = "User"
+user_family_name = "test"
 
 mock_auth_url_docker = getenv("OIDC_URL", "http://mockauth:8000")  # called from inside docker-network
 mock_auth_url_local = getenv("OIDC_URL_TEST", "http://localhost:8000")  # called from local machine


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
prevent errors:
```
metadata_submitter_backend_dev | [2022-01-13 10:08:01][aiohttp.server][1 MainProcess] [ERROR   ](L:405) log_exception: Error handling request
metadata_submitter_backend_dev | Traceback (most recent call last):
metadata_submitter_backend_dev |   File "/usr/local/lib/python3.8/site-packages/oidcrp/oauth2/__init__.py", line 174, in service_request
metadata_submitter_backend_dev |     response = service.get_response_ext(url, method, body, response_body_type, headers,
metadata_submitter_backend_dev | AttributeError: 'AccessToken' object has no attribute 'get_response_ext'
metadata_submitter_backend_dev | 
metadata_submitter_backend_dev | During handling of the above exception, another exception occurred:
metadata_submitter_backend_dev | 
metadata_submitter_backend_dev | Traceback (most recent call last):
metadata_submitter_backend_dev |   File "/usr/local/lib/python3.8/site-packages/oidcmsg/message.py", line 595, in verify
metadata_submitter_backend_dev |     val = self._dict[attribute]
metadata_submitter_backend_dev | KeyError: 'sub'
metadata_submitter_backend_dev | 
metadata_submitter_backend_dev | During handling of the above exception, another exception occurred:
metadata_submitter_backend_dev | 
metadata_submitter_backend_dev | Traceback (most recent call last):
metadata_submitter_backend_dev |   File "/usr/local/lib/python3.8/site-packages/aiohttp/web_protocol.py", line 435, in _handle_request
metadata_submitter_backend_dev |     resp = await request_handler(request)
metadata_submitter_backend_dev |   File "/usr/local/lib/python3.8/site-packages/aiohttp/web_app.py", line 504, in _handle
metadata_submitter_backend_dev |     resp = await handler(request)
metadata_submitter_backend_dev |   File "/usr/local/lib/python3.8/site-packages/aiohttp/web_middlewares.py", line 117, in impl
metadata_submitter_backend_dev |     return await handler(request)
metadata_submitter_backend_dev |   File "/usr/local/lib/python3.8/site-packages/metadata_backend/api/middlewares.py", line 43, in http_error_handler
metadata_submitter_backend_dev |     response = await handler(req)
metadata_submitter_backend_dev |   File "/usr/local/lib/python3.8/site-packages/metadata_backend/api/middlewares.py", line 114, in check_login
metadata_submitter_backend_dev |     return await handler(request)
metadata_submitter_backend_dev |   File "/usr/local/lib/python3.8/site-packages/metadata_backend/api/auth.py", line 109, in callback
metadata_submitter_backend_dev |     session = self.rph.finalize(session["iss"], session["auth_request"])
metadata_submitter_backend_dev |   File "/usr/local/lib/python3.8/site-packages/oidcrp/rp_handler.py", line 769, in finalize
metadata_submitter_backend_dev |     token = self.get_access_and_id_token(authorization_response, state=_state, client=client,
metadata_submitter_backend_dev |   File "/usr/local/lib/python3.8/site-packages/oidcrp/rp_handler.py", line 727, in get_access_and_id_token
metadata_submitter_backend_dev |     token_resp = self.get_tokens(state, client=client)
metadata_submitter_backend_dev |   File "/usr/local/lib/python3.8/site-packages/oidcrp/rp_handler.py", line 522, in get_tokens
metadata_submitter_backend_dev |     tokenresp = client.do_request(
metadata_submitter_backend_dev |   File "/usr/local/lib/python3.8/site-packages/oidcrp/oauth2/__init__.py", line 98, in do_request
metadata_submitter_backend_dev |     return self.service_request(_srv, response_body_type=response_body_type,
metadata_submitter_backend_dev |   File "/usr/local/lib/python3.8/site-packages/oidcrp/oauth2/__init__.py", line 177, in service_request
metadata_submitter_backend_dev |     response = self.get_response(service, url, method, body, response_body_type, headers,
metadata_submitter_backend_dev |   File "/usr/local/lib/python3.8/site-packages/oidcrp/oauth2/__init__.py", line 143, in get_response
metadata_submitter_backend_dev |     return self.parse_request_response(service, resp,
metadata_submitter_backend_dev |   File "/usr/local/lib/python3.8/site-packages/oidcrp/oauth2/__init__.py", line 230, in parse_request_response
metadata_submitter_backend_dev |     return service.parse_response(reqresp.text, value_type,
metadata_submitter_backend_dev |   File "/usr/local/lib/python3.8/site-packages/oidcrp/service.py", line 567, in parse_response
metadata_submitter_backend_dev |     resp.verify(**vargs)
metadata_submitter_backend_dev |   File "/usr/local/lib/python3.8/site-packages/oidcmsg/oidc/__init__.py", line 354, in verify
metadata_submitter_backend_dev |     if not verify_id_token(self, **kwargs):
metadata_submitter_backend_dev |   File "/usr/local/lib/python3.8/site-packages/oidcmsg/oidc/__init__.py", line 319, in verify_id_token
metadata_submitter_backend_dev |     if not idt.verify(**kwargs):
metadata_submitter_backend_dev |   File "/usr/local/lib/python3.8/site-packages/oidcmsg/oidc/__init__.py", line 779, in verify
metadata_submitter_backend_dev |     super(IdToken, self).verify(**kwargs)
metadata_submitter_backend_dev |   File "/usr/local/lib/python3.8/site-packages/oidcmsg/oidc/__init__.py", line 580, in verify
metadata_submitter_backend_dev |     super(OpenIDSchema, self).verify(**kwargs)
metadata_submitter_backend_dev |   File "/usr/local/lib/python3.8/site-packages/oidcmsg/oauth2/__init__.py", line 46, in verify
metadata_submitter_backend_dev |     super(ResponseMessage, self).verify(**kwargs)
metadata_submitter_backend_dev |   File "/usr/local/lib/python3.8/site-packages/oidcmsg/message.py", line 598, in verify
metadata_submitter_backend_dev |     raise MissingRequiredAttribute("%s" % attribute)
metadata_submitter_backend_dev | oidcmsg.exception.MissingRequiredAttribute: Missing required attribute 'sub'
```

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

<!-- List changes made. -->
1. oidcp does not allow empty values, prefill them in mockauth so front-end can start

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply


### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
