### PR TITLE
Feature/update submission endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Submission endpoint update #371
+  - Adds mandatory query parameter `folder` for submit endpoint POST 
+  - On actions add and modify object is added or updated to folder(submission) where it belongs with it's accession ID, schema, submission type, title and filename
+  - Adds metax integration to submit endpoint
 - Integration with Metax service #356
   - Adds new local container for testing against mocked Metax API
   - Introduces new env vars: METAX_USER, METAX_PASS, METAX_URL
   - Adds new key metaxIdentifier to Study and Dataset collections containing metax id returned from Metax API
   - Adds new handler MetaxServiceHandler to take care of mapping Submitter metadata to Metax metadata and to connect to Metax API
 - Add patching of folders after object save and update operations #354
+  - Adds mandatory query parameter `folder` for objects endpoint POST 
   - Object is added or updated to folder(submission) where it belongs with it's accession ID, schema, submission type, title and filename in the case of CSV and XML upload
   - Adds configuration for mypy linting to VScode devcontainer setup
 - Templates API #256
@@ -46,7 +51,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - multilevel add patch objects to support `/extraInfo/datasetIdentifiers/-` which needs dot notation for mongodb to work e.g. `extraInfo.datasetIdentifiers` #332
 
 ### Changed
-
 - Refactor auth.py package by removing custom OIDC code and replacing it with https://github.com/IdentityPython/JWTConnect-Python-OidcRP. #315
   - New mandatory ENV `OIDC_URL`
   - New optional ENVs `OIDC_SCOPE`, `AUTH_METHOD`

--- a/docs/specification.yml
+++ b/docs/specification.yml
@@ -21,6 +21,14 @@ paths:
       tags:
         - Submission
       summary: XML submission endpoint, will also trigger validation.
+      parameters:
+        - name: folder
+          in: query
+          schema:
+            type: string
+          description: The folder ID where object belongs to.
+          required: true
+          example: "folder=12345"
       requestBody:
         content:
           multipart/form-data:
@@ -293,11 +301,6 @@ paths:
         - Submission
       summary: Submit data to a specific schema
       parameters:
-        - in: query
-          name: folder
-          schema:
-            type: string
-          description: The folder ID where object belongs to.
         - name: schema
           in: path
           description: Name of the Metadata schema.

--- a/metadata_backend/api/handlers/object.py
+++ b/metadata_backend/api/handlers/object.py
@@ -182,7 +182,7 @@ class ObjectAPIHandler(RESTAPIHandler):
 
         # Create draft dataset to Metax catalog
         if collection in _allowed_doi:
-            [await self._create_metax_dataset(req, collection, item) for item, _ in objects]
+            [await self.create_metax_dataset(req, collection, item) for item, _ in objects]
 
         body = ujson.dumps(data, escape_forward_slashes=False)
 
@@ -460,7 +460,7 @@ class ObjectAPIHandler(RESTAPIHandler):
             )
         return [patch_op]
 
