### PR TITLE
Alternative dev flow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.tox
+.*_cache
+build
+htmlcov
+venv
+.venv
+.git
+*.egg-info
+
+**/__pycache__
+**/build
+**/bindings
+
+**/*.zip
+**/*.tar*

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
+# When using Procfile, set the host to localhost for all local services
+
 # authentication
 AAI_CLIENT_SECRET=secret_must_be_long
 AAI_CLIENT_ID=aud2

--- a/.github/config/.wordlist.txt
+++ b/.github/config/.wordlist.txt
@@ -259,6 +259,7 @@ histone
 hmpr
 homologene
 hostname
+hostnames
 hotfix
 hq
 html
@@ -471,6 +472,7 @@ primaryid
 probeset
 processedreads
 processingtype
+procfile
 projectid
 projectnumber
 promethion
@@ -588,9 +590,9 @@ subjectsSchema
 submissionfolder
 submissionfolderslice
 submissiontype
-submitter's
 submitterdemultiplexed
 submitterid
+submitter's
 submitters
 svg
 swati
@@ -616,6 +618,7 @@ tsonga
 turkmen
 twi
 txt
+ue
 ui
 ujson
 umi
@@ -636,6 +639,7 @@ uyghur
 validator
 vcf
 venda
+venv
 volapük
 vscode
 wcs

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,5 @@
+db: docker  run -v ${PWD}/scripts/init_mongo.js:/docker-entrypoint-initdb.d/init_mongo.js:ro --env-file ${PWD}/.env -p 27017:27017 mongo
+mockauth:   gunicorn --reload --worker-class aiohttp.GunicornUVLoopWebWorker --workers 1 --log-level debug --graceful-timeout 60 --timeout 120 --bind ${BACKEND_HOST}:8000              tests.integration.mock_auth:init
+mockdoi:    gunicorn --reload --worker-class aiohttp.GunicornUVLoopWebWorker --workers 1 --log-level debug --graceful-timeout 60 --timeout 120 --bind ${BACKEND_HOST}:8001              tests.integration.mock_doi_api:init
+mockmetax:  gunicorn --reload --worker-class aiohttp.GunicornUVLoopWebWorker --workers 1 --log-level debug --graceful-timeout 60 --timeout 120 --bind ${BACKEND_HOST}:8002              tests.integration.mock_metax_api:init
+backend:    gunicorn --reload --worker-class aiohttp.GunicornUVLoopWebWorker --workers 1 --log-level debug --graceful-timeout 60 --timeout 120 --bind ${BACKEND_HOST}:${BACKEND_PORT}   metadata_backend.server:init

