### PR TITLE
Refactor/patch object on save

### DIFF
--- a/.github/config/.wordlist.txt
+++ b/.github/config/.wordlist.txt
@@ -115,6 +115,7 @@ cscfi
 cscusername
 csi
 csrf
+csv
 ctrl
 cts
 curation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- templates API #256
+- Add patching of folders after object save and update operations
+  - Object is added or updated to folder(submission) where it belongs with it's accession ID, schema, submission type, title and filename in the case of CSV and XML upload
+  - Adds configuration for mypy linting to VScode devcontainer setup
+- Templates API #256
   - use `ujson` as default json library
-- creating draft Datacite DOI for folders #257
+- Creating draft Datacite DOI for folders #257
   - created a mock web app, which would act similarly to DataCite REST API
   - altered `publish_folder` endpoint so that `extraInfo` containing the DOI data is added upon publishing
   - added `datePublished` key to folders which takes in the date/time, when folder is published
@@ -26,7 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - update github actions
 - Add folder querying by date #308
 - Add description to JSON schemas #323
-
   - add JSON schema spelling checker to pyspelling github action
   - optimise wordlist by adding regex ignore patterns
   - added pyspelling to pre-commit hooks (fixed syntax for scripts according to https://github.com/koalaman/shellcheck )
@@ -41,22 +43,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - New mandatory ENV `OIDC_URL`
   - New optional ENVs `OIDC_SCOPE`, `AUTH_METHOD`
   - Added oidcrp dependency
-- use node 16+ #345
+- Use node 16+ #345
 - VScode Dev environment #287
   - Adds requirements-dev.in/txt files. Now pip dependencies can be managed with pip-tools
   - README updated with tox command, development build instructions, and prettify Dockerfile.
-- update ENA XML and JSON schemas #299
+- Update ENA XML and JSON schemas #299
 - Github actions changed the use of https://git.io/misspell to rojopolis/spellcheck-github-actions #316
 - Separated most of the handlers to own files inside the handlers folder #319
 
 ### Fixed
 
-- coveralls report #267
-- typos for functions and tests #279
-- fix spelling mistakes for JSON schemas #323
-- oidcrp does not allow empty values, prefill them in mockauth so front-end can start #333
+- Coveralls report #267
+- Typos for functions and tests #279
+- Fix spelling mistakes for JSON schemas #323
+- Oidcrp does not allow empty values, prefill them in mockauth so front-end can start #333
 - Fix development environment #336
-  
   - Add env vars OIDC_URL and OIDC_URL_TEST to mock auth container
   - Adds logging configs for mock auth
   - Updates mock auth api's token endpoint with expiration configs
@@ -76,7 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- package updates
+- Package updates
 
 ### Added
 
@@ -88,72 +89,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- add integration tests for misses in dataset, experiment, policy
+- Add integration tests for misses in dataset, experiment, policy
 
 ### Changed
 
-- package updates
+- Package updates
 - EGA XML schemas version:1.8.0
-- refactor analysis and experiment schemas to adhere to XML schema
+- Refactor analysis and experiment schemas to adhere to XML schema
 
 ### Fixed
 
-- fix misses for DAC, experiment and policy processing of XML
-- fix misses in JSON Schema
+- Fix misses for DAC, experiment and policy processing of XML
+- Fix misses in JSON Schema
 
 ## [0.9.0] - 2021-03-22
 
 ### Added
 
-- use dependabot
-- support simultaneous sessions
+- Use dependabot
+- Support simultaneous sessions
 
 ### Changed
 
 - Refactor JSON schema Links
-- refactor handlers to be more streamlined
-- validate patch requests for JSON content
-- switch to python 3.8
+- Refactor handlers to be more streamlined
+- Validate patch requests for JSON content
+- Switch to python 3.8
 
 ## [0.8.1] - 2021-02-15
 
 ### Fixed
 
-- bugfix for error pages #202
+- Bugfix for error pages #202
 
 ## [0.8.0] - 2021-02-12
 
 ### Added
 
 - TLS support
-- use `sub` as alternative to `eppn` to identify users
+- Use `sub` as alternative to `eppn` to identify users
 - `PATCH` for objects and `PUT` for XML objects enabled
-- delete folders and objects associated to user on user delete
+- Delete folders and objects associated to user on user delete
 
 ### Changed
 
-- redirect to error pages
-- extended integration tests
+- Redirect to error pages
+- Extended integration tests
 
 ### Fixed
 
-- fix replace on json patch
-- general bug and fixes
+- Fix replace on json patch
+- General bug and fixes
 
 ## [0.7.1] - 2021-01-19
 
 ### Fixed
 
-- hotfix release #176
- 
+- Hotfix release #176
   - added check_object_exists to check object exists and fail early with 404 before checking it belongs to user
   - refactor and added more check_folder_exists to check folder exists before doing anything
   - integration test to check objects are deleted properly
 
 ### Changes
 
-- check objects and folders exist before any operation
-- integration check to see if deleted object or folder are still registered in db
+- Check objects and folders exist before any operation
+- Integration check to see if deleted object or folder are still registered in db
 
 ## [0.7.0] - 2021-01-06
 
@@ -162,7 +162,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CodeQL github action #162
 - `/health` endpoint #173
 
-- map `users` to `folders` with `_handle_check_ownedby_user` #158
+- Map `users` to `folders` with `_handle_check_ownedby_user` #158
   - querying for objects is restricted to only the objects that belong to user 
   - return folders owned by user or published
   - added a few db operators some used (aggregate, remove)
@@ -170,17 +170,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - standardise raises description and general improvements and fixes of logs and descriptions
 
 ### Changed
-- verify `/publish` endpoint #163
-- restrict endpoints to logged in users #151
-- updated documentation #165
-- switch to using uuids for accession ids #168
-- integration tests and increase unit test coverage #166
+- Verify `/publish` endpoint #163
+- Restrict endpoints to logged in users #151
+- Updated documentation #165
+- Switch to using uuids for accession ids #168
+- Integration tests and increase unit test coverage #166
 
 ### Fixed
 
-- fixes for idp and location headers redirects #150
-- fix race condition in db operations #158
-- fix handling of draft deletion by removing redundant deletion #164, #169 and #172
+- Fixes for idp and location headers redirects #150
+- Fix race condition in db operations #158
+- Fix handling of draft deletion by removing redundant deletion #164, #169 and #172
 
 ## [0.6.1] - 2020-11-23
 
@@ -190,38 +190,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- refactor draft `/folder` #144
-- refactor gh actions #140
-- patch publish #141
+- Refactor draft `/folder` #144
+- Refactor gh actions #140
+- Patch publish #141
 
 ### Fixed
 
-- bugfixes for login redirect #139
+- Bugfixes for login redirect #139
 
 ## [0.6.0] - 2020-10-08
 
 ### Added 
 
-- authentication with OIDC  #133
-- only 3.7 support going further #134
-- more submission actions `ADD` and `MODIFY` #137
+- Authentication with OIDC  #133
+- Only 3.7 support going further #134
+- More submission actions `ADD` and `MODIFY` #137
 
 
 ## [0.5.3] - 2020-08-21
 
 ### Changed
 
-- updated OpenAPI specifications #127
-- python modules, project description and instructions to documentation sources #128
-- added integration tests #129
-- updated documentation #130
+- Updated OpenAPI specifications #127
+- Python modules, project description and instructions to documentation sources #128
+- Added integration tests #129
+- Updated documentation #130
 
 
 ## [0.5.2] - 2020-08-14
 
 ### Fixes
 
-- fix mimetype for SVG image and package data
+- Fix mimetype for SVG image and package data
 
 ## [0.5.1] - 2020-08-14
 
@@ -233,10 +233,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixes
 
 - Dockerfile build fixes #115
-- fix JSON Schema details #117 
-- missing env from github actions #119
-- typo fixes #120
-- await responses #122
+- Fix JSON Schema details #117 
+- Missing env from github actions #119
+- Typo fixes #120
+- Await responses #122
 
 
 ## [0.5.0] - 2020-08-06
@@ -250,28 +250,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - JSON validation
 - XML better parsing
 - Auth middleware
-- pagination
+- Pagination
 
 ### Changed
 
 - Improved current naming conventions #82
 - Login flow with new routes for Home & Login #76, #79, #80
-- change from pymongo to motor
+- Change from pymongo to motor
 
 ## [0.2.0] - 2020-07-01
 
 ### Added
 
 - Added integration tests
-- switched to github actions
-- added base docs folder
-- added more refined XML parsing
+- Switched to github actions
+- Added base docs folder
+- Added more refined XML parsing
 - Integration tests added
 - Refactor unit tests
 
 ### Changed
 
-- refactor API endpoints and responses
+- Refactor API endpoints and responses
   - error using https://tools.ietf.org/html/rfc7807
   - `objects` and `schemas` endpoints added
 

--- a/docs/specification.yml
+++ b/docs/specification.yml
@@ -299,6 +299,13 @@ paths:
           schema:
             type: string
           required: true
+        - name: folder
+          in: query
+          schema:
+            type: string
+          description: The folder ID where object belongs to.
+          required: true
+          example: "folder=12345"
       requestBody:
         content:
           multipart/form-data::
@@ -535,6 +542,13 @@ paths:
           schema:
             type: string
           required: true
+        - name: folder
+          in: query
+          schema:
+            type: string
+          description: The folder ID where object belongs to.
+          required: true
+          example: "folder=12345"
       requestBody:
         content:
           multipart/form-data::

--- a/metadata_backend/api/handlers/folder.py
+++ b/metadata_backend/api/handlers/folder.py
@@ -14,9 +14,9 @@ from ...conf.conf import publisher
 from ...helpers.doi import DOIHandler
 from ...helpers.logger import LOG
 from ...helpers.validator import JSONValidator
-from .restapi import RESTAPIHandler
 from ..middlewares import get_session
 from ..operators import FolderOperator, Operator, UserOperator
+from .restapi import RESTAPIHandler
 
 
 class FolderAPIHandler(RESTAPIHandler):
@@ -26,7 +26,7 @@ class FolderAPIHandler(RESTAPIHandler):
         """Check patch operations in request are valid.
 
         We check that ``metadataObjects`` and ``drafts`` have ``_required_values``.
-        For tags we check that the ``submissionType`` takes either ``XML`` or
+        For tags we check that the ``submissionType`` takes either ``CSV``, ``XML`` or
         ``Form`` as values.
         :param patch_ops: JSON patch request
         :raises: HTTPBadRequest if request does not fullfil one of requirements
@@ -41,8 +41,12 @@ class FolderAPIHandler(RESTAPIHandler):
         for op in patch_ops:
             if _tags.match(op["path"]):
                 LOG.info(f"{op['op']} on tags in folder")
-                if "submissionType" in op["value"].keys() and op["value"]["submissionType"] not in ["XML", "Form"]:
-                    reason = "submissionType is restricted to either 'XML' or 'Form' values."
+                if "submissionType" in op["value"].keys() and op["value"]["submissionType"] not in [
+                    "XML",
+                    "CSV",
+                    "Form",
+                ]:
+                    reason = "submissionType is restricted to either 'CSV', 'XML' or 'Form' values."
                     LOG.error(reason)
                     raise web.HTTPBadRequest(reason=reason)
                 pass

--- a/metadata_backend/api/handlers/object.py
+++ b/metadata_backend/api/handlers/object.py
@@ -109,7 +109,7 @@ class ObjectAPIHandler(RESTAPIHandler):
         operator: Union[Operator, XMLOperator]
         if req.content_type == "multipart/form-data":
             _only_xml = False if schema_type in _allowed_csv else True
-            files, cont_type = await multipart_content(req, extract_one=True, expect_xml=_only_xml)
+            files, cont_type, _ = await multipart_content(req, extract_one=True, expect_xml=_only_xml)
             if cont_type == "xml":
                 # from this tuple we only care about the content
                 # files should be of form (content, schema)
@@ -222,7 +222,7 @@ class ObjectAPIHandler(RESTAPIHandler):
         content: Union[Dict, str]
         operator: Union[Operator, XMLOperator]
         if req.content_type == "multipart/form-data":
-            files, _ = await multipart_content(req, extract_one=True, expect_xml=True)
+            files, _, _ = await multipart_content(req, extract_one=True, expect_xml=True)
             content, _ = files[0]
             operator = XMLOperator(db_client)
         else:

--- a/metadata_backend/api/handlers/submission.py
+++ b/metadata_backend/api/handlers/submission.py
@@ -128,8 +128,9 @@ class SubmissionAPIHandler:
         :returns: Dict containing specific action that was completed
         """
         if action == "add":
+            assession_id, _ = await XMLOperator(db_client).create_metadata_object(schema, content)
             result = {
-                "accessionId": await XMLOperator(db_client).create_metadata_object(schema, content),
+                "accessionId": assession_id,
                 "schema": schema,
             }
             LOG.debug(f"added some content in {schema} ...")

--- a/metadata_backend/api/handlers/submission.py
+++ b/metadata_backend/api/handlers/submission.py
@@ -31,7 +31,7 @@ class SubmissionAPIHandler:
         :raises: HTTPBadRequest if request is missing some parameters or cannot be processed
         :returns: XML-based receipt from submission
         """
-        files, _ = await multipart_content(req, expect_xml=True)
+        files, _, _ = await multipart_content(req, expect_xml=True)
         schema_types = Counter(file[1] for file in files)
         if "submission" not in schema_types:
             reason = "There must be a submission.xml file in submission."
@@ -92,7 +92,7 @@ class SubmissionAPIHandler:
         :param req: Multipart POST request with submission.xml and files
         :returns: JSON response indicating if validation was successful or not
         """
-        files, _ = await multipart_content(req, extract_one=True, expect_xml=True)
+        files, _, _ = await multipart_content(req, extract_one=True, expect_xml=True)
         xml_content, schema_type = files[0]
         validator = await self._perform_validation(schema_type, xml_content)
         return web.Response(body=validator.resp_body, content_type="application/json")

--- a/metadata_backend/api/handlers/template.py
+++ b/metadata_backend/api/handlers/template.py
@@ -69,7 +69,7 @@ class TemplatesAPIHandler(RESTAPIHandler):
                     reason = f"template key is missing from request body for element: {num}."
                     LOG.error(reason)
                     raise web.HTTPBadRequest(reason=reason)
-                accession_id = await operator.create_metadata_object(collection, tmpl["template"])
+                accession_id, _ = await operator.create_metadata_object(collection, tmpl["template"])
                 data = [{"accessionId": accession_id, "schema": collection}]
                 if "tags" in tmpl:
                     data[0]["tags"] = tmpl["tags"]
@@ -82,7 +82,7 @@ class TemplatesAPIHandler(RESTAPIHandler):
                 reason = "template key is missing from request body."
                 LOG.error(reason)
                 raise web.HTTPBadRequest(reason=reason)
-            accession_id = await operator.create_metadata_object(collection, content["template"])
+            accession_id, _ = await operator.create_metadata_object(collection, content["template"])
             data = [{"accessionId": accession_id, "schema": collection}]
             if "tags" in content:
                 data[0]["tags"] = content["tags"]

--- a/metadata_backend/api/operators.py
+++ b/metadata_backend/api/operators.py
@@ -39,7 +39,7 @@ class BaseOperator(ABC):
         self.db_service = DBService(db_name, db_client)
         self.content_type = content_type
 
-    async def create_metadata_object(self, schema_type: str, data: Union[Dict, str]) -> str:
+    async def create_metadata_object(self, schema_type: str, data: Union[Dict, str]) -> Tuple[str, str]:
         """Create new metadata object to database.
 
         Data formatting and addition step for JSON or XML must be implemented
@@ -49,9 +49,9 @@ class BaseOperator(ABC):
         :param data: Data to be saved to database.
         :returns: Accession id for the object inserted to database
         """
-        accession_id = await self._format_data_to_create_and_add_to_db(schema_type, data)
+        accession_id, title = await self._format_data_to_create_and_add_to_db(schema_type, data)
         LOG.info(f"Inserting object with schema {schema_type} to database succeeded with accession id: {accession_id}")
-        return accession_id
+        return accession_id, title
 
     async def replace_metadata_object(self, schema_type: str, accession_id: str, data: Union[Dict, str]) -> str:
         """Replace metadata object from database.
@@ -127,7 +127,7 @@ class BaseOperator(ABC):
             LOG.error(reason)
             raise web.HTTPBadRequest(reason=reason)
 
-    async def _insert_formatted_object_to_db(self, schema_type: str, data: Dict) -> str:
+    async def _insert_formatted_object_to_db(self, schema_type: str, data: Dict) -> Tuple[str, str]:
         """Insert formatted metadata object to database.
 
         :param schema_type: Schema type of the object to insert.
@@ -142,7 +142,11 @@ class BaseOperator(ABC):
             LOG.error(reason)
             raise web.HTTPBadRequest(reason=reason)
         if insert_success:
-            return data["accessionId"]
+            try:
+                title = data["descriptor"]["studyTitle"] if schema_type == "study" else data["title"]
+            except (TypeError, KeyError):
+                title = ""
+            return data["accessionId"], title
         else:
             reason = "Inserting object to database failed for some reason."
             LOG.error(reason)
@@ -249,7 +253,7 @@ class BaseOperator(ABC):
             raise web.HTTPNotFound(reason=reason)
 
     @abstractmethod
-    async def _format_data_to_create_and_add_to_db(self, schema_type: str, data: Any) -> str:
+    async def _format_data_to_create_and_add_to_db(self, schema_type: str, data: Any) -> Tuple[str, str]:
         """Format and add data to database.
 
         Must be implemented by subclass.
@@ -380,7 +384,7 @@ class Operator(BaseOperator):
         )
         return data, page_num, page_size, total_objects[0]["total"]
 
-    async def _format_data_to_create_and_add_to_db(self, schema_type: str, data: Dict) -> str:
+    async def _format_data_to_create_and_add_to_db(self, schema_type: str, data: Dict) -> Tuple[str, str]:
         """Format JSON metadata object and add it to db.
 
         Adds necessary additional information to object before adding to db.
@@ -513,7 +517,7 @@ class XMLOperator(BaseOperator):
         """
         super().__init__(mongo_database, "text/xml", db_client)
 
-    async def _format_data_to_create_and_add_to_db(self, schema_type: str, data: str) -> str:
+    async def _format_data_to_create_and_add_to_db(self, schema_type: str, data: str) -> Tuple[str, str]:
         """Format XML metadata object and add it to db.
 
         XML is validated, then parsed to JSON, which is added to database.
@@ -527,10 +531,10 @@ class XMLOperator(BaseOperator):
         # remove `draft-` from schema type
         schema = schema_type[6:] if schema_type.startswith("draft") else schema_type
         data_as_json = XMLToJSONParser().parse(schema, data)
-        accession_id = await Operator(db_client)._format_data_to_create_and_add_to_db(schema_type, data_as_json)
+        accession_id, title = await Operator(db_client)._format_data_to_create_and_add_to_db(schema_type, data_as_json)
         LOG.debug(f"XMLOperator formatted data for xml-{schema_type} to add to DB")
         return await self._insert_formatted_object_to_db(
-            f"xml-{schema_type}", {"accessionId": accession_id, "content": data}
+            f"xml-{schema_type}", {"accessionId": accession_id, "title": title, "content": data}
         )
 
     async def _format_data_to_replace_and_add_to_db(self, schema_type: str, accession_id: str, data: str) -> str:

--- a/metadata_backend/helpers/parser.py
+++ b/metadata_backend/helpers/parser.py
@@ -1,17 +1,17 @@
 """Tool to parse XML and CSV files to JSON."""
 
-import re
 import csv
+import re
 from io import StringIO
 from typing import Any, Dict, List, Optional, Type, Union
 
 from aiohttp import web
+from pymongo import UpdateOne
 from xmlschema import XMLSchema, XMLSchemaConverter, XMLSchemaException, XsdElement, XsdType
 
 from .logger import LOG
 from .schema_loader import SchemaNotFoundException, XMLSchemaLoader
 from .validator import JSONValidator, XMLValidator
-from pymongo import UpdateOne
 
 
 class MetadataXMLConverter(XMLSchemaConverter):
@@ -457,6 +457,8 @@ def jsonpatch_mongo(identifier: Dict, json_patch: List[Dict[str, Any]]) -> List:
                 queries.append(UpdateOne(identifier, {"$set": {op["path"][1:].replace("/", "."): op["value"]}}))
         elif op["op"] == "replace":
             path = op["path"][1:-2] if op["path"].endswith("/-") else op["path"][1:].replace("/", ".")
+            if op.get("match", None):
+                identifier.update(op["match"])
             queries.append(UpdateOne(identifier, {"$set": {path: op["value"]}}))
 
     return queries

--- a/metadata_backend/helpers/schema_loader.py
+++ b/metadata_backend/helpers/schema_loader.py
@@ -42,6 +42,7 @@ class SchemaLoader(ABC):
         for file in [x for x in self.path.iterdir()]:
             if schema_type in file.name and file.name.endswith(self.loader_type):
                 schema_file = file
+                break
         if not schema_file:
             raise SchemaNotFoundException
 

--- a/metadata_backend/helpers/schemas/folders.json
+++ b/metadata_backend/helpers/schemas/folders.json
@@ -998,6 +998,7 @@
                 "title": "Type of submission",
                 "enum": [
                   "XML",
+                  "CSV",
                   "Form"
                 ]
               }
