### PR TITLE
Make metax errors visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - migrated to variables used by motor 3 for ssl https://motor.readthedocs.io/en/stable/migrate-to-motor-3.html?highlight=ssl_certfile#renamed-uri-options
   - env vars `MONGO_SSL_CLIENT_KEY` and `MONGO_SSL_CLIENT_CERT` are replaced with `MONGO_SSL_CLIENT_CERT_KEY`
 - Refactor **folder** to **submission** #411
-- HTTPError exceptions return a response with JSON Problem instead of an HTML page #382
 - HTTP PATCH for submissions has changed to only accept 'name' and 'description' in a flat JSON object.
+- Better (metax) error handling #382
+  - HTTPError exceptions return a response with JSON Problem instead of an HTML page #433
+  - Make Metax errors visible to user #453
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Better (metax) error handling #382
   - HTTPError exceptions return a response with JSON Problem instead of an HTML page #433
   - Make Metax errors visible to user #453
+  - Catch unexpected errors and return a JSON Problem instead of server crashing #453
 
 ### Removed
 

--- a/docker-compose-tls.yml
+++ b/docker-compose-tls.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.4"
 services:
   backend:
     build:
@@ -10,7 +10,7 @@ services:
     volumes:
       - ./config:/tls
     ports:
-      - 5430:5430
+      - "5430:5430"
     depends_on:
       - database
       - mockauth
@@ -54,7 +54,7 @@ services:
     expose:
       - 27017
     ports:
-      - 27017:27017
+      - "27017:27017"
   mockauth:
     build:
       dockerfile: Dockerfile-dev
@@ -83,7 +83,7 @@ services:
     expose:
       - 8001
     ports:
-      - 8001:8001
+      - "8001:8001"
     volumes:
       - ./tests/integration/mock_doi_api.py:/mock_doi_api.py
     entrypoint: ["python", "/mock_doi_api.py", "0.0.0.0", "8001"]
@@ -97,7 +97,7 @@ services:
     expose:
       - 8002
     ports:
