### PR TITLE
Add retry decorator to Metax API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- connection checking and `retry`-mechanism for calls to Metax-service in case of server and connection errors
 
 ### Added
 

--- a/metadata_backend/api/handlers/object.py
+++ b/metadata_backend/api/handlers/object.py
@@ -320,10 +320,10 @@ class ObjectAPIHandler(RESTAPIHandler):
 
         # Update draft dataset to Metax catalog
         if collection in _allowed_doi:
-            if not data.get("metaxIdentifier", None):
-                await self.create_metax_dataset(req, collection, data, create_draft_doi=False)
-            else:
+            if data.get("metaxIdentifier", None):
                 await MetaxServiceHandler(req).update_draft_dataset(collection, data)
+            else:
+                await self.create_metax_dataset(req, collection, data, create_draft_doi=False)
 
         body = ujson.dumps({"accessionId": accession_id}, escape_forward_slashes=False)
         LOG.info(f"PUT object with accession ID {accession_id} in schema {collection} was successful.")
@@ -381,10 +381,10 @@ class ObjectAPIHandler(RESTAPIHandler):
             object_data, _ = await operator.read_metadata_object(collection, accession_id)
             # MYPY related if statement, Operator (when not XMLOperator) always returns object_data as dict
             if isinstance(object_data, Dict):
-                if not object_data.get("metaxIdentifier", None):
-                    await self.create_metax_dataset(req, collection, object_data, create_draft_doi=False)
-                else:
+                if object_data.get("metaxIdentifier", None):
                     await MetaxServiceHandler(req).update_draft_dataset(collection, object_data)
+                else:
+                    await self.create_metax_dataset(req, collection, object_data, create_draft_doi=False)
             else:
                 raise ValueError("Object's data must be dictionary")
 

--- a/metadata_backend/helpers/metax_api_handler.py
+++ b/metadata_backend/helpers/metax_api_handler.py
@@ -1,14 +1,25 @@
 """Class for handling calls to METAX API."""
+
 from typing import Any, Dict, List
 
-from aiohttp import BasicAuth, ClientSession
-from aiohttp.web import HTTPBadRequest, HTTPError, HTTPForbidden, HTTPNotFound, Request
+from aiohttp import BasicAuth, ClientConnectorError, ClientSession
+from aiohttp.web import (
+    HTTPBadRequest,
+    HTTPError,
+    HTTPForbidden,
+    HTTPNotFound,
+    HTTPRequestTimeout,
+    HTTPServerError,
+    HTTPUnauthorized,
+    Request,
+)
 
 from ..api.middlewares import get_session
 from ..api.operators import UserOperator
 from ..conf.conf import metax_config
 from .logger import LOG
 from .metax_mapper import MetaDataMapper
+from .retry import retry
 
 
 class MetaxServiceHandler:
@@ -60,7 +71,7 @@ class MetaxServiceHandler:
     async def get_metadata_provider_user(self) -> str:
         """Get current user's external id.
 
-        returns: current users external ID
+        :returns: Current users external ID
         """
         current_user = get_session(self.req)["user_info"]
         user_op = UserOperator(self.db_client)
@@ -68,108 +79,114 @@ class MetaxServiceHandler:
         metadata_provider_user = user["externalId"]
         return metadata_provider_user
 
-    async def post_dataset_as_draft(self, collection: str, data: Dict) -> str:
-        """Send draft dataset to Metax.
+    @retry(total_tries=5)
+    async def _get(self, metax_id: str) -> str:
+        async with ClientSession() as sess:
+            resp = await sess.get(
+                f"{self.metax_url}{self.rest_route}/{metax_id}",
+                auth=self.auth,
+            )
+            status = resp.status
+            if status == 200:
+                return await resp.json()
+            else:
+                reason = await resp.text()
+                raise self.metax_error(status, reason)
 
-        Construct Metax dataset data from submitters' Study or Dataset and
-        send it as new draft dataset to Metax Dataset API.
+    @retry(total_tries=3)
+    async def _post_draft(self, json_data: Dict) -> Dict:
+        """Post call to Metax REST API.
 