@@ -1036,6 +1037,7 @@
                 "title": "Type of submission",
                 "enum": [
                   "XML",
+                  "CSV",
                   "Form"
                 ]
               }

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -773,7 +773,11 @@ async def test_crud_folders_works(sess):
             {
                 "accessionId": draft_id,
                 "schema": "draft-sample",
-                "tags": {"submissionType": "XML", "displayTitle": "SRS001433.xml", "fileName": "SRS001433.xml"},
+                "tags": {
+                    "submissionType": "XML",
+                    "displayTitle": "HapMap sample from Homo sapiens",
+                    "fileName": "SRS001433.xml",
+                },
             }
         ], "folder drafts content mismatch"
         assert res["metadataObjects"] == [], "there are objects in folder, expected empty"
@@ -797,7 +801,11 @@ async def test_crud_folders_works(sess):
             {
                 "accessionId": draft_id,
                 "schema": "draft-sample",
-                "tags": {"submissionType": "XML", "displayTitle": "SRS001433.xml", "fileName": "SRS001433.xml"},
+                "tags": {
+                    "submissionType": "XML",
+                    "displayTitle": "HapMap sample from Homo sapiens",
+                    "fileName": "SRS001433.xml",
+                },
             }
         ], "folder drafts content mismatch"
         assert res["metadataObjects"] == [
@@ -862,7 +870,11 @@ async def test_crud_folders_works_no_publish(sess):
             {
                 "accessionId": draft_id,
                 "schema": "draft-sample",
-                "tags": {"submissionType": "XML", "displayTitle": "SRS001433.xml", "fileName": "SRS001433.xml"},
+                "tags": {
+                    "submissionType": "XML",
+                    "displayTitle": "HapMap sample from Homo sapiens",
+                    "fileName": "SRS001433.xml",
+                },
             }
         ], "folder drafts content mismatch"
         assert res["metadataObjects"] == [], "there are objects in folder, expected empty"
