### PR TITLE
streamline publish folder with doi and metax information

### DIFF
--- a/.github/config/.wordlist.txt
+++ b/.github/config/.wordlist.txt
@@ -165,6 +165,7 @@ dockerfile
 docstrings
 doi
 doiinfo
+dois
 dt
 dzongkha
 ean
@@ -343,8 +344,8 @@ metagenomics
 metatranscriptome
 metatranscriptomic
 metax
-metaxservicehandler
 metaxidentifier
+metaxservicehandler
 methylation
 methylcytidine
 mf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Adds configuration for mypy linting to VScode devcontainer setup
 - Templates API #256
   - use `ujson` as default json library
-- Creating draft Datacite DOI for folders #257
+- Creating draft Datacite DOI for folders #257 #332
   - created a mock web app, which would act similarly to DataCite REST API
   - altered `publish_folder` endpoint so that `extraInfo` containing the DOI data is added upon publishing
   - added `datePublished` key to folders which takes in the date/time, when folder is published
+- DOI Publishing and deletion to Datacite #332 #369
+  - create draft DOIs for both Study and Datasets and add them to the folder `extraInfo` when published
+  - delete draft DOIs on object delete
+  - update DOI info at Datacite when folder is published
 - VScode Dev environment #287
   - Add VS Code development container
   - Update docker for development
@@ -39,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - enum are sorted alphabetically, with the exception of other and unspecified values which are left at the end of the list
   - allow for accession key in `referenceAlignment` & `process sequence` as array, previously all accession keys were converted to `accessionId` which is not correct
   - add default `gender` as `unknown`
-
+- multilevel add patch objects to support `/extraInfo/datasetIdentifiers/-` which needs dot notation for mongodb to work e.g. `extraInfo.datasetIdentifiers` #332
 
 ### Changed
 
@@ -53,7 +57,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - README updated with tox command, development build instructions, and prettify Dockerfile.
 - Update ENA XML and JSON schemas #299
 - Github actions changed the use of https://git.io/misspell to rojopolis/spellcheck-github-actions #316
-- Separated most of the handlers to own files inside the handlers folder #319
+- Separated most of the handlers to own files inside the handlers folder #319 
+- allow inserting only one study in folder #332
+- JSON schemas #332
+   - introduce `keywords` required for Metax in `doiInfo`
+   - dataset `description` and study `studyAbstract` are now mandatory
 
 ### Fixed
 

--- a/metadata_backend/api/handlers/folder.py
+++ b/metadata_backend/api/handlers/folder.py
@@ -11,10 +11,10 @@ from aiohttp.web import Request, Response
 from multidict import CIMultiDict
 
 from ...conf.conf import doi_config
-from ...helpers.logger import LOG
-from ...helpers.validator import JSONValidator
-from ...helpers.metax_api_handler import MetaxServiceHandler
 from ...helpers.doi import DOIHandler
+from ...helpers.logger import LOG
+from ...helpers.metax_api_handler import MetaxServiceHandler
+from ...helpers.validator import JSONValidator
 from ..middlewares import get_session
 from ..operators import FolderOperator, Operator, UserOperator
 from .restapi import RESTAPIHandler
@@ -529,7 +529,10 @@ class FolderAPIHandler(RESTAPIHandler):
         for obj in folder["drafts"]:
             await obj_ops.delete_metadata_object(obj["schema"], obj["accessionId"])
 
-        await MetaxServiceHandler(req).publish_dataset(metax_ids)
+        # update study to metax with data comming from doi info
+        metax_handler = MetaxServiceHandler(req)
+        await metax_handler.update_dataset_with_doi_info(folder["doiInfo"], metax_ids)
+        await metax_handler.publish_dataset(metax_ids)
 
         # Patch the folder into a published state
         patch = [

--- a/metadata_backend/api/handlers/object.py
+++ b/metadata_backend/api/handlers/object.py
@@ -182,7 +182,7 @@ class ObjectAPIHandler(RESTAPIHandler):
 
         # Create draft dataset to Metax catalog
         if collection in _allowed_doi:
-            [await self._create_metax_dataset(req, collection, item, folder_id) for item in objects]
+            [await self._create_metax_dataset(req, collection, item) for item in objects]
 
         body = ujson.dumps(data, escape_forward_slashes=False)
 
@@ -460,7 +460,7 @@ class ObjectAPIHandler(RESTAPIHandler):
             )
         return [patch_op]
 