-        :param collection: schema of incomming submitters metadata
-        :param data: validated Study or Dataset data dict
-        :raises: HTTPError depending on returned error from Metax
-        :returns: Metax ID for dataset returned by Metax API
+        :param json_data: Dict with request data
+        :returns: Dict with full Metax dataset
         """
-        LOG.debug(
-            f"Creating draft dataset to Metax service from Submitter {collection} with accession ID "
-            f"{data['accessionId']}"
-        )
-        metax_dataset = self.minimal_dataset_template
-        metax_dataset["metadata_provider_user"] = await self.get_metadata_provider_user()
-        if collection == "dataset":
-            dataset_data = self.create_metax_dataset_data_from_dataset(data)
-        else:
-            dataset_data = self.create_metax_dataset_data_from_study(data)
-        metax_dataset["research_dataset"] = dataset_data
         async with ClientSession() as sess:
             resp = await sess.post(
                 f"{self.metax_url}{self.rest_route}",
                 params="draft",
-                json=metax_dataset,
+                json=json_data,
                 auth=self.auth,
             )
             status = resp.status
             if status == 201:
                 metax_data = await resp.json()
                 LOG.info(f"Created Metax draft dataset {metax_data['identifier']}")
-                LOG.debug(f"Created Metax draft dataset {metax_data['identifier']} with data: {metax_dataset}.")
-                metax_id = metax_data["identifier"]
+                return metax_data
             else:
                 reason = await resp.text()
-                raise self.process_error(status, reason)
+                raise self.metax_error(status, reason)
 
-            # Metax service overwrites preferred id (DOI) with temporary id for draft datasets
-            # Patching dataset with full research_dataset data updates preferred id to the real one
-            async with ClientSession() as sess:
-                resp = await sess.patch(
-                    f"{self.metax_url}{self.rest_route}/{metax_id}",
-                    json={"research_dataset": dataset_data},
-                    auth=self.auth,
-                )
-                status = resp.status
-                if status == 200:
-                    metax_data = await resp.json()
-                    LOG.info("Updated Metax draft dataset with permanent preferred identifier.")
-                    LOG.debug(
-                        f"Updated Metax draft dataset {metax_data['identifier']} with permanent preferred "
-                        "identifier."
-                    )
-                    return metax_id
-                else:
-                    reason = await resp.text()
-                    raise self.process_error(status, reason)
+    @retry(total_tries=3)
+    async def _put(self, metax_id: str, json_data: Dict) -> Dict:
+        """Put call to Metax REST API.
 
-    async def update_draft_dataset(self, collection: str, data: Dict) -> str:
-        """Update draft dataset to Metax.
-
-        Construct Metax draft dataset data from submitters' Study or Dataset and
-        send it to Metax Dataset API for update.
-
-        :param collection: schema of incomming submitters metadata
-        :param data: validated Study or Dataset data dict
-        :raises: HTTPError depending on returned error from Metax
-        :returns: Metax ID for dataset returned by Metax API
+        :param metax_id: ID of dataset to be updated
+        :param json_data: Dict with request data
+        :returns: Dict with full Metax dataset
         """
-        LOG.info(f"Updating Metax draft dataset {data['metaxIdentifier']}")
-        metax_dataset = self.minimal_dataset_template
-        metax_dataset["metadata_provider_user"] = await self.get_metadata_provider_user()
-        if collection == "dataset":
-            dataset_data = self.create_metax_dataset_data_from_dataset(data)
-        else:
-            dataset_data = self.create_metax_dataset_data_from_study(data)
-        metax_dataset["research_dataset"] = dataset_data
-
         async with ClientSession() as sess:
             resp = await sess.put(
-                f'{self.metax_url}{self.rest_route}/{data["metaxIdentifier"]}',
-                params="draft",
-                json=metax_dataset,
+                f"{self.metax_url}{self.rest_route}/{metax_id}",
+                json=json_data,
                 auth=self.auth,
             )
             status = resp.status
             if status == 200:
-                metax_data = await resp.json()
-                LOG.debug(f"Updated Metax draft dataset with ID {metax_data['identifier']} with data: {metax_dataset}")
-                return metax_data["identifier"]
+                LOG.info(f"Updated Metax dataset {metax_id}")
+                return await resp.json()
             else:
                 reason = await resp.text()