@@ -885,7 +897,11 @@ async def test_crud_folders_works_no_publish(sess):
             {
                 "accessionId": draft_id,
                 "schema": "draft-sample",
-                "tags": {"submissionType": "XML", "displayTitle": "SRS001433.xml", "fileName": "SRS001433.xml"},
+                "tags": {
+                    "submissionType": "XML",
+                    "displayTitle": "HapMap sample from Homo sapiens",
+                    "fileName": "SRS001433.xml",
+                },
             }
         ], "folder drafts content mismatch"
         assert res["metadataObjects"] == [

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -157,7 +157,7 @@ class HandlersTestCase(AioHTTPTestCase):
 
     async def fake_xmloperator_replace_metadata_object(self, schema_type, accession_id, content):
         """Fake replace operation to return mocked accessionId."""
-        return self.test_ega_string
+        return self.test_ega_string, "title"
 
     async def fake_operator_create_metadata_object(self, schema_type, content):
         """Fake create operation to return mocked accessionId."""
@@ -169,7 +169,7 @@ class HandlersTestCase(AioHTTPTestCase):
 
     async def fake_operator_replace_metadata_object(self, schema_type, accession_id, content):
         """Fake replace operation to return mocked accessionId."""
-        return self.test_ega_string
+        return self.test_ega_string, "title"
 
     async def fake_operator_delete_metadata_object(self, schema_type, accession_id):
         """Fake delete operation to await successful operation indicator."""

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -387,7 +387,7 @@ class ObjectHandlerTestCase(HandlersTestCase):
         """Test that submission is handled, XMLOperator is called."""
         files = [("study", "SRP000539.xml")]
         data = self.create_submission_data(files)
-        response = await self.client.post("/objects/study", data=data)
+        response = await self.client.post("/objects/study", params={"folder": "some id"}, data=data)
         self.assertEqual(response.status, 201)
         self.assertIn(self.test_ega_string, await response.text())
         self.MockedXMLOperator().create_metadata_object.assert_called_once()
@@ -399,7 +399,7 @@ class ObjectHandlerTestCase(HandlersTestCase):
             "alias": "GSE10966",
             "descriptor": {"studyTitle": "Highly", "studyType": "Other"},
         }