-    async def _create_metax_dataset(self, req: Request, collection: str, object: Dict) -> str:
+    async def create_metax_dataset(self, req: Request, collection: str, object: Dict) -> str:
         """Handle connection to Metax api handler for dataset creation.
 
         Dataset or Study object is assigned with DOI

--- a/metadata_backend/api/handlers/submission.py
+++ b/metadata_backend/api/handlers/submission.py
@@ -5,19 +5,20 @@ from typing import Dict, List
 import ujson
 from aiohttp import web
 from aiohttp.web import Request, Response
-from motor.motor_asyncio import AsyncIOMotorClient
 from multidict import MultiDict, MultiDictProxy
 from xmlschema import XMLSchemaException
 
 from ...helpers.logger import LOG
+from ...helpers.metax_api_handler import MetaxServiceHandler
 from ...helpers.parser import XMLToJSONParser
 from ...helpers.schema_loader import SchemaNotFoundException, XMLSchemaLoader
 from ...helpers.validator import XMLValidator
-from ..operators import Operator, XMLOperator
+from ..operators import FolderOperator, Operator, XMLOperator
 from .common import multipart_content
+from .object import ObjectAPIHandler
 
 
-class SubmissionAPIHandler:
+class SubmissionAPIHandler(ObjectAPIHandler):
     """Handler for non-rest API methods."""
 
     async def submit(self, req: Request) -> Response:
@@ -66,20 +67,20 @@ class SubmissionAPIHandler:
 
         # Go through parsed files and do the actual action
         results: List[Dict] = []
-        db_client = req.app["db_client"]
         for file in files:
             content_xml = file[0]
             schema_type = file[1]
+            filename = file[2]
             if schema_type == "submission":
                 LOG.debug("file has schema of submission type, continuing ...")
                 continue  # No need to use submission xml
             action = actions[schema_type]
             if isinstance(action, List):
                 for item in action:
-                    result = await self._execute_action(schema_type, content_xml, db_client, item)
+                    result = await self._execute_action(req, schema_type, content_xml, item, filename)
                     results.append(result)
             else:
-                result = await self._execute_action(schema_type, content_xml, db_client, action)
+                result = await self._execute_action(req, schema_type, content_xml, action, filename)
                 results.append(result)
 
         body = ujson.dumps(results, escape_forward_slashes=False)
@@ -115,7 +116,7 @@ class SubmissionAPIHandler:
             LOG.error(reason)
             raise web.HTTPBadRequest(reason=reason)
 
-    async def _execute_action(self, schema: str, content: str, db_client: AsyncIOMotorClient, action: str) -> Dict:
+    async def _execute_action(self, req: Request, schema: str, content: str, action: str, filename: str) -> Dict:
         """Complete the command in the action set of the submission file.
 
         Only "add/modify/validate" actions are supported.
