### PR TITLE
HTTP PATCH for submissions only accepts 'name' and 'description'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - migrated to variables used by motor 3 for ssl https://motor.readthedocs.io/en/stable/migrate-to-motor-3.html?highlight=ssl_certfile#renamed-uri-options
   - env vars `MONGO_SSL_CLIENT_KEY` and `MONGO_SSL_CLIENT_CERT` are replaced with `MONGO_SSL_CLIENT_CERT_KEY`
 - Refactor **folder** to **submission**
+- HTTP PATCH for submissions has changed to only accept 'name' and 'description' in a flat JSON object.
 
 ### Removed
 

--- a/docs/specification.yml
+++ b/docs/specification.yml
@@ -1089,9 +1089,20 @@ paths:
       summary: Update information of an object submission.
       requestBody:
         content:
-          application/json-patch+json:
+          application/json:
             schema:
-              $ref: "#/components/schemas/JSONPatch"
+              type: object
+              description: JSON object containing a new 'name' and / or 'description'.
+              properties:
+                name:
+                  type: string
+                  description: Name of the submission.
+                  example: "Research project submission #2"
+                description:
+                  type: string
+                  description: A longer description of the submission.
+                  example: "As part of the research project we produced this submission with our initial research results."
+
       parameters:
         - name: submissionId
           in: path

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -900,13 +900,20 @@ class SubmissionHandlerTestCase(HandlersTestCase):
         response = await self.client.patch("/submissions/FOL12345678", json=data)
         self.assertEqual(response.status, 400)
         json_resp = await response.json()
-        reason = "Request contains '/objects' key that cannot be updated to submissions."
+        reason = "Patch submission operation should be provided as a JSON object"
+        self.assertEqual(reason, json_resp["detail"])
+
+        data = {"doiInfo": {}}
+        response = await self.client.patch("/submissions/FOL12345678", json=data)
+        self.assertEqual(response.status, 400)
+        json_resp = await response.json()
+        reason = "Patch submission operation only accept the fields 'name', or 'description'. Provided 'doiInfo'"
         self.assertEqual(reason, json_resp["detail"])
 
     async def test_update_submission_passes(self):
         """Test that submission would update with correct keys."""
         self.MockedSubmissionOperator().update_submission.return_value = self.submission_id
-        data = [{"op": "replace", "path": "/name", "value": "test2"}]
+        data = {"name": "test2"}
         response = await self.client.patch("/submissions/FOL12345678", json=data)
         self.MockedSubmissionOperator().update_submission.assert_called_once()
         self.assertEqual(response.status, 200)


### PR DESCRIPTION
### Description
<!-- Please include a summary of the change or any information deemed important. -->
We're deprecating the use of JSON Patch operations to modify most properties of the submission. Now only 'name' and 'description' can be updated, and in a flat JSON object, example: `{"name": ""}`.


### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
- Closes https://github.com/CSCfi/metadata-submitter/issues/430

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Changes Made

<!-- List changes made. -->
- Submission HTTP PATCH doesn't accept a JSON Patch any more, only specific fields.
- Updated unit and integration tests
- Updated swagger docs

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests
- [x] Integration Tests

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