-        response = await self.client.post("/objects/study", json=json_req)
+        response = await self.client.post("/objects/study", params={"folder": "some id"}, json=json_req)
         self.assertEqual(response.status, 201)
         self.assertIn(self.test_ega_string, await response.text())
         self.MockedOperator().create_metadata_object.assert_called_once()
@@ -407,7 +407,7 @@ class ObjectHandlerTestCase(HandlersTestCase):
     async def test_submit_object_missing_field_json(self):
         """Test that JSON has missing property."""
         json_req = {"centerName": "GEO", "alias": "GSE10966"}
-        response = await self.client.post("/objects/study", json=json_req)
+        response = await self.client.post("/objects/study", params={"folder": "some id"}, json=json_req)
         reason = "Provided input does not seem correct because: ''descriptor' is a required property'"
         self.assertEqual(response.status, 400)
         self.assertIn(reason, await response.text())
@@ -419,7 +419,7 @@ class ObjectHandlerTestCase(HandlersTestCase):
             "alias": "GSE10966",
             "descriptor": {"studyTitle": "Highly", "studyType": "ceva"},
         }
-        response = await self.client.post("/objects/study", json=json_req)
+        response = await self.client.post("/objects/study", params={"folder": "some id"}, json=json_req)
         reason = "Provided input does not seem correct for field: 'descriptor'"
         self.assertEqual(response.status, 400)
         self.assertIn(reason, await response.text())