-                raise self.process_error(status, reason)
+                raise self.metax_error(status, reason)
 
-    async def delete_draft_dataset(self, metax_id: str) -> None:
+    @retry(total_tries=3)
+    async def _patch(self, metax_id: str, json_data: Dict) -> Dict:
+        """Patch call to Metax REST API.
+
+        :param metax_id: ID of dataset to be updated
+        :param json_data: Dict with request data
+        :returns: Dict with full Metax dataset
+        """
+        async with ClientSession() as sess:
+            resp = await sess.patch(
+                f"{self.metax_url}{self.rest_route}/{metax_id}",
+                json=json_data,
+                auth=self.auth,
+            )
+            status = resp.status
+            if status == 200:
+                LOG.info(f"Patched Metax dataset {metax_id}")
+                return await resp.json()
+            else:
+                reason = await resp.text()
+                raise self.metax_error(status, reason)
+
+    @retry(total_tries=5)
+    async def _bulk_patch(self, json_data: Dict) -> Dict:
+        """Bulk patch call to Metax REST API.
+
+        :param json_data: Dict with request data
+        :returns: Dict with full Metax dataset
+        """
+        async with ClientSession() as sess:
+            resp = await sess.patch(
+                f"{self.metax_url}{self.rest_route}",
+                json=json_data,
+                auth=self.auth,
+            )
+            status = resp.status
+            if status == 200:
+                LOG.info("Updated Metax datasets")
+                return await resp.json()
+            else:
+                reason = await resp.text()
+                raise self.metax_error(status, reason)
+
+    @retry((HTTPServerError, ClientConnectorError), 3)
+    async def _delete_draft(self, metax_id: str) -> None:
         """Delete draft dataset from Metax service.
 
         :param metax_id: Identification string pointing to Metax dataset to be deleted
         """
