### PR TITLE
keywords as list instead of array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - JSON schemas #332
    - introduce `keywords` required for Metax in `doiInfo`
    - dataset `description` and study `studyAbstract` are now mandatory
+- `keywords` will be comma separated values, that will require splitting when adding to Metax API
 
 ### Fixed
 

--- a/metadata_backend/helpers/schemas/datacite.json
+++ b/metadata_backend/helpers/schemas/datacite.json
@@ -163,13 +163,9 @@
             "uniqueItems": true
         },
         "keywords": {
-            "type": "array",
+            "type": "string",
             "title": "Keywords",
-            "description": "A keyword or tag describing the resources. It is recommended to use a controlled vocabulary, ontology or classification when choosing keywords. At least one keyword is required.",
-            "items": {
-                "minLength": 1,
-                "type": "string"
-            }
+            "description": "A list of keywords or tags describing the resources. It is recommended to use a controlled vocabulary, ontology or classification when choosing keywords. Multiple keywords can be added, separating them by comma."
         },
         "contributors": {
             "type": "array",

--- a/metadata_backend/helpers/schemas/folders.json
+++ b/metadata_backend/helpers/schemas/folders.json
@@ -213,13 +213,9 @@
           "uniqueItems": true
         },
         "keywords": {
-          "type": "array",
+          "type": "string",
           "title": "Keywords",
-          "description": "A keyword or tag describing the resources. It is recommended to use a controlled vocabulary, ontology or classification when choosing keywords. At least one keyword is required.",
-          "items": {
-            "minLength": 1,
-            "type": "string"
-          }
+          "description": "A list of keywords or tags describing the resources. It is recommended to use a controlled vocabulary, ontology or classification when choosing keywords. Multiple keywords can be added, separating them by comma."
         },
         "contributors": {
           "type": "array",

--- a/tests/test_files/doi/test_doi.json
+++ b/tests/test_files/doi/test_doi.json
@@ -22,10 +22,7 @@
       "subjectScheme": "Fields of Science and Technology (FOS)"
     }
   ],
-  "keywords": [
-    "test",
-    "keyword"
-  ],
+  "keywords": "test,keyword",
   "contributors": [
     {
       "name": "Contributor, Test",


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

closes #385 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->


- [x] New feature (non-breaking change which adds functionality)

### Changes Made

<!-- List changes made. -->
1. modify schema for doi to be of type string instead of array
2. this will require `keywords` be split by comma into an array when added to Metax API

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply