### PR TITLE
Fix/person required fields

### DIFF
--- a/metadata_backend/api/operators.py
+++ b/metadata_backend/api/operators.py
@@ -453,7 +453,7 @@ class Operator(BaseOperator):
             LOG.error(reason)
             raise web.HTTPBadRequest(reason=reason)
         else:
-            LOG.info(f"Object {schema_type} with id {accession_id} opdated with metax info.")
+            LOG.info(f"Object {schema_type} with id {accession_id} metax info updated.")
             return True
 
     async def _format_data_to_create_and_add_to_db(self, schema_type: str, data: Dict) -> Dict:

--- a/metadata_backend/helpers/metax_mapper.py
+++ b/metadata_backend/helpers/metax_mapper.py
@@ -290,8 +290,6 @@ class MetaDataMapper:
                     metax_creator["member_of"]["identifier"] = affiliation["affiliationIdentifier"]
             # Metax schema accepts only one identifier per creator
             # so we take first one
-            else:
-                del metax_creator["member_of"]
             if creator.get("nameIdentifiers", None) and creator["nameIdentifiers"][0].get("nameIdentifier", None):
                 metax_creator["identifier"] = creator["nameIdentifiers"][0]["nameIdentifier"]
             else:
@@ -319,8 +317,6 @@ class MetaDataMapper:
                 metax_contributor["member_of"]["name"]["en"] = affiliation["name"]
                 if affiliation.get("affiliationIdentifier"):
                     metax_contributor["member_of"]["identifier"] = affiliation["affiliationIdentifier"]
-            else:
-                del metax_contributor["member_of"]
             # Metax schema accepts only one identifier per creator
             # so we take first one
             if contributor.get("nameIdentifiers", None) and contributor["nameIdentifiers"][0].get(

--- a/metadata_backend/helpers/schemas/datacite.json
+++ b/metadata_backend/helpers/schemas/datacite.json
@@ -16,7 +16,8 @@
                 "title": "Main researcher(s) involved with data or the author(s) of the publication.",
                 "required": [
                     "givenName",
-                    "familyName"
+                    "familyName",
+                    "affiliation"
                 ],
                 "properties": {
                     "givenName": {
@@ -181,7 +182,8 @@
                 "required": [
                     "givenName",
                     "familyName",
-                    "contributorType"
+                    "contributorType",
+                    "affiliation"
                 ],
                 "properties": {
                     "givenName": {

--- a/metadata_backend/helpers/schemas/folders.json
+++ b/metadata_backend/helpers/schemas/folders.json
@@ -57,7 +57,8 @@
             "title": "Main researcher(s) involved with data or the author(s) of the publication.",
             "required": [
               "givenName",
-              "familyName"
+              "familyName",
+              "affiliation"
             ],
             "properties": {
               "givenName": {
@@ -231,7 +232,8 @@
             "required": [
               "givenName",
               "familyName",
-              "contributorType"
+              "contributorType",
+              "affiliation"
             ],
             "properties": {
               "givenName": {


### PR DESCRIPTION
### Description
While publishing the submission in SD Submit, the request failed due to a missing field error coming from Metax. 
Fixed by adding `affiliation` as a required field for `creators` and `contributors` in Datacite schema. This field is needed to map `member_of`-field for `creator`, `curator`, `rights_holder` and `contributor` from Metax schema. 

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

Adds `affiliation` to required fields for `creators` and `contributor` in Datacite schema

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply


### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
