### PR TITLE
Add PUT endpoint for submitting DOI information.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Endpoint for submitting DOI information. #389
 
 ### Added
 

--- a/docs/specification.yml
+++ b/docs/specification.yml
@@ -1156,6 +1156,48 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/403Forbidden"
+  /folders/{folderId}/doi:
+    put:
+      tags:
+        - Manage
+      summary: Delete an object folder with a specified folder ID.
+      parameters:
+        - name: folderId
+          in: path
+          description: ID of the object folder.
+          schema:
+            type: string
+          required: true
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DoiInfo"
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FolderCreated"
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/400BadRequest"
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/401Unauthorized"
+        403:
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/403Forbidden"
   /publish/{folderId}:
     patch:
       tags:
@@ -1535,54 +1577,7 @@ components:
           type: boolean
           description: If folder is published or not
         doiInfo:
-          type: object
-          required:
-            - creators
-            - titles
-            - subjects
-          properties:
-            creators:
-              type: array
-              items:
-                type: object
-                properties:
-                  name:
-                    type: string
-                    description: Full name
-                    example: "Family name, First name"
-                  nameType:
-                    type: string
-                    description: Type of name
-                    example: "Personal"
-                  givenName:
-                    type: string
-                    description: Official first name
-                    example: "First name"
-                  familyName:
-                    type: string
-                    description: Official Family name
-                    example: "Family name"
-                  nameIdentifiers:
-                    type: array
-                    items:
-                      type: object
-                  affiliation:
-                    type: array
-                    items:
-                      type: object
-            subjects:
-              type: array
-              items:
-                type: object
-                properties:
-                  subject:
-                    type: string
-                    description: FOS defined subject name
-                    example: "FOS: field"
-                  subjectScheme:
-                    type: string
-                    description: Subject scheme name
-                    example: "Fields of Science and Technology (FOS)"
+          $ref: "#/components/schemas/DoiInfo"
         extraInfo:
           type: object
           required:
@@ -1724,6 +1719,55 @@ components:
         userId:
           type: string
           description: Custom generated ID for the user object.
+    DoiInfo:
+      type: object
+      required:
+        - creators
+        - titles
+        - subjects
+      properties:
+        creators:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+                description: Full name
+                example: "Family name, First name"
+              nameType:
+                type: string
+                description: Type of name
+                example: "Personal"
+              givenName:
+                type: string
+                description: Official first name
+                example: "First name"
+              familyName:
+                type: string
+                description: Official Family name
+                example: "Family name"
+              nameIdentifiers:
+                type: array
+                items:
+                  type: object
+              affiliation:
+                type: array
+                items:
+                  type: object
+        subjects:
+          type: array
+          items:
+            type: object
+            properties:
+              subject:
+                type: string
+                description: FOS defined subject name
+                example: "FOS: field"
+              subjectScheme:
+                type: string
+                description: Subject scheme name
+                example: "Fields of Science and Technology (FOS)"
     JSONPatch:
       type: array
       items:

--- a/metadata_backend/api/handlers/folder.py
+++ b/metadata_backend/api/handlers/folder.py
@@ -638,3 +638,33 @@ class FolderAPIHandler(RESTAPIHandler):
 
         LOG.info(f"DELETE folder with ID {_folder_id} was successful.")
         return web.Response(status=204)
+
+    async def put_folder_doi(self, req: Request) -> Response:
+        """Put or replace DOI metadata to a folder.
+
+        :param req: PUT request with DOI schema in the body
+        :returns: HTTP No Content response
+        """
+        folder_id = req.match_info["folderId"]
+        db_client = req.app["db_client"]
+        operator = FolderOperator(db_client)
+
+        await operator.check_folder_exists(folder_id)
+        await self._handle_check_ownership(req, "folders", folder_id)
+
+        folder = await operator.read_folder(folder_id)
+        doi_info = await self._get_data(req)
+        folder["doiInfo"] = doi_info
+        JSONValidator(folder, "folders").validate
+
+        op = "add"
+        if "doiInfo" in folder:
+            op = "replace"
+        patch = [
+            {"op": op, "path": "/doiInfo", "value": doi_info},
+        ]
+        upd_folder = await operator.update_folder(folder_id, patch)
+
+        body = ujson.dumps({"folderId": upd_folder}, escape_forward_slashes=False)
+        LOG.info(f"PUT folder with ID {folder_id} was successful.")
+        return web.Response(body=body, status=200, content_type="application/json")