@@ -431,7 +431,7 @@ class ObjectHandlerTestCase(HandlersTestCase):
             "alias": "GSE10966",
             "descriptor": {"studyTitle": "Highly", "studyType": "Other"},
         }
-        response = await self.client.post("/objects/study", data=json_req)
+        response = await self.client.post("/objects/study", params={"folder": "some id"}, data=json_req)
         reason = "JSON is not correctly formatted. See: Expecting value: line 1 column 1"
         self.assertEqual(response.status, 400)
         self.assertIn(reason, await response.text())
@@ -442,7 +442,7 @@ class ObjectHandlerTestCase(HandlersTestCase):
         data = self.create_submission_data(files)
         file_content = self.get_file_data("sample", "EGAformat.csv")
         self.MockedCSVParser().parse.return_value = [{}, {}, {}]
-        response = await self.client.post("/objects/sample", data=data)
+        response = await self.client.post("/objects/sample", params={"folder": "some id"}, data=data)
         json_resp = await response.json()
         self.assertEqual(response.status, 201)
         self.assertEqual(self.test_ega_string, json_resp[0]["accessionId"])
@@ -460,7 +460,7 @@ class ObjectHandlerTestCase(HandlersTestCase):
         """Test multipart request post fails when no objects are parsed."""
         files = [("sample", "empty.csv")]
         data = self.create_submission_data(files)