@@ -128,34 +129,10 @@ class SubmissionAPIHandler:
         :returns: Dict containing specific action that was completed
         """
         if action == "add":
-            json_data = await XMLOperator(db_client).create_metadata_object(schema, content)
-            result = {
-                "accessionId": json_data["accessionId"],
-                "schema": schema,
-            }
-            LOG.debug(f"added some content in {schema} ...")
-            return result
+            return await self._execute_action_add(req, schema, content, filename)
 
         elif action == "modify":
-            data_as_json = XMLToJSONParser().parse(schema, content)
-            if "accessionId" in data_as_json:
-                accession_id = data_as_json["accessionId"]
-            else:
-                alias = data_as_json["alias"]
-                query = MultiDictProxy(MultiDict([("alias", alias)]))
-                data, _, _, _ = await Operator(db_client).query_metadata_database(schema, query, 1, 1, [])
-                if len(data) > 1:
-                    reason = "Alias in provided XML file corresponds with more than one existing metadata object."
-                    LOG.error(reason)
-                    raise web.HTTPBadRequest(reason=reason)
-                accession_id = data[0]["accessionId"]
-            data_as_json.pop("accessionId", None)
-            result = {
-                "accessionId": await Operator(db_client).update_metadata_object(schema, accession_id, data_as_json),
-                "schema": schema,
-            }
-            LOG.debug(f"modified some content in {schema} ...")
-            return result
+            return await self._execute_action_modify(req, schema, content, filename)
 
         elif action == "validate":
             validator = await self._perform_validation(schema, content)
@@ -165,3 +142,115 @@ class SubmissionAPIHandler:
             reason = f"Action {action} in XML is not supported."
             LOG.error(reason)
             raise web.HTTPBadRequest(reason=reason)
+
+    async def _execute_action_add(self, req: Request, schema: str, content: str, filename: str) -> Dict:
+        """Complete the command in the action set of the submission file.
+
+        Only "add/modify/validate" actions are supported.
+
+        :param schema: Schema type of the object in question
+        :param content: Metadata object referred to in submission
+        :param db_client: Database client for database operations
+        :param action: Type of action to be done
+        :raises: HTTPBadRequest if an incorrect or non-supported action is called
+        :returns: Dict containing specific action that was completed
+        """
+        _allowed_doi = {"study", "dataset"}
+        db_client = req.app["db_client"]
+        folder_op = FolderOperator(db_client)
+
+        folder_id = req.query.get("folder", "")
+        if not folder_id:
+            reason = "Folder is required query parameter. Please provide folder id where object is added to."
+            raise web.HTTPBadRequest(reason=reason)
+
+        # we need to check if there is already a study in a folder
+        # we only allow one study per folder
+        # this is not enough to catch duplicate entries if updates happen in parallel
+        # that is why we check in db_service.update_study
+        if not req.path.startswith("/drafts") and schema == "study":
+            _ids = await folder_op.get_collection_objects(folder_id, schema)
+            if len(_ids) == 1:
+                reason = "Only one study is allowed per submission."
+                raise web.HTTPBadRequest(reason=reason)
+
+        json_data = await XMLOperator(db_client).create_metadata_object(schema, content)
+
+        result = {
+            "accessionId": json_data["accessionId"],
+            "schema": schema,
+        }
+        LOG.debug(f"added some content in {schema} ...")
+
+        # Gathering data for object to be added to folder
+        patch = self._prepare_folder_patch_new_object(schema, [(json_data, filename)], "xml")
+        await folder_op.update_folder(folder_id, patch)
+
+        # Create draft dataset to Metax catalog
+        if schema in _allowed_doi:
+            await self.create_metax_dataset(req, schema, json_data)
+
+        return result
+
+    async def _execute_action_modify(self, req: Request, schema: str, content: str, filename: str) -> Dict:
+        """Complete the command in the action set of the submission file.
+
+        Only "add/modify/validate" actions are supported.
+
+        :param schema: Schema type of the object in question
+        :param content: Metadata object referred to in submission
+        :param db_client: Database client for database operations
+        :param action: Type of action to be done
+        :raises: HTTPBadRequest if an incorrect or non-supported action is called
+        :returns: Dict containing specific action that was completed
+        """
+        _allowed_doi = {"study", "dataset"}
+        db_client = req.app["db_client"]
+        folder_op = FolderOperator(db_client)
+        operator = Operator(db_client)
+        data_as_json = XMLToJSONParser().parse(schema, content)
+        if "accessionId" in data_as_json:
+            accession_id = data_as_json["accessionId"]
+        else:
+            alias = data_as_json["alias"]
+            query = MultiDictProxy(MultiDict([("alias", alias)]))
+            data, _, _, _ = await operator.query_metadata_database(schema, query, 1, 1, [])
+            if len(data) > 1:
+                reason = "Alias in provided XML file corresponds with more than one existing metadata object."
+                LOG.error(reason)
+                raise web.HTTPBadRequest(reason=reason)
+            accession_id = data[0]["accessionId"]
+        data_as_json.pop("accessionId", None)
+        result = {
+            # should here be replace_metadata_object ??
+            "accessionId": await operator.update_metadata_object(schema, accession_id, data_as_json),
+            "schema": schema,
+        }
+
+        exists, folder_id, published = await folder_op.check_object_in_folder(schema, result["accessionId"])
+        if exists:
+            if published:
+                reason = "Published objects cannot be updated."
+                LOG.error(reason)
+                raise web.HTTPUnauthorized(reason=reason)
+
+        # If there's changed title it will be updated to folder
+        try:
+            _ = data_as_json["descriptor"]["studyTitle"] if schema == "study" else data_as_json["title"]
+            # should we overwrite filename as it is the name of file with partial update data
+            patch = self._prepare_folder_patch_update_object(schema, data_as_json, filename)
+            await folder_op.update_folder(folder_id, patch)
+        except (TypeError, KeyError):
+            pass
+
+        # Update draft dataset to Metax catalog
+        if schema in _allowed_doi:
+            object_data, _ = await operator.read_metadata_object(schema, accession_id)
+            # MYPY related if statement, Operator (when not XMLOperator) always returns object_data as dict
+            if isinstance(object_data, Dict):
+                await MetaxServiceHandler(req).update_draft_dataset(schema, object_data)
+            else:
+                raise ValueError("Object's data must be dictionary")
+
+        LOG.debug(f"modified some content in {schema} ...")
+        return result

--- a/metadata_backend/api/handlers/submission.py
+++ b/metadata_backend/api/handlers/submission.py
@@ -121,10 +121,11 @@ class SubmissionAPIHandler(ObjectAPIHandler):
 
         Only "add/modify/validate" actions are supported.
 
+        :param req: Multipart POST request
         :param schema: Schema type of the object in question
         :param content: Metadata object referred to in submission
-        :param db_client: Database client for database operations
         :param action: Type of action to be done
+        :param filename: Name of file being processed
         :raises: HTTPBadRequest if an incorrect or non-supported action is called
         :returns: Dict containing specific action that was completed
         """