-    async def _create_metax_dataset(self, req: Request, collection: str, object: Dict, folder_id: str) -> str:
+    async def _create_metax_dataset(self, req: Request, collection: str, object: Dict) -> str:
         """Handle connection to Metax api handler for dataset creation.
 
         Dataset or Study object is assigned with DOI
@@ -482,9 +482,6 @@ class ObjectAPIHandler(RESTAPIHandler):
         new_info = {"doi": object["doi"], "metaxIdentifier": metax_id}
         await operator.create_metax_info(collection, object["accessionId"], new_info)
 
-        folder_op = FolderOperator(req.app["db_client"])
-        doi_patch = self._prepare_folder_patch_doi(collection, object["doi"], metax_id)
-        await folder_op.update_folder(folder_id, doi_patch)
         return metax_id
 
     async def _draft_doi(self, schema_type: str) -> str:
@@ -502,28 +499,3 @@ class ObjectAPIHandler(RESTAPIHandler):
         LOG.debug(f"doi created with doi: {_doi_data['fullDOI']}")
 
         return _doi_data["fullDOI"]
-
-    def _prepare_folder_patch_doi(self, schema: str, doi: str, url: str) -> List:
-        """Prepare patch operation for updating object's doi information in a folder.
-
-        :param schema: schema of object to be updated
-        :param ids: object IDs
-        :returns: dict with patch operation
-        """
-        patch = []
-
-        data = {
-            "identifier": {
-                "identifierType": "DOI",
-                "doi": doi,
-            },
-            "url": url,
-        }
-        if schema == "study":
-            patch_op = {"op": "add", "path": "/extraInfo/studyIdentifier", "value": data}
-            patch.append(patch_op)
-        elif schema == "dataset":
-            patch_op = {"op": "add", "path": "/extraInfo/datasetIdentifiers/-", "value": data}
-            patch.append(patch_op)
-
-        return patch

--- a/metadata_backend/api/operators.py
+++ b/metadata_backend/api/operators.py
@@ -99,7 +99,7 @@ class BaseOperator(ABC):
         try:
             data_raw = await self.db_service.read(schema_type, accession_id)
             if not data_raw:
-                LOG.error(f"Object with {accession_id} not found.")
+                LOG.error(f"Object with {accession_id} not found in schema: {schema_type}.")
                 raise web.HTTPNotFound()
             data = await self._format_read_data(schema_type, data_raw)
         except (ConnectionFailure, OperationFailure) as error:

--- a/metadata_backend/conf/conf.py
+++ b/metadata_backend/conf/conf.py
@@ -153,12 +153,15 @@ aai_config = {
 
 # 6) Set the DataCite REST API values
 
-doi_api = os.getenv("DOI_API", "")
-doi_prefix = os.getenv("DOI_PREFIX", "")
-doi_user = os.getenv("DOI_USER", "")
-doi_key = os.getenv("DOI_KEY", "")
-datacite_url = os.getenv("DATACITE_URL", "https://doi.org")
-publisher = "CSC - IT Center for Science"
+doi_config = {
+    "api": os.getenv("DOI_API", ""),
+    "prefix": os.getenv("DOI_PREFIX", ""),
+    "user": os.getenv("DOI_USER", ""),
+    "key": os.getenv("DOI_KEY", ""),
+    "url": os.getenv("DATACITE_URL", "https://doi.org"),
+    "publisher": "CSC - IT Center for Science",
+    "discovery_url": "https://etsin.fairdata.fi/dataset/",
+}
 
 metax_config = {
     "username": os.getenv("METAX_USER", "sd"),

--- a/metadata_backend/helpers/doi.py
+++ b/metadata_backend/helpers/doi.py
@@ -26,7 +26,12 @@ class DOIHandler:
         self.headers = {"Content-Type": "application/vnd.api+json"}
 
     async def create_draft(self, prefix: Union[str, None] = None) -> Dict:
-        """Generate random suffix and POST request a draft DOI to DataCite DOI API."""
+        """Generate random suffix and POST request a draft DOI to DataCite DOI API.
+
+        :param prefix: Custom prefix to add to the DOI e.g. study/dataset
+        :raises: HTTPInternalServerError if we the Datacite DOI draft registration fails
+        :returns: Dictionary with DOI and URL
+        """
         suffix = uuid4().hex[:10]
         doi_suffix = f"{prefix}.{suffix[:4]}-{suffix[4:]}" if prefix else f"{suffix[:4]}-{suffix[4:]}"
         # this payload is sufficient to get a draft DOI
@@ -47,27 +52,48 @@ class DOIHandler:
                 else:
                     reason = f"DOI API draft creation request failed with code: {response.status}"
                     LOG.error(reason)
-                    raise web.HTTPBadRequest(reason=reason)  # 400 might not be the correct error for this
+                    raise web.HTTPInternalServerError(reason=reason)
 
         return doi_data
 
-    async def set_state(self, doi_payload: dict) -> None:
+    async def set_state(self, doi_payload: Dict) -> None:
         """Set DOI and associated metadata.
 
         We will only support publish event type, and we expect the data to be
         prepared for the update.
         Partial updates are possible.
 