-        response = await self.client.post("/objects/sample", data=data)
+        response = await self.client.post("/objects/sample", params={"folder": "some id"}, data=data)
         json_resp = await response.json()
         self.assertEqual(response.status, 400)
         self.assertEqual(json_resp["detail"], "Request data seems empty.")
@@ -495,7 +495,7 @@ class ObjectHandlerTestCase(HandlersTestCase):
             "alias": "GSE10966",
             "descriptor": {"studyTitle": "Highly", "studyType": "Other"},
         }
-        response = await self.client.post("/drafts/study", json=json_req)
+        response = await self.client.post("/drafts/study", params={"folder": "some id"}, json=json_req)
         self.assertEqual(response.status, 201)
         self.assertIn(self.test_ega_string, await response.text())
         self.MockedOperator().create_metadata_object.assert_called_once()
@@ -544,7 +544,7 @@ class ObjectHandlerTestCase(HandlersTestCase):
         """Test that sending two files to endpoint results failure."""
         files = [("study", "SRP000539.xml"), ("study", "SRP000539_copy.xml")]
         data = self.create_submission_data(files)
-        response = await self.client.post("/objects/study", data=data)
+        response = await self.client.post("/objects/study", params={"folder": "some id"}, data=data)
         reason = "Only one file can be sent to this endpoint at a time."
         self.assertEqual(response.status, 400)
         self.assertIn(reason, await response.text())