@@ -144,14 +145,12 @@ class SubmissionAPIHandler(ObjectAPIHandler):
             raise web.HTTPBadRequest(reason=reason)
 
     async def _execute_action_add(self, req: Request, schema: str, content: str, filename: str) -> Dict:
-        """Complete the command in the action set of the submission file.
+        """Complete the add action.
 
-        Only "add/modify/validate" actions are supported.
-
+        :param req: Multipart POST request
         :param schema: Schema type of the object in question
         :param content: Metadata object referred to in submission
-        :param db_client: Database client for database operations
-        :param action: Type of action to be done
+        :param filename: Name of file being processed
         :raises: HTTPBadRequest if an incorrect or non-supported action is called
         :returns: Dict containing specific action that was completed
         """
@@ -193,14 +192,12 @@ class SubmissionAPIHandler(ObjectAPIHandler):
         return result
 
     async def _execute_action_modify(self, req: Request, schema: str, content: str, filename: str) -> Dict:
-        """Complete the command in the action set of the submission file.
+        """Complete the modify action.
 
-        Only "add/modify/validate" actions are supported.
-
+        :param req: Multipart POST request
         :param schema: Schema type of the object in question
         :param content: Metadata object referred to in submission
-        :param db_client: Database client for database operations
-        :param action: Type of action to be done
+        :param filename: Name of file being processed
         :raises: HTTPBadRequest if an incorrect or non-supported action is called
         :returns: Dict containing specific action that was completed
         """

--- a/metadata_backend/api/handlers/submission.py
+++ b/metadata_backend/api/handlers/submission.py
@@ -31,7 +31,7 @@ class SubmissionAPIHandler:
         :raises: HTTPBadRequest if request is missing some parameters or cannot be processed
         :returns: XML-based receipt from submission
         """
-        files, _, _ = await multipart_content(req, expect_xml=True)
+        files, _ = await multipart_content(req, expect_xml=True)
         schema_types = Counter(file[1] for file in files)
         if "submission" not in schema_types:
             reason = "There must be a submission.xml file in submission."
@@ -92,8 +92,8 @@ class SubmissionAPIHandler:
         :param req: Multipart POST request with submission.xml and files
         :returns: JSON response indicating if validation was successful or not
         """
-        files, _, _ = await multipart_content(req, extract_one=True, expect_xml=True)
-        xml_content, schema_type = files[0]
+        files, _ = await multipart_content(req, extract_one=True, expect_xml=True)
+        xml_content, schema_type, _ = files[0]
         validator = await self._perform_validation(schema_type, xml_content)
         return web.Response(body=validator.resp_body, content_type="application/json")
 


### PR DESCRIPTION
### Description

Update submit endpoint to do folder patching and Metax related actions similarly as object endpoint.

Fix bug with multipart content filename extraction:
it is possible to submit several metadata objects with each of their own
file which is happening in submit endpoint. Till now only the last file's filename was
extracted. That is now fixed.

**Disclaimer**: rebased on #356

### Related issues
Closes  #368

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Changes Made
Separate add and modify actions to own functions in the submission handler.
Add folder patching after submission _add_ and _modify_ actions.
Add integration with Metax on submission _add_ and _modify_ actions.
Update integration tests.

### Testing
- [x] Integration Tests