-        LOG.info(f"Deleting Metax draft dataset {metax_id}")
         async with ClientSession() as sess:
             resp = await sess.delete(
                 f"{self.metax_url}{self.rest_route}/{metax_id}",
@@ -180,7 +197,107 @@ class MetaxServiceHandler:
                 LOG.debug(f"Deleted draft dataset {metax_id} from Metax service")
             else:
                 reason = await resp.text()
-                raise self.process_error(status, reason)
+                raise self.metax_error(status, reason)
+
+    @retry(total_tries=5)
+    async def _publish(self, metax_id: str) -> str:
+        """Post call to Metax RPC publish endpoint.
+
+        :param metax_id: ID of dataset to be updated
+        :param json_data: Dict with request data
+        :returns: Dict with full Metax dataset
+        """
+        async with ClientSession() as sess:
+            resp = await sess.post(
+                f"{self.metax_url}{self.publish_route}",
+                params={"identifier": metax_id},
+                auth=self.auth,
+            )
+            status = resp.status
+            if status == 200:
+                LOG.info(f"Metax ID {metax_id} was published to Metax service.")
+                res = await resp.json()
+                return res["preferred_identifier"]
+            else:
+                reason = await resp.text()
+                raise self.metax_error(status, reason)
+
+    async def post_dataset_as_draft(self, collection: str, data: Dict) -> str:
+        """Send draft dataset to Metax.
+
+        Construct Metax dataset data from submitters' Study or Dataset and
+        send it as new draft dataset to Metax Dataset API.
+
+        :param collection: Schema of incomming submitters metadata
+        :param data: Validated Study or Dataset data dict
+        :raises: HTTPError depending on returned error from Metax
+        :returns: Metax ID for dataset returned by Metax API
+        """
+        LOG.debug(
+            f"Creating draft dataset to Metax service from Submitter {collection} with accession ID "
+            f"{data['accessionId']}"
+        )
+        try:
+            metax_dataset = self.minimal_dataset_template
+            metax_dataset["metadata_provider_user"] = await self.get_metadata_provider_user()
+            if collection == "dataset":
+                dataset_data = self.create_metax_dataset_data_from_dataset(data)
+            else:
+                dataset_data = self.create_metax_dataset_data_from_study(data)
+            metax_dataset["research_dataset"] = dataset_data
+
+            metax_data = await self._post_draft(metax_dataset)
+            LOG.debug(
+                f"Created Metax draft dataset from Submitter {collection} "
+                f"{data['accessionId']} with data: {metax_data}."
+            )
+            metax_id = metax_data["identifier"]
+            # Metax service overwrites preferred id (DOI) with temporary id for draft datasets
+            # Patching dataset with full research_dataset data updates preferred id to the real one
+            LOG.debug(f"Updating Metax draft dataset {metax_id} with permanent preferred identifier.")
+            await self._patch(metax_id, {"research_dataset": dataset_data})
+            return metax_id
+        except (HTTPRequestTimeout, HTTPServerError, ClientConnectorError):
+            return ""
+
+    async def update_draft_dataset(self, collection: str, data: Dict) -> None:
+        """Update draft dataset to Metax.
+
+        Construct Metax draft dataset data from submitters' Study or Dataset and
+        send it to Metax Dataset API for update.
+
+        :param collection: Schema of incomming submitters metadata
+        :param data: Validated Study or Dataset data dict
+        :raises: HTTPError depending on returned error from Metax
+        :returns: Metax ID for dataset returned by Metax API
+        """
+        LOG.info(f"Updating {collection} object data to Metax service.")
+        try:
+            metax_dataset = self.minimal_dataset_template
+            metax_dataset["metadata_provider_user"] = await self.get_metadata_provider_user()
+            if collection == "dataset":
+                dataset_data = self.create_metax_dataset_data_from_dataset(data)
+            else:
+                dataset_data = self.create_metax_dataset_data_from_study(data)
+            metax_dataset["research_dataset"] = dataset_data
+
+            metax_data = await self._put(data["metaxIdentifier"], metax_dataset)
+            LOG.debug(f"Updated Metax ID {data['metaxIdentifier']}, new metadata is: {metax_data}")
+        except (HTTPRequestTimeout, HTTPServerError, ClientConnectorError) as e:
+            LOG.debug(f"Updating draft dataset failed due to: {e}")
+            pass
+
+    async def delete_draft_dataset(self, metax_id: str) -> None:
+        """Delete draft dataset from Metax service.
+
+        :param metax_id: Identification string pointing to Metax dataset to be deleted
+        """
+        LOG.info(f"Deleting Metax draft dataset {metax_id}")
+        try:
+            await self._delete_draft(metax_id)
+        except (HTTPRequestTimeout, HTTPServerError, ClientConnectorError) as e:
+            LOG.debug(f"Updating draft dataset failed due to: {e}")
+            pass
 
     async def update_dataset_with_doi_info(self, doi_info: Dict, _metax_ids: List) -> None:
         """Update dataset for publishing.
@@ -194,36 +311,14 @@ class MetaxServiceHandler:
         )
         bulk_data = []
         for id in _metax_ids:
-            async with ClientSession() as sess:
-                resp = await sess.get(
-                    f"{self.metax_url}{self.rest_route}/{id['metaxIdentifier']}",
-                    auth=self.auth,
-                )
-                status = resp.status
-                if status == 200:
-                    metax_data = await resp.json()
-                else:
-                    reason = await resp.text()
-                    raise self.process_error(status, reason)
+            metax_data = await self._get(id["metaxIdentifier"])
 
-                # Map fields from doi info to Metax schema
-                mapper = MetaDataMapper(metax_data["research_dataset"], doi_info)
-                # creator is required field
-                mapped_metax_data = mapper.map_metadata()
-                bulk_data.append({"identifier": id["metaxIdentifier"], "research_dataset": mapped_metax_data})
+            # Map fields from doi info to Metax schema
+            mapper = MetaDataMapper(metax_data["research_dataset"], doi_info)
+            mapped_metax_data = mapper.map_metadata()
+            bulk_data.append({"identifier": id["metaxIdentifier"], "research_dataset": mapped_metax_data})
 
-        async with ClientSession() as sess:
-            resp = await sess.patch(
-                f"{self.metax_url}{self.rest_route}",
-                json=bulk_data,
-                auth=self.auth,
-            )
-            if resp.status == 200:
-                LOG.debug("Objects metadata are updated to Metax for publishing")
-                return await resp.json()
-            else:
-                reason = await resp.text()
-                raise self.process_error(status, reason)
+        await self._bulk_patch(bulk_data)
 
     async def publish_dataset(self, _metax_ids: List[Dict]) -> None:
         """Publish draft dataset to Metax service.
@@ -233,37 +328,24 @@ class MetaxServiceHandler:
         :param _metax_ids: List of metax IDs that include study and datasets
         """
         LOG.info(f"Publishing Metax datasets {','.join([id['metaxIdentifier'] for id in _metax_ids])}")
+
         for object in _metax_ids:
             metax_id = object["metaxIdentifier"]
             doi = object["doi"]
-            async with ClientSession() as sess:
-                resp = await sess.post(
-                    f"{self.metax_url}{self.publish_route}",
-                    params={"identifier": metax_id},
-                    auth=self.auth,
-                )
-                status = resp.status
-                if status == 200:
-                    preferred_id = await resp.json()
-                    if doi != preferred_id["preferred_identifier"]:
-                        LOG.warning(
-                            f"Metax Preferred Identifier {preferred_id['preferred_identifier']} "
-                            f"does not match object's DOI {doi}"
-                        )
-                    LOG.debug(
-                        f"Object with metax ID {object['metaxIdentifier']} and DOI {object['doi']} is "
-                        "published to Metax service."
-                    )
-                else:
-                    reason = await resp.text()
-                    raise self.process_error(status, reason)
-            LOG.debug(f"Metax ID {object['metaxIdentifier']} was published to Metax service.")
+            preferred_id = await self._publish(metax_id)
+
+            if doi != preferred_id:
+                LOG.warning(f"Metax Preferred Identifier {preferred_id} " f"does not match object's DOI {doi}")
+            LOG.debug(
+                f"Object with metax ID {object['metaxIdentifier']} and DOI {object['doi']} is "
+                "published to Metax service."
+            )
 
     def create_metax_dataset_data_from_study(self, data: Dict) -> Dict:
         """Construct Metax dataset's research dataset dictionary from Submitters Study.
 
         :param data: Study data
-        :returns: constructed research dataset
+        :returns: Constructed research dataset
         """
         research_dataset = self.minimal_dataset_template["research_dataset"]
         research_dataset["preferred_identifier"] = data["doi"]
@@ -322,7 +404,7 @@ class MetaxServiceHandler:
         return metax_creators
 
     # we dont know exactly what is comming from Metax so we try it all
-    def process_error(self, status: int, resp_json: str) -> HTTPError:
+    def metax_error(self, status: int, resp_json: str) -> HTTPError:
         """Construct Metax dataset's research dataset dictionary from Submitters Dataset.
 
         :param status: Status code of the HTTP exception
@@ -332,9 +414,11 @@ class MetaxServiceHandler:
         LOG.error(resp_json)
         if status == 400:
             return HTTPBadRequest(reason=resp_json)
+        if status == 401:
+            return HTTPUnauthorized(reason=resp_json)
         if status == 403:
             return HTTPForbidden(reason=resp_json)
         if status == 404:
             return HTTPNotFound(reason=resp_json)
         else:
-            return HTTPError(reason=resp_json)
+            return HTTPServerError(reason=resp_json)

--- a/metadata_backend/helpers/retry.py
+++ b/metadata_backend/helpers/retry.py
@@ -1,0 +1,70 @@
+"""Decorator for function retry call."""
+# Copyright 2021 Fabian Bosler https://gist.github.com/FBosler/be10229aba491a8c912e3a1543bbc74e
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+# THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+# OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import time
+from functools import wraps
+from typing import Any, Callable, Dict, List, Tuple
+
+from aiohttp import ClientConnectorError
+from aiohttp.web import HTTPServerError
+
+from .logger import LOG
+
+
+def retry(
+    exceptions: Tuple = (HTTPServerError, ClientConnectorError),
+    total_tries: int = 4,
+    initial_wait: float = 0.5,
+    backoff_factor: int = 2,
+) -> Any:
+    """Call the decorated function and apply an exponential backoff.
+
+    :param exceptions: Exception(s) that trigger a retry, can be a tuple
+    :param total_tries: Total tries
+    :param initial_wait: Time to first retry
+    :param backoff_factor: Backoff multiplier (e.g. value of 2 will double the delay each retry).
+    :param logger: logger to be used, if none specified print
+    """
+
+    def retry_decorator(f: Callable) -> Callable:
+        @wraps(f)
+        async def func_with_retries(*args: List, **kwargs: Dict) -> None:
+            _tries, _delay = total_tries, initial_wait
+            while _tries > 1:
+                try:
+                    LOG.info(f"Function: {f.__name__} {total_tries + 1 - _tries}. try")
+                    return await f(*args, **kwargs)
+                except exceptions as e:
+                    _tries -= 1
+                    print_args = args if args else "no args"
+                    if _tries == 1:
+                        msg = str(
+                            f"Function: {f.__name__} failed after {total_tries} tries. "
+                            f"args: {print_args}, kwargs: {kwargs}"
+                        )
+                        LOG.error(msg)
+                        raise
+                    msg = str(
+                        f"Function: {f.__name__}, Exception: {e}\n"
+                        f"Retrying in {_delay} seconds!, args: {print_args}, kwargs: {kwargs}\n"
+                    )
+                    LOG.info(msg)
+                    time.sleep(_delay)
+                    _delay *= backoff_factor
+
+        return func_with_retries
+
+    return retry_decorator

--- a/tests/integration/mock_metax_api.py
+++ b/tests/integration/mock_metax_api.py
@@ -48,11 +48,11 @@ async def get_dataset(req: web.Request) -> web.Response:
         raise web.HTTPBadRequest(
             reason={
                 "detail": ["Query params missing Metax ID."],
-                "error_identifier": datetime.now(),
+                "error_identifier": str(datetime.now()),
             }
         )
-    stuff = list(drafts.keys()) + list(published.keys())
-    if metax_id not in stuff:
+    datasets = list(drafts.keys()) + list(published.keys())
+    if metax_id not in datasets:
         LOG.error(f"No dataset found with identifier {metax_id}")
         raise web.HTTPNotFound(reason={"detail": "Not found."})
     try:
@@ -83,7 +83,7 @@ async def post_dataset(req: web.Request) -> web.Response:
         raise web.HTTPBadRequest(
             reason={
                 "detail": reason,
-                "error_identifier": datetime.now(),
+                "error_identifier": str(datetime.now()),
             }
         )
     validate_data(content)
@@ -123,7 +123,7 @@ async def update_dataset(req: web.Request) -> web.Response:
         raise web.HTTPBadRequest(
             reason={
                 "detail": ["Query params missing Metax ID."],
-                "error_identifier": datetime.now(),
+                "error_identifier": str(datetime.now()),
             }
         )
     if metax_id not in drafts.keys():
@@ -138,7 +138,7 @@ async def update_dataset(req: web.Request) -> web.Response:
         raise web.HTTPBadRequest(
             reason={
                 "detail": reason,
-                "error_identifier": datetime.now(),
+                "error_identifier": str(datetime.now()),
             }
         )
     validate_data(content)
@@ -174,7 +174,7 @@ async def patch_datasets(req: web.Request) -> web.Response:
         raise web.HTTPBadRequest(
             reason={
                 "detail": reason,
-                "error_identifier": datetime.now(),
+                "error_identifier": str(datetime.now()),
             }
         )
     for dataset in content:
@@ -185,7 +185,7 @@ async def patch_datasets(req: web.Request) -> web.Response:
             raise web.HTTPBadRequest(
                 reason={
                     "detail": "Dataset is missing required identifiers",
-                    "error_identifier": datetime.now(),
+                    "error_identifier": str(datetime.now()),
                 }
             )
         if metax_id not in drafts.keys():
@@ -195,7 +195,7 @@ async def patch_datasets(req: web.Request) -> web.Response:
                 {
                     "object": {
                         "detail": reason,
-                        "error_identifier": datetime.now(),
+                        "error_identifier": str(datetime.now()),
                     }
                 }
             )