--- a/README.md
+++ b/README.md
@@ -43,16 +43,15 @@ Tests can be run with tox automation: just run `tox -p auto` on project root (re
 
 ## Developing
 
-Docker is utilizing the Buildkit builder toolkit. To activate it you might need to update your docker configurations with `{ "features": { "buildkit": true } }` inside the /etc/docker/daemon.json.
+Clone the repository
+```bash
+git clone -b develop git@github.com:CSCfi/metadata-submitter.git
+cd metadata-submitter
+```
 
-If the above is not enough, try:
-```
-$ wget https://github.com/docker/buildx/releases/download/v0.7.0/buildx-v0.7.0.linux-amd64
-$ mkdir -p ~/.docker/cli-plugins
-$ cp ~/Downloads/buildx-v0.7.0.linux-amd64 ~/.docker/cli-plugins/docker-buildx
-$ chmod +x ~/.docker/cli-plugins/docker-buildx
-```
-and add `{ "experimental": "enabled" }` inside the /etc/docker/daemon.json.
+Git hooks are activated inside the local development environment which will run tox tests before pushing. To ignore them for fast updates use `git` with the flag `--no-verify`.
+
+Below we provide two alternative ways of developing, with _VS Code dev containers_ or with _Python virtual environment using a Procfile_.
 
 ### Developing with VS Code
 
@@ -63,7 +62,48 @@ To start using the VS Code devcontainer:
 - with CTRL+SHIFT P choose Remote-Container: Reopen in Container
 - to run application and debug F5
 
-Git hooks are activated inside the local development environment which will run tox tests before pushing. To ignore them for fast updates use the flag `--no-verify`.
+#### Docker setup
+
+Docker is utilizing the Buildkit builder toolkit. To activate it you might need to update your docker configurations with `{ "features": { "buildkit": true } }` inside the /etc/docker/daemon.json.
+
+If the above is not enough, try:
+```bash
+$ wget https://github.com/docker/buildx/releases/download/v0.7.0/buildx-v0.7.0.linux-amd64
+$ mkdir -p ~/.docker/cli-plugins
+$ cp ~/Downloads/buildx-v0.7.0.linux-amd64 ~/.docker/cli-plugins/docker-buildx
+$ chmod +x ~/.docker/cli-plugins/docker-buildx
+```
+and add `{ "experimental": "enabled" }` inside the /etc/docker/daemon.json.
+
+### Developing with Python virtual environment
+
+Install python dependencies, optionally in a virtual environment.
+
+```bash
+$ python3 -m venv venv --prompt submitter  # Optional step, creates python virtual environment
+$ source venv/bin/activate  # activates virtual environment
+$ pip install -U pip
+$ pip install -Ue .
+$ pip install -r requirements-dev.txt
+```
+
+Copy `.env` file and set up the environment variables.
+The example file has hostnames for development with VS Code dev containers. You will have to change the hostnames to `localhost`. 
+
+```bash
+$ cp .env.example .env  # Make any changes you need to the file
+```
+
+Start the servers with code reloading enabled, so any code changes restarts the servers automatically.
+
+```bash
+$ honcho start
+```
+
+Now you should be able to access the development server at `localhost:5430`.
+If it doesn't work right away, check your settings in `.env` and restart the servers manually if you make changes to `.env` file.
+
+**Note**: This approach uses Docker to run MongoDB. You can comment it out in the `Procfile` if you don't want to use Docker.
 
 ### Keeping Python requirements up to date
 
@@ -87,9 +127,9 @@ Git hooks are activated inside the local development environment which will run 
 ## Build and deploy
 
 Production version can be built and run with following docker commands:
-```
-docker build --no-cache . -t metadata-submitter
-docker run -p 5430:5430 metadata-submitter
+```bash
+$ docker build --no-cache . -t metadata-submitter
+$ docker run -p 5430:5430 metadata-submitter
 ```
 
 Frontend is built and added as static files to backend while building. 

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,4 +1,6 @@
 aiofiles  # to run integration tests
+authlib
+bandit
 black
 certifi
 flake8
@@ -6,4 +8,12 @@ honcho  # Runs Procfile
 mypy
 pip-tools  # pip depedencies management
 pre-commit
-tox
+pyspelling
+pytest
+pytest-cov
+sphinx
+sphinx_rtd_theme
+tox    
+types-python-dateutil
+types-ujson
+types-requests

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -2,6 +2,7 @@ aiofiles  # to run integration tests
 black
 certifi
 flake8
+honcho  # Runs Procfile
 mypy
 pip-tools  # pip depedencies management
 pre-commit

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,6 +25,8 @@ filelock==3.6.0
 flake8==4.0.1
     # via -r requirements-dev.in
 identify==2.4.12
+honcho==1.1.0
+    # via -r requirements-dev.in
     # via pre-commit
 mccabe==0.6.1
     # via flake8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,28 +6,80 @@
 #
 aiofiles==0.8.0
     # via -r requirements-dev.in
+alabaster==0.7.12
+    # via sphinx
+attrs==21.4.0
+    # via pytest
+authlib==1.0.1
+    # via -r requirements-dev.in
+babel==2.10.1
+    # via sphinx
+bandit==1.7.4
+    # via -r requirements-dev.in
+beautifulsoup4==4.11.1
+    # via pyspelling
 black==22.3.0
     # via -r requirements-dev.in
+bracex==2.2.1
+    # via wcmatch
 certifi==2021.10.8
-    # via -r requirements-dev.in
+    # via
+    #   -r requirements-dev.in
+    #   requests
+cffi==1.15.0
+    # via cryptography
 cfgv==3.3.1
     # via pre-commit
-click==8.1.1
+charset-normalizer==2.0.12
+    # via requests
+click==8.1.3
     # via
     #   black
     #   pip-tools
+coverage[toml]==6.3.2
+    # via pytest-cov
+cryptography==37.0.2
+    # via authlib
 distlib==0.3.4
     # via virtualenv
+docutils==0.17.1
+    # via
+    #   sphinx
+    #   sphinx-rtd-theme
 filelock==3.6.0
     # via
     #   tox
     #   virtualenv
 flake8==4.0.1
     # via -r requirements-dev.in
-identify==2.4.12
+gitdb==4.0.9
+    # via gitpython
+gitpython==3.1.27
+    # via bandit
 honcho==1.1.0
     # via -r requirements-dev.in
+html5lib==1.1
+    # via pyspelling
+identify==2.5.0
     # via pre-commit
+idna==3.3
+    # via requests
+imagesize==1.3.0
+    # via sphinx
+importlib-metadata==4.11.3
+    # via
+    #   markdown
+    #   sphinx
+iniconfig==1.1.1
+    # via pytest
+jinja2==3.1.2
+    # via sphinx
+lxml==4.8.0
+    # via pyspelling
+markdown==3.3.7
+    # via pyspelling
+markupsafe==2.1.1
+    # via jinja2
 mccabe==0.6.1
     # via flake8
 mypy==0.950
@@ -39,35 +91,92 @@ mypy-extensions==0.4.3
 nodeenv==1.6.0
     # via pre-commit
 packaging==21.3
-    # via tox
+    # via
+    #   pytest
+    #   sphinx
+    #   tox
 pathspec==0.9.0
     # via black
+pbr==5.9.0
+    # via stevedore
 pep517==0.12.0
     # via pip-tools
 pip-tools==6.6.1
     # via -r requirements-dev.in
-platformdirs==2.5.1
+platformdirs==2.5.2
     # via
     #   black
     #   virtualenv
 pluggy==1.0.0
-    # via tox
+    # via
+    #   pytest
+    #   tox
 pre-commit==2.19.0
     # via -r requirements-dev.in
 py==1.11.0
-    # via tox
+    # via
+    #   pytest
+    #   tox
 pycodestyle==2.8.0
     # via flake8
+pycparser==2.21
+    # via cffi
 pyflakes==2.4.0
     # via flake8
-pyparsing==3.0.7
+pygments==2.12.0
+    # via sphinx
+pyparsing==3.0.9
     # via packaging
+pyspelling==2.7.3
+    # via -r requirements-dev.in
+pytest==7.1.2
+    # via
+    #   -r requirements-dev.in
+    #   pytest-cov
+pytest-cov==3.0.0
+    # via -r requirements-dev.in
+pytz==2022.1
+    # via babel
 pyyaml==6.0
-    # via pre-commit
+    # via
+    #   bandit
+    #   pre-commit
+    #   pyspelling
+requests==2.27.1
+    # via sphinx
 six==1.16.0
     # via
+    #   html5lib
     #   tox
     #   virtualenv
+smmap==5.0.0
+    # via gitdb
+snowballstemmer==2.2.0
+    # via sphinx
+soupsieve==2.3.2.post1
+    # via
+    #   beautifulsoup4
+    #   pyspelling
+sphinx==4.5.0
+    # via
+    #   -r requirements-dev.in
+    #   sphinx-rtd-theme
+sphinx-rtd-theme==1.0.0
+    # via -r requirements-dev.in
+sphinxcontrib-applehelp==1.0.2
+    # via sphinx
+sphinxcontrib-devhelp==1.0.2
+    # via sphinx
+sphinxcontrib-htmlhelp==2.0.0
+    # via sphinx
+sphinxcontrib-jsmath==1.0.1
+    # via sphinx
+sphinxcontrib-qthelp==1.0.3
+    # via sphinx
+sphinxcontrib-serializinghtml==1.1.5
+    # via sphinx
+stevedore==3.5.0
+    # via bandit
 toml==0.10.2
     # via
     #   pre-commit
@@ -75,18 +184,38 @@ toml==0.10.2
 tomli==2.0.1
     # via
     #   black
+    #   coverage
     #   mypy
     #   pep517
+    #   pytest
 tox==3.25.0
     # via -r requirements-dev.in
-typing-extensions==4.1.1
-    # via mypy
-virtualenv==20.14.0
+types-python-dateutil==2.8.15
+    # via -r requirements-dev.in
+types-requests==2.27.25
+    # via -r requirements-dev.in
+types-ujson==4.2.1
+    # via -r requirements-dev.in
+types-urllib3==1.26.14
+    # via types-requests
+typing-extensions==4.2.0
+    # via
+    #   black
+    #   mypy
+urllib3==1.26.9
+    # via requests
+virtualenv==20.14.1
     # via
     #   pre-commit
     #   tox
+wcmatch==8.3
+    # via pyspelling
+webencodings==0.5.1
+    # via html5lib
 wheel==0.37.1
     # via pip-tools
+zipp==3.8.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/tests/integration/mock_auth.py
+++ b/tests/integration/mock_auth.py
@@ -249,7 +249,7 @@ async def oidc_config(request: web.Request) -> web.Response:
     return web.json_response(oidc_config_json)
 
 
-def init() -> web.Application:
+async def init() -> web.Application:
     """Start server."""
     app = web.Application()
     app.router.add_get("/setmock", setmock)

--- a/tests/integration/mock_doi_api.py
+++ b/tests/integration/mock_doi_api.py
@@ -156,7 +156,7 @@ async def delete(req: web.Request) -> web.Response:
     return web.json_response(status=204)
 
 
-def init() -> web.Application:
+async def init() -> web.Application:
     """Start server."""
     app = web.Application()
     app.router.add_post("/dois", create)

--- a/tests/integration/mock_metax_api.py
+++ b/tests/integration/mock_metax_api.py
@@ -348,7 +348,7 @@ def validate_data(data: Dict, draft=True) -> None:
         raise web.HTTPBadRequest(reason=reason, content_type="application/json")
 
 
-def init() -> web.Application:
+async def init() -> web.Application:
     """Start server."""
     app = web.Application()
     api_routes = [


### PR DESCRIPTION
### Description
<!-- Please include a summary of the change or any information deemed important. -->
Hopefully this is a positive contribution to development flow.

As an alternative to using dev containers, now it's possible to run all services in a python virtual environment with `honcho start`, by using the `Procfile` and existing `.env` file. This has code reloading enabled.


### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

<!-- List changes made. -->
- Application factory should be async - allows running with `gunicorn` for easy code reloading
- `Procfile` run with `honcho start` for an alternative way of running services locally during development
- Often used packages for development were added to `requirements-dev.txt`
- `.dockerignore` file prevents large and unnecessary files/folders to be passed to docker container, such as `.tox` during development.

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
