### PR TITLE
restrict the use of doi key for study and dataset

### DIFF
--- a/metadata_backend/api/operators.py
+++ b/metadata_backend/api/operators.py
@@ -484,18 +484,18 @@ class Operator(BaseOperator):
 
         Replace information in object before adding to db.
 
-        We will not replace accessionId, publishDate or dateCreated,
+        We will not replace ``accessionId``, ``publishDate`` or ``dateCreated``,
         as these are generated when created.
-        Will not replace metaxIdentifier for study and dataset
+        Will not replace ``metaxIdentifier`` and ``doi`` for ``study`` and ``dataset``
         as it is generated when created.
-        We will keep also publisDate and dateCreated from old object.
+        We will keep also ``publisDate`` and ``dateCreated`` from old object.
 
         :param schema_type: Schema type of the object to replace.
         :param accession_id: Identifier of object to replace.
         :param data: Metadata object
         :returns: Accession Id for object inserted to database
         """
-        forbidden_keys = {"accessionId", "publishDate", "dateCreated", "metaxIdentifier"}
+        forbidden_keys = {"accessionId", "publishDate", "dateCreated", "metaxIdentifier", "doi"}
         if any(i in data for i in forbidden_keys):
             reason = f"Some items (e.g: {', '.join(forbidden_keys)}) cannot be changed."
             LOG.error(reason)
@@ -509,12 +509,15 @@ class Operator(BaseOperator):
     async def _format_data_to_update_and_add_to_db(self, schema_type: str, accession_id: str, data: Any) -> str:
         """Format and update data in database.
 
+        Will not allow to update ``metaxIdentifier`` and ``doi`` for ``study`` and ``dataset``
+        as it is generated when created.
+
         :param schema_type: Schema type of the object to replace.
         :param accession_id: Identifier of object to replace.
         :param data: Metadata object
         :returns: Accession Id for object inserted to database
         """
-        forbidden_keys = {"accessionId", "publishDate", "dateCreated", "metaxIdentifier"}
+        forbidden_keys = {"accessionId", "publishDate", "dateCreated", "metaxIdentifier", "doi"}
         if any(i in data for i in forbidden_keys):
             reason = f"Some items (e.g: {', '.join(forbidden_keys)}) cannot be changed."
             LOG.error(reason)


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->

We need to restrict doi key so that it does not possible to overwrite it with put or patch

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

closes #379 

this should have been fixed in #380 but got lost on rebase of #356

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

<!-- List changes made. -->

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