-        :param doi_suffix: DOI to do operations on.
-        :param state: can be publish, register or hide.
+        :param doi_payload: Dictionary with payload to send to Datacite
+        :raises: HTTPInternalServerError if we the Datacite DOI update fails
+        :returns: None
         """
         auth = BasicAuth(login=self.doi_user, password=self.doi_key)
         async with ClientSession(headers=self.headers, auth=auth) as session:
             async with session.put(f"{self.doi_api}/{doi_payload['id']}", json=doi_payload) as response:
                 if response.status == 200:
-                    draft_resp = await response.json()
-                    LOG.debug(f"Datacite doi response: {draft_resp}")
+                    _resp = await response.json()
+                    LOG.info(f"Datacite doi {doi_payload['id']} updated ")
+                    LOG.debug(f"Datacite doi {doi_payload['id']} updated, response: {_resp}")
                 else:
                     reason = f"DOI API set state request failed with code: {response.status}"
                     LOG.error(reason)
-                    raise web.HTTPBadRequest(reason=reason)  # 400 might not be the correct error for this
+                    raise web.HTTPInternalServerError(reason=reason)
+
+    async def delete(self, doi: str) -> None:
+        """Delete DOI and associated metadata.
+
+        Datacite only support deleting draft DOIs.
+
+        :param doi: identifier to be utilized for deleting draft DOI
+        :raises: HTTPInternalServerError if we the Datacite draft DOI delete fails
+        :returns: None
+        """
+        auth = BasicAuth(login=self.doi_user, password=self.doi_key)
+        async with ClientSession(headers=self.headers, auth=auth) as session:
+            async with session.delete(f"{self.doi_api}/{doi}") as response:
+                if response.status == 204:
+                    LOG.info(f"Datacite doi {doi} deleted.")
+                else:
+                    reason = f"DOI API delete request failed with code: {response.status}"
+                    LOG.error(reason)
+                    raise web.HTTPInternalServerError(reason=reason)

--- a/metadata_backend/helpers/doi.py
+++ b/metadata_backend/helpers/doi.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 from aiohttp import web, ClientSession, BasicAuth, ClientTimeout
 
 from ..helpers.logger import LOG
-from ..conf import conf
+from ..conf.conf import doi_config
 
 
 class DOIHandler:
@@ -17,11 +17,11 @@ class DOIHandler:
 
     def __init__(self) -> None:
         """Get DOI credentials from config."""
-        self.doi_api = conf.doi_api
-        self.doi_prefix = conf.doi_prefix
-        self.doi_user = conf.doi_user
-        self.doi_key = conf.doi_key
-        self.doi_url = f"{conf.datacite_url.rstrip('/')}/{self.doi_prefix}"
+        self.doi_api = doi_config["api"]
+        self.doi_prefix = doi_config["prefix"]
+        self.doi_user = doi_config["user"]
+        self.doi_key = doi_config["key"]
+        self.doi_url = f"{doi_config['url'].rstrip('/')}/{self.doi_prefix}"
         self.timeout = ClientTimeout(total=2 * 60)  # 2 minutes timeout
         self.headers = {"Content-Type": "application/vnd.api+json"}
 

--- a/metadata_backend/helpers/doi.py
+++ b/metadata_backend/helpers/doi.py
@@ -64,7 +64,7 @@ class DOIHandler:
         Partial updates are possible.
 
         :param doi_payload: Dictionary with payload to send to Datacite
-        :raises: HTTPInternalServerError if we the Datacite DOI update fails
+        :raises: HTTPInternalServerError if the Datacite DOI update fails
         :returns: None
         """
         auth = BasicAuth(login=self.doi_user, password=self.doi_key)

--- a/metadata_backend/helpers/metax_api_handler.py
+++ b/metadata_backend/helpers/metax_api_handler.py
@@ -80,9 +80,9 @@ class MetaxServiceHandler:
         metax_dataset = self.minimal_dataset_template
         metax_dataset["metadata_provider_user"] = await self.get_metadata_provider_user()
         if collection == "dataset":
-            dataset_data = await self.create_metax_dataset_data_from_dataset(data)
+            dataset_data = self.create_metax_dataset_data_from_dataset(data)
         else:
-            dataset_data = await self.create_metax_dataset_data_from_study(data)
+            dataset_data = self.create_metax_dataset_data_from_study(data)
         metax_dataset["research_dataset"] = dataset_data
         LOG.debug(
             f"Creating draft dataset to Metax service from Submitter {collection} with accession ID "
@@ -123,9 +123,9 @@ class MetaxServiceHandler:
         # TODO: should this be changed if person updating data is different from data creator?
         metax_dataset["metadata_provider_user"] = await self.get_metadata_provider_user()
         if collection == "dataset":
-            dataset_data = await self.create_metax_dataset_data_from_dataset(data)
+            dataset_data = self.create_metax_dataset_data_from_dataset(data)
         else:
-            dataset_data = await self.create_metax_dataset_data_from_study(data)
+            dataset_data = self.create_metax_dataset_data_from_study(data)
         metax_dataset["research_dataset"] = dataset_data
         LOG.info(f"Sending updated {collection} object data to Metax service.")
 
@@ -197,7 +197,7 @@ class MetaxServiceHandler:
                     raise self.process_error(status, reason)
             LOG.info(f"Metax ID {object['metaxIdentifier']} was published to Metax service.")
 
-    async def create_metax_dataset_data_from_study(self, data: Dict) -> Dict:
+    def create_metax_dataset_data_from_study(self, data: Dict) -> Dict:
         """Construct Metax dataset's research dataset dictionary from Submitters Study.
 
         :param data: Study data
@@ -211,7 +211,7 @@ class MetaxServiceHandler:
         LOG.debug(f"Created Metax dataset from Study with data: {research_dataset}")
         return research_dataset
 
-    async def create_metax_dataset_data_from_dataset(self, data: Dict) -> Dict:
+    def create_metax_dataset_data_from_dataset(self, data: Dict) -> Dict:
         """Construct Metax dataset's research dataset dictionary from Submitters Dataset.
 
         :param data: Dataset data

--- a/tests/integration/mock_doi_api.py
+++ b/tests/integration/mock_doi_api.py
@@ -97,7 +97,7 @@ def update_dict(d, u):
 
 
 async def create(req: web.Request) -> web.Response:
-    """DOI endpoint."""
+    """DOI draft creation endpoint."""
     try:
         content = await req.json()
     except json.decoder.JSONDecodeError as e:
@@ -129,7 +129,7 @@ async def create(req: web.Request) -> web.Response:
 
 
 async def update(req: web.Request) -> web.Response:
-    """DOI endpoint."""
+    """DOI update endpoint."""
     try:
         content = await req.json()
     except json.decoder.JSONDecodeError as e:
@@ -150,11 +150,18 @@ async def update(req: web.Request) -> web.Response:
     return web.json_response(data, status=200)
 
 
+async def delete(req: web.Request) -> web.Response:
+    """DOI delete endpoint."""
+
+    return web.json_response(status=204)
+
+
 def init() -> web.Application:
     """Start server."""
     app = web.Application()
     app.router.add_post("/dois", create)
     app.router.add_put("/dois/{id:.*}", update)
+    app.router.add_delete("/dois/{id:.*}", delete)
     return app
 
 

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -868,7 +868,7 @@ async def test_metax_crud_with_xml(sess, folder_id):
                 assert False, "Metax ID was not in response data"
         object.append(metax_id)
         async with sess.get(f"{metax_url}/{metax_id}") as metax_resp:
-            assert metax_resp.status == 200, f"HTTP Status code error, got {resp.status}"
+            assert metax_resp.status == 200, f"HTTP Status code error, got {metax_resp.status}"
             metax_res = await metax_resp.json()
             assert (
                 res.get("doi", None) == metax_res["research_dataset"]["preferred_identifier"]
@@ -881,7 +881,7 @@ async def test_metax_crud_with_xml(sess, folder_id):
 
     for _, _, metax_id in ids:
         async with sess.get(f"{metax_url}/{metax_id}") as metax_resp:
-            assert metax_resp.status == 200, f"HTTP Status code error, got {resp.status}"
+            assert metax_resp.status == 200, f"HTTP Status code error, got {metax_resp.status}"
             metax_res = await metax_resp.json()
             assert (
                 metax_res.get("date_modified", None) is not None
@@ -893,7 +893,7 @@ async def test_metax_crud_with_xml(sess, folder_id):
 
     for _, _, metax_id in ids:
         async with sess.get(f"{metax_url}/{metax_id}") as metax_resp:
-            assert metax_resp.status == 404, f"HTTP Status code error - expected 404 Not Found, got {resp.status}"
+            assert metax_resp.status == 404, f"HTTP Status code error - expected 404 Not Found, got {metax_resp.status}"
 
 
 async def test_metax_crud_with_json(sess, folder_id):
@@ -923,7 +923,7 @@ async def test_metax_crud_with_json(sess, folder_id):
                 assert False, "Metax ID was not in response data"
         object.append(metax_id)
         async with sess.get(f"{metax_url}/{metax_id}") as metax_resp:
-            assert metax_resp.status == 200, f"HTTP Status code error, got {resp.status}"
+            assert metax_resp.status == 200, f"HTTP Status code error, got {metax_resp.status}"
             metax_res = await metax_resp.json()
             assert (
                 res.get("doi", None) == metax_res["research_dataset"]["preferred_identifier"]
@@ -988,19 +988,16 @@ async def test_metax_publish_dataset(sess, folder_id):
 
     await publish_folder(sess, folder_id)
 
-    # TODO: This must be updated as Metax identifier will be moved to folder from object after publishing
-    # for schema, object_id, metax_id in objects:
-    #     async with sess.get(f"{objects_url}/{schema}/{object_id}") as resp:
-    #         assert resp.status == 200, f"HTTP Status code error, got {resp.status}"
-    #         res = await resp.json()
-    #         actual = res["metaxIdentifier"]
-    #         expected = {"identifier": metax_id, "status": "published"}
-    #         assert expected == actual
+    for schema, object_id, metax_id in objects:
+        async with sess.get(f"{objects_url}/{schema}/{object_id}") as resp:
+            assert resp.status == 200, f"HTTP Status code error, got {resp.status}"
+            res = await resp.json()
+            assert res["metaxIdentifier"] == metax_id
 
-    #     async with sess.get(f"{metax_url}/{metax_id}") as metax_resp:
-    #         assert metax_resp.status == 200, f"HTTP Status code error, got {resp.status}"
-    #         metax_res = await metax_resp.json()
-    #         assert metax_res["state"] == "published"
+        async with sess.get(f"{metax_url}/{metax_id}") as metax_resp:
+            assert metax_resp.status == 200, f"HTTP Status code error, got {metax_resp.status}"
+            metax_res = await metax_resp.json()
+            assert metax_res["state"] == "published"
 
 
 async def test_crud_folders_works(sess):

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -69,6 +69,7 @@ class HandlersTestCase(AioHTTPTestCase):
                 {"accessionId": "EGA123456", "schema": "sample"},
             ],
             "drafts": [],
+            "doiInfo": {"creators": [{"name": "Creator, Test"}]},
         }
         self.user_id = "USR12345678"
         self.test_user = {
@@ -998,6 +999,7 @@ class FolderHandlerTestCase(HandlersTestCase):
         """Test that folder would be published and DOI would be added."""
         self.MockedDoiHandler().set_state.return_value = None
         self.MockedFolderOperator().update_folder.return_value = self.folder_id
+        self.MockedMetaxHandler().update_dataset_with_doi_info.return_value = None
         self.MockedMetaxHandler().publish_dataset.return_value = None
         with patch(
             self._mock_prepare_doi,

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -999,7 +999,17 @@ class FolderHandlerTestCase(HandlersTestCase):
         self.MockedDoiHandler().set_state.return_value = None
         self.MockedFolderOperator().update_folder.return_value = self.folder_id
         self.MockedMetaxHandler().publish_dataset.return_value = None
-        with patch(self._mock_prepare_doi, return_value=({}, [{}])):
+        with patch(
+            self._mock_prepare_doi,
+            return_value=(
+                {"id": "prefix/suffix-study", "attributes": {"url": "http://metax_id", "types": {}}},
+                [{"id": "prefix/suffix-dataset", "attributes": {"url": "http://metax_id", "types": {}}}],
+                [
+                    {"doi": "prefix/suffix-study", "metaxIdentifier": "metax_id"},
+                    {"doi": "prefix/suffix-dataset", "metaxIdentifier": "metax_id"},
+                ],
+            ),
+        ):
             response = await self.client.patch("/publish/FOL12345678")
             self.assertEqual(response.status, 200)
             json_resp = await response.json()

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -120,6 +120,7 @@ class HandlersTestCase(AioHTTPTestCase):
         self.doi_handler = {
             "create_draft.side_effect": self.fake_doi_create_draft,
             "set_state.side_effect": self.fake_doi_set_state,
+            "delete.side_effect": self.fake_doi_delete,
         }
 
         RESTAPIHandler._handle_check_ownedby_user = make_mocked_coro(True)
@@ -167,6 +168,11 @@ class HandlersTestCase(AioHTTPTestCase):
 
     async def fake_doi_set_state(self, data):
         """."""
+        return {"fullDOI": "10.xxxx/yyyyy", "dataset": "https://doi.org/10.xxxx/yyyyy"}
+
+    async def fake_doi_delete(self, doi):
+        """."""
+        return None
 
     async def fake_operator_read_metadata_object(self, schema_type, accession_id):
         """Fake read operation to return mocked JSON."""
@@ -663,9 +669,10 @@ class ObjectHandlerTestCase(HandlersTestCase):
     async def test_delete_is_called(self):
         """Test query method calls operator and returns status correctly."""
         url = "/objects/study/EGA123456"
-        response = await self.client.delete(url)
-        self.assertEqual(response.status, 204)
-        self.MockedOperator().delete_metadata_object.assert_called_once()
+        with patch("metadata_backend.api.handlers.object.DOIHandler.delete", return_value=None):
+            response = await self.client.delete(url)
+            self.assertEqual(response.status, 204)
+            self.MockedOperator().delete_metadata_object.assert_called_once()
 
     async def test_query_fails_with_xml_format(self):
         """Test query method calls operator and returns status correctly."""


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

closes #367 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update (this needs a follow up PR)

### Changes Made

<!-- List changes made. -->
- move doi/datacite configuration to dict to be in line with other configuration
- remove adding `extraInfo` to folder on object POST and adding it when the folder is published
- prepare Metax and Datacite information at once so that we don't need to iterate multiple times and get the information for each object once
- some functions do not need to be async in metax class
- add option to delete draft doi when an object is deleted

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Needs testing (start an issue or do a follow up PR about it)

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
Unit tests will be improved with a new PR