--- a/metadata_backend/server.py
+++ b/metadata_backend/server.py
@@ -100,6 +100,7 @@ async def init() -> web.Application:
         web.get("/folders", _folder.get_folders),
         web.post("/folders", _folder.post_folder),
         web.get("/folders/{folderId}", _folder.get_folder),
+        web.put("/folders/{folderId}/doi", _folder.put_folder_doi),
         web.patch("/folders/{folderId}", _folder.patch_folder),
         web.delete("/folders/{folderId}", _folder.delete_folder),
         # publish submissions

--- a/tests/http/publication_minimal.http
+++ b/tests/http/publication_minimal.http
@@ -1,0 +1,60 @@
+# https://github.com/Huachao/vscode-restclient
+# https://jsonpath.com/
+
+
+@backend_url = http://localhost:5430
+@auth_url = http://localhost:8000
+@doi_url = http://localhost:8001
+@metax_url = http://localhost:8002
+
+@auth_email = mock_user@test.what
+
+
+@project_id = {{user_data_req.response.body.projects[0].projectId}}
+@folder_id = {{folder_id_req.response.body.folderId}}
+
+### Mock athentication
+GET {{auth_url}}/setmock
+    ?sub={{auth_email}}
+    &given=Mock
+    &family=Family
+
+###
+GET {{backend_url}}/aai
+
+### Get user data
+# @name user_data_req
+GET {{backend_url}}/users/current
+
+
+
+### Create folder
+# @name folder_id_req
+POST {{backend_url}}/folders
+
+{
+    "name": "folder test 1",
+    "description": "folder test 1",
+    "projectId": "{{project_id}}"
+}
+
+### List folders
+GET {{backend_url}}/folders
+    ?projectId={{project_id}}
+
+### Get folder
+GET {{backend_url}}/folders/{{folder_id}}
+
+### Add study to folder
+POST {{backend_url}}/objects/study
+    ?folder={{folder_id}}
+
+< ../test_files/study/SRP000539.json
+
+### Add DOI to folder
+PUT {{backend_url}}/folders/{{folder_id}}/doi
+
+< ../test_files/doi/test_doi.json
+
+### Publish folder
+PATCH {{backend_url}}/publish/{{folder_id}}

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -498,6 +498,20 @@ async def delete_folder_publish(sess, folder_id):
         assert resp.status == 401, f"HTTP Status code error, got {resp.status}"
 
 