@@ -228,7 +228,7 @@ async def patch_dataset(req: web.Request) -> web.Response:
         raise web.HTTPBadRequest(
             reason={
                 "detail": ["Query params missing Metax ID."],
-                "error_identifier": datetime.now(),
+                "error_identifier": str(datetime.now()),
             }
         )
     if metax_id not in drafts.keys():
@@ -243,7 +243,7 @@ async def patch_dataset(req: web.Request) -> web.Response:
         raise web.HTTPBadRequest(
             reason={
                 "detail": reason,
-                "error_identifier": datetime.now(),
+                "error_identifier": str(datetime.now()),
             }
         )
     for key, value in content.items():
@@ -272,12 +272,12 @@ async def publish_dataset(req: web.Request) -> web.Response:
         raise web.HTTPBadRequest(
             reason={
                 "detail": ["Query params missing Metax ID."],
-                "error_identifier": datetime.now(),
+                "error_identifier": str(datetime.now()),
             }
         )
     if metax_id in published:
         LOG.error(f"Dataset {metax_id} is already published.")
-        reason = {"detail": ["Dataset is already published."], "error_identifier": datetime.now()}
+        reason = {"detail": ["Dataset is already published."], "error_identifier": str(datetime.now())}
         raise web.HTTPBadRequest(reason=reason)
     if metax_id not in drafts.keys():
         LOG.error(f"No dataset found with identifier {metax_id}")