@@ -616,7 +616,7 @@ class ObjectHandlerTestCase(HandlersTestCase):
         json_get_resp = await get_resp.json()
         self.assertIn("Specified schema", json_get_resp["detail"])
 
-        post_rep = await self.client.post("/objects/bad_scehma_name")
+        post_rep = await self.client.post("/objects/bad_scehma_name", params={"folder": "some id"})
         self.assertEqual(post_rep.status, 404)
         post_json_rep = await post_rep.json()
         self.assertIn("Specified schema", post_json_rep["detail"])

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,7 +1,7 @@
 """Test API endpoints from handlers module."""
 
 from pathlib import Path
-from unittest.mock import patch, call
+from unittest.mock import call, patch
 
 from aiohttp import FormData
 from aiohttp.test_utils import AioHTTPTestCase, make_mocked_coro
@@ -153,7 +153,7 @@ class HandlersTestCase(AioHTTPTestCase):
 
     async def fake_xmloperator_create_metadata_object(self, schema_type, content):
         """Fake create operation to return mocked accessionId."""
-        return self.test_ega_string
+        return self.test_ega_string, "title"
 
     async def fake_xmloperator_replace_metadata_object(self, schema_type, accession_id, content):
         """Fake replace operation to return mocked accessionId."""
@@ -161,7 +161,7 @@ class HandlersTestCase(AioHTTPTestCase):
 
     async def fake_operator_create_metadata_object(self, schema_type, content):
         """Fake create operation to return mocked accessionId."""
-        return self.test_ega_string
+        return self.test_ega_string, "title"
 
     async def fake_operator_update_metadata_object(self, schema_type, accession_id, content):
         """Fake update operation to return mocked accessionId."""
@@ -443,6 +443,7 @@ class ObjectHandlerTestCase(HandlersTestCase):
         file_content = self.get_file_data("sample", "EGAformat.csv")
         self.MockedCSVParser().parse.return_value = [{}, {}, {}]
         response = await self.client.post("/objects/sample", params={"folder": "some id"}, data=data)
+        print("=== RESP ===", await response.text())
         json_resp = await response.json()
         self.assertEqual(response.status, 201)
         self.assertEqual(self.test_ega_string, json_resp[0]["accessionId"])