-      - 8002:8002
+      - "8002:8002"
     volumes:
       - ./tests/integration/mock_metax_api.py:/mock_metax_api.py
     entrypoint: ["python", "/mock_metax_api.py", "0.0.0.0", "8002"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.4"
 services:
   backend:
     build:
@@ -8,7 +8,7 @@ services:
     image: cscfi/metadata-submitter-dev
     container_name: "metadata_submitter_backend_dev"
     ports:
-      - 5430:5430
+      - "5430:5430"
     depends_on:
       - database
       - mockauth
@@ -47,7 +47,7 @@ services:
     expose:
       - 27017
     ports:
-      - 27017:27017
+      - "27017:27017"
   mockauth:
     build:
       dockerfile: Dockerfile-dev
@@ -62,7 +62,7 @@ services:
     expose:
       - 8000
     ports:
-      - 8000:8000
+      - "8000:8000"
     volumes:
       - ./tests/integration/mock_auth.py:/mock_auth.py
     entrypoint: ["python", "/mock_auth.py", "0.0.0.0", "8000"]
@@ -76,7 +76,7 @@ services:
     expose:
       - 8001
     ports:
-      - 8001:8001
+      - "8001:8001"
     volumes:
       - ./tests/integration/mock_doi_api.py:/mock_doi_api.py
     entrypoint: ["python", "/mock_doi_api.py", "0.0.0.0", "8001"]
@@ -90,7 +90,7 @@ services:
     expose:
       - 8002
     ports:
-      - 8002:8002
+      - "8002:8002"
     volumes:
       - ./tests/integration/mock_metax_api.py:/mock_metax_api.py
     entrypoint: ["python", "/mock_metax_api.py", "0.0.0.0", "8002"]

--- a/docs/specification.yml
+++ b/docs/specification.yml
@@ -1246,6 +1246,18 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/403Forbidden"
+        502:
+          description: Bad Gateway
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/502BadGateway"
+        504:
+          description: Gateway Timeout
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/504GatewayTimeout"
   /users/{userId}:
     get:
       tags:
@@ -1424,6 +1436,22 @@ components:
           example: Forbidden
         detail:
           example: the request does not contain the right permissions
+    502BadGateway:
+      allOf:
+        - $ref: "#/components/schemas/ErrorModel"
+      properties:
+        title:
+          example: Bad Gateway
+        detail:
+          example: "Metax error: metax service provider couldn't process request"
+    504GatewayTimeout:
+      allOf:
+        - $ref: "#/components/schemas/ErrorModel"
+      properties:
+        title:
+          example: Gateway Timeout
+        detail:
+          example: "Metax error: could not reach the metax service provider"
     SchemasList:
       type: array
       items:

--- a/metadata_backend/api/handlers/object.py
+++ b/metadata_backend/api/handlers/object.py
@@ -116,8 +116,6 @@ class ObjectAPIHandler(RESTAPIHandler):
 
         await self._handle_check_ownership(req, "submissions", submission_id)
 
-        await MetaxServiceHandler(req).check_connection()
-
         self._check_schema_exists(schema_type)
         collection = f"draft-{schema_type}" if req.path.startswith("/drafts") else schema_type
 
@@ -187,8 +185,13 @@ class ObjectAPIHandler(RESTAPIHandler):
         await submission_op.update_submission(submission_id, patch)
 
         # Create draft dataset to Metax catalog
-        if collection in _allowed_doi:
-            [await self.create_metax_dataset(req, collection, item) for item, _ in objects]
+        try:
+            if collection in _allowed_doi:
+                [await self.create_metax_dataset(req, collection, item) for item, _ in objects]
+        except Exception as e:
+            # We don't care if it fails here
+            LOG.info(f"create_metax_dataset failed: {e} for collection {collection}")
+            pass
 
         body = ujson.dumps(data, escape_forward_slashes=False)
 
@@ -231,9 +234,6 @@ class ObjectAPIHandler(RESTAPIHandler):
 
         await self._handle_check_ownership(req, collection, accession_id)
 
-        metax_handler = MetaxServiceHandler(req)
-        await metax_handler.check_connection()
-
         submission_op = SubmissionOperator(db_client)
         exists, submission_id, published = await submission_op.check_object_in_submission(collection, accession_id)
         if exists:
@@ -266,7 +266,12 @@ class ObjectAPIHandler(RESTAPIHandler):
 
         # Delete draft dataset from Metax catalog
         if collection in _allowed_doi:
-            await metax_handler.delete_draft_dataset(metax_id)
+            try:
+                await MetaxServiceHandler(req).delete_draft_dataset(metax_id)
+            except Exception as e:
+                # We don't care if it fails here
+                LOG.info(f"delete_draft_dataset failed: {e} for collection {collection}")
+                pass
             doi_service = DOIHandler()
             await doi_service.delete(doi_id)
 
@@ -311,9 +316,6 @@ class ObjectAPIHandler(RESTAPIHandler):
 
         await self._handle_check_ownership(req, collection, accession_id)
 
-        metax_handler = MetaxServiceHandler(req)
-        await metax_handler.check_connection()
-
         submission_op = SubmissionOperator(db_client)
         exists, submission_id, published = await submission_op.check_object_in_submission(collection, accession_id)
         if exists:
@@ -327,11 +329,16 @@ class ObjectAPIHandler(RESTAPIHandler):
         await submission_op.update_submission(submission_id, patch)
 
         # Update draft dataset to Metax catalog
-        if collection in _allowed_doi:
-            if data.get("metaxIdentifier", None):
-                await metax_handler.update_draft_dataset(collection, data)
-            else:
-                await self.create_metax_dataset(req, collection, data, create_draft_doi=False)
+        try:
+            if collection in _allowed_doi:
+                if data.get("metaxIdentifier", None):
+                    await MetaxServiceHandler(req).update_draft_dataset(collection, data)
+                else:
+                    await self.create_metax_dataset(req, collection, data, create_draft_doi=False)
+        except Exception as e:
+            # We don't care if it fails here
+            LOG.info(f"update_draft_dataset or create_metax_dataset failed: {e} for collection {collection}")
+            pass
 
         body = ujson.dumps({"accessionId": accession_id}, escape_forward_slashes=False)
         LOG.info(f"PUT object with accession ID {accession_id} in schema {collection} was successful.")
@@ -366,9 +373,6 @@ class ObjectAPIHandler(RESTAPIHandler):
 
         await self._handle_check_ownership(req, collection, accession_id)
 
-        metax_handler = MetaxServiceHandler(req)
-        await metax_handler.check_connection()
-
         submission_op = SubmissionOperator(db_client)
         exists, submission_id, published = await submission_op.check_object_in_submission(collection, accession_id)
         if exists:
@@ -388,16 +392,21 @@ class ObjectAPIHandler(RESTAPIHandler):
             pass
 
         # Update draft dataset to Metax catalog
-        if collection in {"study", "dataset"}:
-            object_data, _ = await operator.read_metadata_object(collection, accession_id)
-            # MYPY related if statement, Operator (when not XMLOperator) always returns object_data as dict
-            if isinstance(object_data, Dict):
-                if object_data.get("metaxIdentifier", None):
-                    await metax_handler.update_draft_dataset(collection, object_data)
+        try:
+            if collection in {"study", "dataset"}:
+                object_data, _ = await operator.read_metadata_object(collection, accession_id)
+                # MYPY related if statement, Operator (when not XMLOperator) always returns object_data as dict
+                if isinstance(object_data, Dict):
+                    if object_data.get("metaxIdentifier", None):
+                        await MetaxServiceHandler(req).update_draft_dataset(collection, object_data)
+                    else:
+                        await self.create_metax_dataset(req, collection, object_data, create_draft_doi=False)
                 else:
-                    await self.create_metax_dataset(req, collection, object_data, create_draft_doi=False)
-            else:
-                raise ValueError("Object's data must be dictionary")
+                    raise ValueError("Object's data must be dictionary")
+        except Exception as e:
+            # We don't care if it fails here
+            LOG.info(f"update_draft_dataset or create_metax_dataset failed: {e} for collection {collection}")
+            pass
 
         body = ujson.dumps({"accessionId": accession_id}, escape_forward_slashes=False)
         LOG.info(f"PATCH object with accession ID {accession_id} in schema {collection} was successful.")

--- a/metadata_backend/api/handlers/object.py
+++ b/metadata_backend/api/handlers/object.py
@@ -116,6 +116,8 @@ class ObjectAPIHandler(RESTAPIHandler):
 
         await self._handle_check_ownership(req, "submissions", submission_id)
 
+        await MetaxServiceHandler(req).check_connection()
+
         self._check_schema_exists(schema_type)
         collection = f"draft-{schema_type}" if req.path.startswith("/drafts") else schema_type
 
@@ -229,6 +231,9 @@ class ObjectAPIHandler(RESTAPIHandler):
 
         await self._handle_check_ownership(req, collection, accession_id)
 
+        metax_handler = MetaxServiceHandler(req)
+        await metax_handler.check_connection()
+
         submission_op = SubmissionOperator(db_client)
         exists, submission_id, published = await submission_op.check_object_in_submission(collection, accession_id)
         if exists:
@@ -261,7 +266,7 @@ class ObjectAPIHandler(RESTAPIHandler):
 
         # Delete draft dataset from Metax catalog
         if collection in _allowed_doi:
-            await MetaxServiceHandler(req).delete_draft_dataset(metax_id)
+            await metax_handler.delete_draft_dataset(metax_id)
             doi_service = DOIHandler()
             await doi_service.delete(doi_id)
 
@@ -306,6 +311,9 @@ class ObjectAPIHandler(RESTAPIHandler):
 
         await self._handle_check_ownership(req, collection, accession_id)
 
+        metax_handler = MetaxServiceHandler(req)
+        await metax_handler.check_connection()
+
         submission_op = SubmissionOperator(db_client)
         exists, submission_id, published = await submission_op.check_object_in_submission(collection, accession_id)
         if exists:
@@ -321,7 +329,7 @@ class ObjectAPIHandler(RESTAPIHandler):
         # Update draft dataset to Metax catalog
         if collection in _allowed_doi:
             if data.get("metaxIdentifier", None):
-                await MetaxServiceHandler(req).update_draft_dataset(collection, data)
+                await metax_handler.update_draft_dataset(collection, data)
             else:
                 await self.create_metax_dataset(req, collection, data, create_draft_doi=False)
 
@@ -358,6 +366,9 @@ class ObjectAPIHandler(RESTAPIHandler):
 
         await self._handle_check_ownership(req, collection, accession_id)
 
+        metax_handler = MetaxServiceHandler(req)
+        await metax_handler.check_connection()
+
         submission_op = SubmissionOperator(db_client)
         exists, submission_id, published = await submission_op.check_object_in_submission(collection, accession_id)
         if exists:
@@ -382,7 +393,7 @@ class ObjectAPIHandler(RESTAPIHandler):
             # MYPY related if statement, Operator (when not XMLOperator) always returns object_data as dict
             if isinstance(object_data, Dict):
                 if object_data.get("metaxIdentifier", None):
-                    await MetaxServiceHandler(req).update_draft_dataset(collection, object_data)
+                    await metax_handler.update_draft_dataset(collection, object_data)
                 else:
                     await self.create_metax_dataset(req, collection, object_data, create_draft_doi=False)
             else:

--- a/metadata_backend/api/handlers/submission.py
+++ b/metadata_backend/api/handlers/submission.py
@@ -500,6 +500,8 @@ class SubmissionAPIHandler(RESTAPIHandler):
 
         await self._handle_check_ownership(req, "submissions", submission_id)
 
+        await metax_handler.check_connection()
+
         submission = await operator.read_submission(submission_id)
 
         # we first try to publish the DOI before actually publishing the submission

--- a/metadata_backend/api/handlers/submission.py
+++ b/metadata_backend/api/handlers/submission.py
@@ -500,8 +500,6 @@ class SubmissionAPIHandler(RESTAPIHandler):
 
         await self._handle_check_ownership(req, "submissions", submission_id)
 
-        await metax_handler.check_connection()
-
         submission = await operator.read_submission(submission_id)
 
         # we first try to publish the DOI before actually publishing the submission

--- a/metadata_backend/api/handlers/xml_submission.py
+++ b/metadata_backend/api/handlers/xml_submission.py
@@ -205,6 +205,8 @@ class XMLSubmissionAPIHandler(ObjectAPIHandler):
         db_client = req.app["db_client"]
         submission_op = SubmissionOperator(db_client)
         operator = Operator(db_client)
+        metax_handler = MetaxServiceHandler(req)
+        await metax_handler.check_connection()
         data_as_json = XMLToJSONParser().parse(schema, content)
         if "accessionId" in data_as_json:
             accession_id = data_as_json["accessionId"]
@@ -245,7 +247,7 @@ class XMLSubmissionAPIHandler(ObjectAPIHandler):
             object_data, _ = await operator.read_metadata_object(schema, accession_id)
             # MYPY related if statement, Operator (when not XMLOperator) always returns object_data as dict
             if isinstance(object_data, Dict):
-                await MetaxServiceHandler(req).update_draft_dataset(schema, object_data)
+                await metax_handler.update_draft_dataset(schema, object_data)
             else:
                 raise ValueError("Object's data must be dictionary")
 

--- a/metadata_backend/api/middlewares.py
+++ b/metadata_backend/api/middlewares.py
@@ -74,11 +74,6 @@ async def check_login(request: Request, handler: Callable) -> StreamResponse:
         "/static",
         "/swagger",
         "/health",
-        "/error400",
-        "/error401",
-        "/error403",
-        "/error404",
-        "/error500",
     ]
     if (
         request.path.startswith(tuple(main_paths))

--- a/metadata_backend/api/middlewares.py
+++ b/metadata_backend/api/middlewares.py
@@ -35,7 +35,7 @@ async def http_error_handler(req: Request, handler: Callable) -> Response:
         LOG.debug("Response payload is %r", problem)
         c_type = "application/problem+json"
 
-        if error.status in {400, 401, 403, 404, 415, 422}:
+        if error.status in {400, 401, 403, 404, 415, 422, 502, 504}:
             error.content_type = c_type
             error.text = problem
             raise error

--- a/metadata_backend/api/middlewares.py
+++ b/metadata_backend/api/middlewares.py
@@ -26,14 +26,18 @@ async def http_error_handler(req: Request, handler: Callable) -> Response:
     :raises: Reformatted HTTP Exceptions
     :returns: Successful requests unaffected
     """
+    c_type = "application/problem+json"
     try:
         response = await handler(req)
         return response
+    except (web.HTTPSuccessful, web.HTTPRedirection):
+        # Catches 200s and 300s
+        raise
     except web.HTTPError as error:
+        # Catch 400s and 500s
         LOG.info(HTTP_ERROR_MESSAGE, req.method, req.path, error.status)
         problem = _json_problem(error, req.url)
         LOG.debug("Response payload is %r", problem)
-        c_type = "application/problem+json"
 
         if error.status in {400, 401, 403, 404, 415, 422, 502, 504}:
             error.content_type = c_type
@@ -42,6 +46,13 @@ async def http_error_handler(req: Request, handler: Callable) -> Response:
         else:
             LOG.exception(HTTP_ERROR_MESSAGE + " This IS a bug.", req.method, req.path, error.status)
             raise web.HTTPInternalServerError(text=problem, content_type=c_type)
+    except Exception:
+        # We don't expect any other errors, so we log it and return a nice message instead of letting server crash
+        LOG.exception("HTTP %r request to %r raised an unexpected exception. This IS a bug.", req.method, req.path)
+        exception = web.HTTPInternalServerError(reason="Server ran into an unexpected error", content_type=c_type)
+        problem = _json_problem(exception, req.url)
+        exception.text = problem
+        raise exception
 
 
 @middleware

--- a/metadata_backend/helpers/metax_api_handler.py
+++ b/metadata_backend/helpers/metax_api_handler.py
@@ -80,18 +80,9 @@ class MetaxServiceHandler:
         metadata_provider_user = user["externalId"]
         return metadata_provider_user
 
-    @retry((HTTPRequestTimeout, ClientConnectorError), 5)
-    async def check_connection(self, timeout: int = 2) -> bool:
-        """Check connection for Metax server.
-
-        :param timeout: Request operations timeout
         """
         async with ClientSession() as sess:
             try:
-                await sess.head(self.metax_url, timeout=timeout)
-                return True
-            except asyncio.exceptions.TimeoutError:
-                raise HTTPRequestTimeout(reason=f"Metax server {self.metax_url} is not respondig")
 
     @retry(total_tries=5)
     async def _get(self, metax_id: str) -> str:
@@ -252,7 +243,6 @@ class MetaxServiceHandler:
             f"{data['accessionId']}"
         )
         try:
-            await self.check_connection()
             metax_dataset = self.minimal_dataset_template
             metax_dataset["metadata_provider_user"] = await self.get_metadata_provider_user()
             if collection == "dataset":

--- a/metadata_backend/helpers/metax_api_handler.py
+++ b/metadata_backend/helpers/metax_api_handler.py
@@ -24,7 +24,7 @@ from .retry import retry
 
 
 class MetaxServiceHandler:
-    """API handler for uploading submitter's metadata to METAX service."""
+    """API handler for uploading submitters' metadata to METAX service."""
 
     def __init__(self, req: Request) -> None:
         """Define variables and paths.
@@ -206,10 +206,9 @@ class MetaxServiceHandler:
 
     @retry(total_tries=5)
     async def _publish(self, metax_id: str) -> str:
-        """Post call to Metax RPC publish endpoint.
+        """Post a call to Metax RPC publish endpoint.
 
         :param metax_id: ID of dataset to be updated
-        :param json_data: Dict with request data
         :returns: Dict with full Metax dataset
         """
         async with ClientSession() as sess:
@@ -233,7 +232,7 @@ class MetaxServiceHandler:
         Construct Metax dataset data from submitters' Study or Dataset and
         send it as new draft dataset to Metax Dataset API.
 
-        :param collection: Schema of incomming submitters metadata
+        :param collection: Schema of incoming submitters' metadata
         :param data: Validated Study or Dataset data dict
         :raises: HTTPError depending on returned error from Metax
         :returns: Metax ID for dataset returned by Metax API
@@ -271,7 +270,7 @@ class MetaxServiceHandler:
         Construct Metax draft dataset data from submitters' Study or Dataset and
         send it to Metax Dataset API for update.
 
-        :param collection: Schema of incomming submitters metadata
+        :param collection: Schema of incoming submitters' metadata
         :param data: Validated Study or Dataset data dict
         :raises: HTTPError depending on returned error from Metax
         :returns: Metax ID for dataset returned by Metax API
@@ -310,7 +309,7 @@ class MetaxServiceHandler:
         """Update dataset for publishing.
 
         :param doi_info: Dict containing info to complete metax dataset metadata
-        :param metax_id: Metax id of dataset to be updated
+        :param _metax_ids: List of Metax id of dataset to be updated
         """
         LOG.info(
             "Updating metadata with datacite info for Metax datasets: "

--- a/metadata_backend/helpers/retry.py
+++ b/metadata_backend/helpers/retry.py
@@ -36,7 +36,6 @@ def retry(
     :param total_tries: Total tries
     :param initial_wait: Time to first retry
     :param backoff_factor: Backoff multiplier (e.g. value of 2 will double the delay each retry).
-    :param logger: logger to be used, if none specified print
     """
 
     def retry_decorator(f: Callable) -> Callable:

--- a/tests/http/publication_minimal.http
+++ b/tests/http/publication_minimal.http
@@ -51,7 +51,7 @@ POST {{backend_url}}/objects/study
 
 < ../test_files/study/SRP000539.json
 
-### Add DOI to submission
+### Update DOI in submission
 PUT {{backend_url}}/submissions/{{submission_id}}/doi
 
 < ../test_files/doi/test_doi.json

--- a/tests/integration/mock_metax_api.py
+++ b/tests/integration/mock_metax_api.py
@@ -35,6 +35,15 @@ drafts = {}
 published = {}
 
 
+async def get_root(req: web.Request) -> web.Response:
+    """Mock endpoint for testing server responds.
+
+    :params req: HTTP request with data for Metax dataset
+    :return: HTTPNoContent
+    """
+    return web.HTTPNoContent()
+
+
 async def get_dataset(req: web.Request) -> web.Response:
     """Mock endpoint for retrieving Metax dataset.
 
@@ -352,6 +361,7 @@ async def init() -> web.Application:
     """Start server."""
     app = web.Application()
     api_routes = [
+        web.get("/", get_root),
         web.post("/rest/v2/datasets", post_dataset),
         web.put("/rest/v2/datasets/{metax_id}", update_dataset),
         web.delete("/rest/v2/datasets/{metax_id}", delete_dataset),


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
Refactored Metax error handling, so error becomes visible to end user, only in publication endpoint.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
- Fixes #382

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made
<!-- List changes made. -->
- Remove lingering error page references
- Remove broken HEAD request to check for connection - Metax doesn't support HEAD requests
- Remove duplicate code
- Let Metax errors surface
- Catches unexpected errors and return JSON Problem detail
- Update Docker compose version to 3.4 as the `build target` parameter was introduced in that version
- Add Metax connection check to more endpoints.
- Ignore and log metax errors in Object API endpoints

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

Existing tests should continue to work.

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