@@ -305,13 +305,14 @@ async def delete_dataset(req: web.Request) -> web.Response:
     :params req: HTTP request with Metax dataset id
     :return: HTTP response with HTTP status
     """
-    LOG.info("Deleting Metax dataset")
     metax_id = req.match_info["metax_id"]
+    LOG.debug(f"Deleting Metax dataset {metax_id}")
+
     if not metax_id:
         raise web.HTTPBadRequest(
             reason={
                 "detail": ["Query params missing Metax ID."],
-                "error_identifier": datetime.now(),
+                "error_identifier": str(datetime.now()),
             }
         )
     if metax_id not in drafts.keys():

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -501,7 +501,7 @@ async def delete_folder_publish(sess, folder_id):
 async def create_folder(database, data):
     """Create new object folder to database.
 
-    :param database: database connection
+    :param database: database client to perform db operations
     :param data: Data as dict to be saved to database
     :returns: Folder id for the folder inserted to database
     """
@@ -522,8 +522,11 @@ async def create_folder(database, data):
 async def delete_objects_metax_id(sess, database, collection, accession_id, metax_id):
     """Remove study or dataset metax ID from database and mocked Metax service.
 
+    :param sess: HTTP session in which request call is made
+    :param database: database client to perform db operations
     :param collection: Collection of the object to be manipulated
     :param accession_id: Accession id of the object to be manipulated