+async def put_folder_doi(sess, schema, folder_id, filename):
+    """Put doi into folder within session, returns folderId.
+
+    :param sess: HTTP session in which request call is made
+    :param doi_data: doi data used to update the folder
+    """
+    request_data = await create_request_json_data(schema, filename)
+    async with sess.put(f"{folders_url}/{folder_id}/doi", data=request_data) as resp:
+        ans = await resp.json()
+        assert resp.status == 200, f"HTTP Status code error {resp.status} {ans}"
+        LOG.debug(f"Adding doi to folder {ans['folderId']}")
+        return ans["folderId"]
+
+
 async def create_folder(database, data):
     """Create new object folder to database.
 
@@ -1302,7 +1316,7 @@ async def test_getting_paginated_folders(sess, project_id):
         assert ans["page"]["page"] == 1
         assert ans["page"]["size"] == 5
         assert ans["page"]["totalPages"] == 2
-        assert ans["page"]["totalFolders"] == 7
+        assert ans["page"]["totalFolders"] == 8
         assert len(ans["folders"]) == 5
 
     # Test with custom pagination values
@@ -1312,7 +1326,7 @@ async def test_getting_paginated_folders(sess, project_id):
         assert ans["page"]["page"] == 2
         assert ans["page"]["size"] == 3
         assert ans["page"]["totalPages"] == 3
-        assert ans["page"]["totalFolders"] == 7
+        assert ans["page"]["totalFolders"] == 8
         assert len(ans["folders"]) == 3
 
     # Test querying only published folders
@@ -1322,8 +1336,8 @@ async def test_getting_paginated_folders(sess, project_id):
         assert ans["page"]["page"] == 1
         assert ans["page"]["size"] == 5
         assert ans["page"]["totalPages"] == 1
-        assert ans["page"]["totalFolders"] == 1
-        assert len(ans["folders"]) == 1
+        assert ans["page"]["totalFolders"] == 2
+        assert len(ans["folders"]) == 2
 
     # Test querying only draft folders
     async with sess.get(f"{folders_url}?published=false&projectId={project_id}") as resp:
@@ -1384,6 +1398,7 @@ async def test_getting_folders_filtered_by_date_created(sess, database, project_
     """Check that /folders returns folders filtered by date created.
 
     :param sess: HTTP session in which request call is made
+    :param database: database client to perform db operations
     :param project_id: id of the project the folder belongs to
     """
     folders = []
@@ -1820,6 +1835,30 @@ async def test_submissions_work(sess, folder_id):
     tree.write(mod_study, encoding="utf-8")
 
 
+async def test_minimal_json_publication(sess, project_id):
+    """Test minimal publication workflow with json submissions.
+
+    :param sess: HTTP session in which request call is made
+    :param project_id: id of the project the folder belongs to
+    """
+    folder = {
+        "name": "Minimal json publication",
+        "description": "Testing json publication with new doi endpoint",
+        "projectId": project_id,
+    }
+    folder_id = await post_folder(sess, folder)
+
+    await post_object_json(sess, "study", folder_id, "SRP000539.json")
+    await put_folder_doi(sess, "doi", folder_id, "test_doi.json")
+    await publish_folder(sess, folder_id)
+
+    async with sess.get(f"{folders_url}/{folder_id}") as resp:
+        LOG.debug(f"Checking that folder {folder_id} was published")
+        res = await resp.json()
+        assert res["folderId"] == folder_id, "expected folder id does not match"
+        assert res["published"] is True, "folder is published, expected False"
+
+
 async def test_health_check(sess):
     """Test the health check endpoint.
 
@@ -1939,6 +1978,10 @@ async def main():
         await test_crud_folders_works(sess, project_id)
         await test_crud_folders_works_no_publish(sess, project_id)
         await test_adding_doi_info_to_folder_works(sess, project_id)
+
+        # Test creating a folder, with minimal required objects + DOI for publishing
+        LOG.debug("=== Testing minimal JSON submission ===")
+        await test_minimal_json_publication(sess, project_id)
 
         # Test getting a list of folders and draft templates owned by the user
         LOG.debug("=== Testing getting folders, draft folders and draft templates with pagination ===")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -41,7 +41,7 @@ class AppTestCase(AioHTTPTestCase):
     async def test_api_routes_are_set(self):
         """Test correct amount of api (no frontend) routes is set."""
         server = await self.get_application()
-        self.assertIs(len(server.router.resources()), 19)
+        self.assertIs(len(server.router.resources()), 21)
 
     async def test_frontend_routes_are_set(self):
         """Test correct routes are set when frontend folder is exists."""


### PR DESCRIPTION
### Description
<!-- Please include a summary of the change or any information deemed important. -->
Add PUT endpoint for submitting DOI information.
Previously, DOI could be added to a folder only with a patch request.
The new endpoint makes it easier to format requests that add or update DOI information.


### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
Closes #384
### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

<!-- List changes made. -->
- Added a new endpoint for submitting DOI information

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