@@ -549,7 +550,6 @@ class ObjectHandlerTestCase(HandlersTestCase):
         self.assertEqual(response.status, 400)
         self.assertIn(reason, await response.text())
 
-    # handle_check_ownedby_user.return_value = True
     async def test_get_object(self):
         """Test that accessionId returns correct JSON object."""
         url = f"/objects/study/{self.query_accessionId}"

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -2,21 +2,14 @@
 import datetime
 import re
 import unittest
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock, call, patch
 from uuid import uuid4
-from unittest.mock import MagicMock, patch, call
 
 from aiohttp.web import HTTPBadRequest, HTTPNotFound, HTTPUnprocessableEntity
-from unittest import IsolatedAsyncioTestCase
-
+from metadata_backend.api.operators import FolderOperator, Operator, UserOperator, XMLOperator
 from multidict import MultiDict, MultiDictProxy
 from pymongo.errors import ConnectionFailure
-
-from metadata_backend.api.operators import (
-    FolderOperator,
-    Operator,
-    XMLOperator,
-    UserOperator,
-)
 
 
 class AsyncIterator:
@@ -191,7 +184,7 @@ class TestOperators(IsolatedAsyncioTestCase):
             "descriptor": {"studyTitle": "Highly", "studyType": "Other"},
         }
         operator.db_service.create.return_value = True
-        accession = await operator.create_metadata_object("study", data)
+        accession, _ = await operator.create_metadata_object("study", data)
         operator.db_service.create.assert_called_once()
         self.assertEqual(accession, self.accession_id)
 
@@ -264,10 +257,10 @@ class TestOperators(IsolatedAsyncioTestCase):
         operator.db_service.create.return_value = True
         with patch(
             ("metadata_backend.api.operators.Operator._format_data_to_create_and_add_to_db"),
-            return_value=self.accession_id,
+            return_value=(self.accession_id, "title"),
         ):
             with patch("metadata_backend.api.operators.XMLToJSONParser"):
-                accession = await operator.create_metadata_object("study", "<MOCK_ELEM></MOCK_ELEM>")
+                accession, _ = await operator.create_metadata_object("study", "<MOCK_ELEM></MOCK_ELEM>")
         operator.db_service.create.assert_called_once()
         self.assertEqual(accession, self.accession_id)
 
@@ -375,7 +368,7 @@ class TestOperators(IsolatedAsyncioTestCase):
         xml_data = "<MOCK_ELEM></MOCK_ELEM>"
         with patch(
             ("metadata_backend.api.operators.Operator._format_data_to_create_and_add_to_db"),
-            return_value=self.accession_id,
+            return_value=(self.accession_id, "title"),
         ):
             with patch(
                 ("metadata_backend.api.operators.XMLOperator._insert_formatted_object_to_db"),
@@ -384,7 +377,7 @@ class TestOperators(IsolatedAsyncioTestCase):
                 with patch("metadata_backend.api.operators.XMLToJSONParser"):
                     acc = await (operator._format_data_to_create_and_add_to_db("study", xml_data))
                     m_insert.assert_called_once_with(
-                        "xml-study", {"accessionId": self.accession_id, "content": xml_data}
+                        "xml-study", {"accessionId": self.accession_id, "title": "title", "content": xml_data}
                     )
                     self.assertEqual(acc, self.accession_id)
 

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -198,7 +198,7 @@ class TestOperators(IsolatedAsyncioTestCase):
         operator = Operator(self.client)
         operator.db_service.exists.return_value = True
         operator.db_service.replace.return_value = True
-        accession = await operator.replace_metadata_object("study", self.accession_id, data)
+        accession, _ = await operator.replace_metadata_object("study", self.accession_id, data)
         operator.db_service.replace.assert_called_once()
         self.assertEqual(accession, self.accession_id)
 
@@ -388,7 +388,7 @@ class TestOperators(IsolatedAsyncioTestCase):
         xml_data = "<MOCK_ELEM></MOCK_ELEM>"
         with patch(
             "metadata_backend.api.operators.Operator._format_data_to_replace_and_add_to_db",
-            return_value=self.accession_id,
+            return_value=(self.accession_id, "title"),
         ):
             with patch(
                 "metadata_backend.api.operators.XMLOperator._replace_object_from_db",


### PR DESCRIPTION
### Description

Move responsibility of adding an object to a folder on object creation and update from frontend to object endpoint. 

###Related issues
Closes https://github.com/CSCfi/metadata-submitter/issues/335

### Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
Frontend now should add folder ID as a query parameter with object POST.

### Changes Made
Folder id is now required query param with object POST.
A folder is patched after an object is created and updated.
Adds extraction of title for folder's objects display title.

### Testing
- [x] Integration Tests