+    :param metax_id: ID of metax dataset to be deleted
     """
     try:
         await database[collection].find_one_and_update({"accessionId": accession_id}, {"$set": {"metaxIdentifier": ""}})
@@ -1447,6 +1450,7 @@ async def test_getting_folders_filtered_by_date_created(sess, database, project_
     """Check that /folders returns folders filtered by date created.
 
     :param sess: HTTP session in which request call is made
+    :param database: database client to perform db operations
     :param project_id: id of the project the folder belongs to
     """
     folders = []

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -519,6 +519,22 @@ async def create_folder(database, data):
         LOG.error(f"Folder creation failed due to {str(e)}")
 
 
+async def delete_objects_metax_id(sess, database, collection, accession_id, metax_id):
+    """Remove study or dataset metax ID from database and mocked Metax service.
+
+    :param collection: Collection of the object to be manipulated
+    :param accession_id: Accession id of the object to be manipulated
+    """
+    try:
+        await database[collection].find_one_and_update({"accessionId": accession_id}, {"$set": {"metaxIdentifier": ""}})
+    except Exception as e:
+        LOG.error(f"Object update failed due to {str(e)}")
+    try:
+        await sess.delete(f"{metax_url}/{metax_id}")
+    except Exception as e:
+        LOG.error(f"Object deletion from mmocked Metax failed due to {str(e)}")
+
+
 async def patch_user(sess, user_id, real_user_id, json_patch):
     """Patch one user object within session, return userId.
 
@@ -1052,6 +1068,53 @@ async def test_metax_publish_dataset(sess, folder_id):
             assert actual_rd["rights_holder"] == expected_rd["rights_holder"]
             assert actual_rd["spatial"] == expected_rd["spatial"]
             assert actual_rd["temporal"] == expected_rd["temporal"]
+
+    for _, _, metax_id in objects:
+        # delete of published metax datasets is possible only from mocked metax for testing purpose
+        # Metax service does not allow deleting published datasets
+        await sess.delete(f"{metax_url}/{metax_id}", params={"test": "true"})
+
+
+async def test_metax_publish_dataset_with_missing_metax_id(sess, database, folder_id):
+    """Test publishing dataset to Metax service after folder(submission) is failed to create Metax draft dataset.
+
+    Test will create study and dataset normally. After that imitating missing Metax connection will be done
+    with deleting object's metax ID and making call to mocked Metax service to remove Metax dataset from drafts.
+    Then objects will be published in metadata-submitter which should start a flow of creating draft dataset to Metax
+    and only then publishing it.
+
+    :param sess: HTTP session in which request call is made
+    :param folder_id: id of the folder where objects reside
+    """
+    objects = []
+    for schema, filename in {
+        ("study", "SRP000539.xml"),
+        ("dataset", "dataset.xml"),
+    }:
+        accession_id, _ = await post_object(sess, schema, folder_id, filename)
+        async with sess.get(f"{objects_url}/{schema}/{accession_id}") as resp:
+            res = await resp.json()
+            metax_id = res["metaxIdentifier"]
+        objects.append([schema, accession_id])
+        await delete_objects_metax_id(sess, database, schema, accession_id, metax_id)
+        async with sess.get(f"{objects_url}/{schema}/{accession_id}") as resp:
+            res = await resp.json()
+            assert res["metaxIdentifier"] == ""
+
+    # Publish the folder
+    # add a study and dataset for publishing a folder
+    doi_data_raw = await create_request_json_data("doi", "test_doi.json")
+    doi_data = json.loads(doi_data_raw)
+    patch_add_doi = [{"op": "add", "path": "/doiInfo", "value": doi_data}]
+    folder_id = await patch_folder(sess, folder_id, patch_add_doi)
+
+    await publish_folder(sess, folder_id)
+
+    for schema, accession_id in objects:
+        async with sess.get(f"{objects_url}/{schema}/{accession_id}") as resp:
+            assert resp.status == 200, f"HTTP Status code error, got {resp.status}"
+            res = await resp.json()
+            assert res["metaxIdentifier"] != ""
 
 
 async def test_crud_folders_works(sess, project_id):
@@ -1951,8 +2014,8 @@ async def main():
         # Test objects study and dataset are connecting to metax and saving metax id to db
         LOG.debug("=== Testing Metax integration related basic CRUD operations for study and dataset ===")
         metax_folder = {
-            "name": "basic test pagination",
-            "description": "basic test pagination folder",
+            "name": "Metax testing folder",
+            "description": "Metax crud testing folder",
             "projectId": project_id,
         }
         metax_folder_id = await post_folder(sess, metax_folder)
@@ -1960,6 +2023,13 @@ async def main():
         await test_metax_crud_with_json(sess, metax_folder_id)
         await test_metax_id_not_updated_on_patch(sess, metax_folder_id)
         await test_metax_publish_dataset(sess, metax_folder_id)
+        metax_folder = {
+            "name": "Metax testing publishing folder",
+            "description": "Metax publishing testing folder",
+            "projectId": project_id,
+        }
+        metax_folder_id = await post_folder(sess, metax_folder)
+        await test_metax_publish_dataset_with_missing_metax_id(sess, database, metax_folder_id)
 
         # Test add, modify, validate and release action with submissions
         LOG.debug("=== Testing actions within submissions ===")


### PR DESCRIPTION
### Description

Adds retry mechanism for calls to Metax API.

### Related issues
Fixes #370 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made
Adds retry module with retry decorator
Refactor metax_api_handler to use retry decorator only for API calls.

### Testing

- [x] Integration Tests

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
