### PR TITLE
Mount API as sub application on /v1

### DIFF
--- a/.github/config/.wordlist.txt
+++ b/.github/config/.wordlist.txt
@@ -211,7 +211,6 @@ filetype
 flatfile
 flx
 flybase
-submissionid
 followsreadindex
 formdata
 fos
@@ -267,6 +266,7 @@ html
 http
 httperror
 https
+HTTPSeeOther
 identifiertype
 identitypython
 ido
@@ -589,7 +589,7 @@ studytitle
 studytype
 subjectscheme
 subjectsSchema
-submissionsubmission
+submissionid
 submissionslice
 submissiontype
 submitterdemultiplexed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - HTTPError exceptions return a response with JSON Problem instead of an HTML page #433
   - Make Metax errors visible to user #453
   - Catch unexpected errors and return a JSON Problem instead of server crashing #453
+- Fix session and authorization issues
+  - Prefix API endpoint with /v1
+  - Refactor authentication checking, fixing issues from #421 and remove HTTPSeeOther from the API
 
 ### Removed
 

--- a/docs/frontend.rst
+++ b/docs/frontend.rst
@@ -224,7 +224,7 @@ Example:
 
     import { create } from "apisauce"
 
-    const api = create({ baseURL: "/objects" })
+    const api = create({ baseURL: "/v1/objects" })
 
     const createFromXML = async (objectType: string, XMLFile: string) => {
     let formData = new FormData()

--- a/docs/specification.yml
+++ b/docs/specification.yml
@@ -16,7 +16,7 @@ tags:
   - name: Manage
     description: Endpoints used for managing data
 paths:
-  /submit:
+  /v1/submit:
     post:
       tags:
         - Submission
@@ -60,7 +60,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/403Forbidden"
-  /validate:
+  /v1/validate:
     post:
       tags:
         - Submission
@@ -96,7 +96,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/403Forbidden"
-  /schemas:
+  /v1/schemas:
     get:
       tags:
         - Query
@@ -126,7 +126,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/403Forbidden"
-  /schemas/{schema}:
+  /v1/schemas/{schema}:
     get:
       tags:
         - Query
@@ -163,7 +163,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/403Forbidden"
-  /objects/{schema}:
+  /v1/objects/{schema}:
     get:
       tags:
         - Query
@@ -353,7 +353,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/403Forbidden"
-  /objects/{schema}/{accessionId}:
+  /v1/objects/{schema}/{accessionId}:
     get:
       tags:
         - Query
@@ -538,7 +538,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/403Forbidden"
-  /drafts/{schema}:
+  /v1/drafts/{schema}:
     post:
       tags:
         - Submission
@@ -588,7 +588,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/401Unauthorized"
-  /drafts/{schema}/{accessionId}:
+  /v1/drafts/{schema}/{accessionId}:
     get:
       tags:
         - Query
@@ -773,7 +773,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/403Forbidden"
-  /templates:
+  /v1/templates:
     get:
       tags:
         - Query
@@ -804,7 +804,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/403Forbidden"
-  /templates/{schema}:
+  /v1/templates/{schema}:
     post:
       tags:
         - Submission
@@ -846,7 +846,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/403Forbidden"
-  /templates/{schema}/{accessionId}:
+  /v1/templates/{schema}/{accessionId}:
     get:
       tags:
         - Query
@@ -932,7 +932,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/403Forbidden"
   
-  /submissions:
+  /v1/submissions:
     get:
       tags:
         - Query
@@ -1046,7 +1046,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/403Forbidden"
-  /submissions/{submissionId}:
+  /v1/submissions/{submissionId}:
     get:
       tags:
         - Query
@@ -1167,7 +1167,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/403Forbidden"
-  /submissions/{submissionId}/doi:
+  /v1/submissions/{submissionId}/doi:
     put:
       tags:
         - Manage
@@ -1209,7 +1209,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/403Forbidden"
-  /publish/{submissionId}:
+  /v1/publish/{submissionId}:
     patch:
       tags:
         - Manage
@@ -1258,7 +1258,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/504GatewayTimeout"
-  /users/{userId}:
+  /v1/users/{userId}:
     get:
       tags:
         - Query

--- a/docs/submitter.rst
+++ b/docs/submitter.rst
@@ -153,7 +153,7 @@ The REST API is structured as follows:
 - `Management Endpoints` used for handling data updates and deletion, makes use of HTTP ``PUT``, ``PATCH`` and ``DELETE``.
 
 .. important:: A logged in user can only perform operations on the data it has associated.
-               The information for the current user can be retrieved at ``/users/current`` (the user ID is ``current``), and
+               The information for the current user can be retrieved at ``/v1/users/current`` (the user ID is ``current``), and
                any additional operations on other users are rejected.
 
 

--- a/metadata_backend/api/auth.py
+++ b/metadata_backend/api/auth.py
@@ -49,14 +49,12 @@ class AccessHandler:
         """Redirect user to AAI login.
 
         :param req: A HTTP request instance (unused)
-        :raises: HTTPSeeOther redirect to login AAI
         :raises: HTTPInternalServerError if OIDC configuration init failed
         :returns: HTTPSseeOther redirect to AAI
         """
         LOG.debug("Start login")
 
         # Generate authentication payload
-        session = None
         try:
             session = self.rph.begin("aai")
         except Exception as e:
@@ -77,7 +75,7 @@ class AccessHandler:
         Sets encrypted cookie to identify clients.
 
         :raises: HTTPUnauthorized in case login failed
-        :raises: HTTPBadRequest AAI sends wrong paramters
+        :raises: HTTPBadRequest AAI sends wrong parameters
         :raises: HTTPForbidden in case of bad session
         :param req: A HTTP request instance with callback parameters
         :returns: HTTPSeeOther redirect to home page
@@ -93,7 +91,6 @@ class AccessHandler:
             raise web.HTTPUnauthorized(reason=reason)
 
         # Verify oidc_state and retrieve auth session
-        session = None
         try:
             session = self.rph.get_session_information(params["state"])
         except KeyError as e:

--- a/metadata_backend/api/handlers/user.py
+++ b/metadata_backend/api/handlers/user.py
@@ -10,7 +10,6 @@ from aiohttp import web
 from aiohttp.web import Request, Response
 from multidict import CIMultiDict
 
-from ...conf.conf import aai_config
 from ...helpers.logger import LOG
 from ..operators import UserOperator
 from .restapi import RESTAPIHandler
@@ -124,12 +123,8 @@ class UserAPIHandler(RESTAPIHandler):
 
         session.invalidate()
 
-        response = web.HTTPSeeOther(f"{aai_config['redirect']}/")
-        response.headers["Location"] = (
-            "/" if aai_config["redirect"] == aai_config["domain"] else f"{aai_config['redirect']}/"
-        )
-        LOG.debug("Logged out user ")
-        raise response
+        LOG.debug(f"Logged out user {user_id}")
+        return web.HTTPNoContent()
 
     async def _get_user_items(self, req: Request, user: Dict, item_type: str) -> Tuple[Dict, CIMultiDict[str]]:
         """Get draft templates owned by the user with pagination values.

--- a/metadata_backend/api/handlers/xml_submission.py
+++ b/metadata_backend/api/handlers/xml_submission.py
@@ -8,6 +8,7 @@ from aiohttp.web import Request, Response
 from multidict import MultiDict, MultiDictProxy
 from xmlschema import XMLSchemaException
 
+from ...conf.conf import API_PREFIX
 from ...helpers.logger import LOG
 from ...helpers.metax_api_handler import MetaxServiceHandler
 from ...helpers.parser import XMLToJSONParser
@@ -167,7 +168,7 @@ class XMLSubmissionAPIHandler(ObjectAPIHandler):
         # we only allow one study per submission
         # this is not enough to catch duplicate entries if updates happen in parallel
         # that is why we check in db_service.update_study
-        if not req.path.startswith("/drafts") and schema == "study":
+        if not req.path.startswith(f"{API_PREFIX}/drafts") and schema == "study":
             _ids = await submission_op.get_collection_objects(submission_id, schema)
             if len(_ids) == 1:
                 reason = "Only one study is allowed per submission."

--- a/metadata_backend/conf/conf.py
+++ b/metadata_backend/conf/conf.py
@@ -96,6 +96,8 @@ LOG.debug(f"mongodb connection string is {url}")
 serverTimeout = 15000
 connectTimeout = 15000
 
+API_PREFIX = "/v1"
+
 
 def create_db_client() -> AsyncIOMotorClient:
     """Initialize database client for AioHTTP App.
@@ -142,6 +144,9 @@ swagger_static_path = Path(__file__).parent.parent / "swagger" / "index.html"
 
 
 # 5) Set up configurations for AAI server
+OIDC_ENABLED = False
+if "OIDC_URL" in os.environ and bool(os.getenv("OIDC_URL")):
+    OIDC_ENABLED = True
 
 aai_config = {
     "client_id": os.getenv("AAI_CLIENT_ID", "public"),
@@ -160,7 +165,7 @@ aai_config = {
 # 6) Set the DataCite REST API values
 
 doi_config = {
-    "api": os.getenv("DOI_API", ""),
+    "api": os.getenv("DOI_API", "http://localhost:8001/dois"),
     "prefix": os.getenv("DOI_PREFIX", ""),
     "user": os.getenv("DOI_USER", ""),
     "key": os.getenv("DOI_KEY", ""),

--- a/metadata_backend/server.py
+++ b/metadata_backend/server.py
@@ -1,7 +1,6 @@
 """Functions to launch backend server."""
 
 import asyncio
-import secrets
 
 import uvloop
 import base64
@@ -18,8 +17,14 @@ from .api.handlers.xml_submission import XMLSubmissionAPIHandler
 from .api.handlers.template import TemplatesAPIHandler
 from .api.handlers.user import UserAPIHandler
 from .api.health import HealthHandler
-from .api.middlewares import http_error_handler, check_session_at
-from .conf.conf import aai_config, create_db_client, frontend_static_files, swagger_static_path
+from .api.middlewares import http_error_handler, check_session
+from .conf.conf import (
+    aai_config,
+    create_db_client,
+    frontend_static_files,
+    swagger_static_path,
+    API_PREFIX,
+)
 from .helpers.logger import LOG
 import aiohttp_session
 import aiohttp_session.cookie_storage
@@ -43,29 +48,10 @@ async def init(
     :param inject_middleware: list of middlewares to inject
     :returns: Web Application
     """
-    middlewares = [http_error_handler, check_session_at]
+    middlewares = [http_error_handler, check_session]
     if inject_middleware:
         middlewares = middlewares + inject_middleware
-    server = web.Application()
-
-    # Mutable_map handles cookie storage, also stores the object that provides
-    # the encryption we use
-    # Initialize aiohttp_session
-    server["seckey"] = base64.urlsafe_b64decode(Fernet.generate_key())
-    aiohttp_session.setup(
-        server,
-        aiohttp_session.cookie_storage.EncryptedCookieStorage(
-            server["seckey"],
-        ),
-    )
-
-    # Add the rest of the middlewares
-    [server.middlewares.append(i) for i in middlewares]  # type: ignore
-
-    # Create a signature salt to prevent editing the signature on the client
-    # side. Hash function doesn't need to be cryptographically secure, it's
-    # just a convenient way of getting ascii output from byte values.
-    server["Salt"] = secrets.token_hex(64)
+    api = web.Application(middlewares=middlewares)
 
     _schema = RESTAPIHandler()
     _object = ObjectAPIHandler()
@@ -74,7 +60,7 @@ async def init(
     _xml_submission = XMLSubmissionAPIHandler()
     _template = TemplatesAPIHandler()
     api_routes = [
-        # retrieve schema and informations about it
+        # retrieve schema and information about it
         web.get("/schemas", _schema.get_schema_types),
         web.get("/schemas/{schema}", _schema.get_json_schema),
         # metadata objects operations
@@ -84,7 +70,7 @@ async def init(
         web.put("/objects/{schema}/{accessionId}", _object.put_object),
         web.patch("/objects/{schema}/{accessionId}", _object.patch_object),
         web.delete("/objects/{schema}/{accessionId}", _object.delete_object),
-        # drafts objects operations
+        # draft objects operations
         web.post("/drafts/{schema}", _object.post_object),
         web.get("/drafts/{schema}/{accessionId}", _object.get_object),
         web.put("/drafts/{schema}/{accessionId}", _object.put_object),
@@ -96,7 +82,7 @@ async def init(
         web.get("/templates/{schema}/{accessionId}", _template.get_template),
         web.patch("/templates/{schema}/{accessionId}", _template.patch_template),
         web.delete("/templates/{schema}/{accessionId}", _template.delete_template),
-        # submissions/submissions operations
+        # submissions operations
         web.get("/submissions", _submission.get_submissions),
         web.post("/submissions", _submission.post_submission),
         web.get("/submissions/{submissionId}", _submission.get_submission),
@@ -113,35 +99,48 @@ async def init(
         # validate
         web.post("/validate", _xml_submission.validate),
     ]
-    server.router.add_routes(api_routes)
-    LOG.info("Server configurations and routes loaded")
+    api.add_routes(api_routes)
+    LOG.info("API configurations and routes loaded")
+
+    sec_key = base64.urlsafe_b64decode(Fernet.generate_key())
+    session_middleware = aiohttp_session.session_middleware(
+        aiohttp_session.cookie_storage.EncryptedCookieStorage(sec_key)
+    )
+    server = web.Application(middlewares=[session_middleware])
+    server.add_subapp(API_PREFIX, api)
+
     _access = AccessHandler(aai_config)
     aai_routes = [
         web.get("/aai", _access.login),
         web.get("/logout", _access.logout),
         web.get("/callback", _access.callback),
     ]
-    server.router.add_routes(aai_routes)
+    server.add_routes(aai_routes)
     LOG.info("AAI routes loaded")
     _health = HealthHandler()
     health_routes = [
         web.get("/health", _health.get_health_status),
     ]
-    server.router.add_routes(health_routes)
+    server.add_routes(health_routes)
     LOG.info("Health routes loaded")
     if swagger_static_path.exists():
         swagger_handler = html_handler_factory(swagger_static_path)
         server.router.add_get("/swagger", swagger_handler)
         LOG.info("Swagger routes loaded")
+
+    # These should be the last routes added, as they are a catch-all
     if frontend_static_files.exists():
         _static = StaticHandler(frontend_static_files)
         frontend_routes = [
             web.static("/static", _static.setup_static()),
             web.get("/{path:.*}", _static.frontend),
         ]
-        server.router.add_routes(frontend_routes)
+        server.add_routes(frontend_routes)
         LOG.info("Frontend routes loaded")
-    server["db_client"] = create_db_client()
+
+    db_client = create_db_client()
+    api["db_client"] = db_client
+    server["db_client"] = db_client
     LOG.info("Database client loaded")
     return server
 

--- a/tests/http/publication_minimal.http
+++ b/tests/http/publication_minimal.http
@@ -13,7 +13,7 @@
 @project_id = {{user_data_req.response.body.projects[0].projectId}}
 @submission_id = {{submission_id_req.response.body.submissionId}}
 
-### Mock athentication
+### Mock authentication
 GET {{auth_url}}/setmock
     ?sub={{auth_email}}
     &given=Mock
@@ -22,15 +22,19 @@ GET {{auth_url}}/setmock
 ###
 GET {{backend_url}}/aai
 
+###
+GET {{backend_url}}/logout
+
+
 ### Get user data
 # @name user_data_req
-GET {{backend_url}}/users/current
+GET {{backend_url}}/v1/users/current
 
 
 
 ### Create submission
 # @name submission_id_req
-POST {{backend_url}}/submissions
+POST {{backend_url}}/v1/submissions
 
 {
     "name": "submission test 1",
@@ -39,22 +43,22 @@ POST {{backend_url}}/submissions
 }
 
 ### List submissions
-GET {{backend_url}}/submissions
+GET {{backend_url}}/v1/submissions
     ?projectId={{project_id}}
 
 ### Get submission
-GET {{backend_url}}/submissions/{{submission_id}}
+GET {{backend_url}}/v1/submissions/{{submission_id}}
 
 ### Add study to submission
-POST {{backend_url}}/objects/study
+POST {{backend_url}}/v1/objects/study
     ?submission={{submission_id}}
 
 < ../test_files/study/SRP000539.json
 
 ### Update DOI in submission
-PUT {{backend_url}}/submissions/{{submission_id}}/doi
+PUT {{backend_url}}/v1/submissions/{{submission_id}}/doi
 
 < ../test_files/doi/test_doi.json
 
 ### Publish submission
-PATCH {{backend_url}}/publish/{{submission_id}}
+PATCH {{backend_url}}/v1/publish/{{submission_id}}

--- a/tests/performance/locustfile.py
+++ b/tests/performance/locustfile.py
@@ -5,6 +5,8 @@ import json
 from pathlib import Path
 from locust import HttpUser, task, tag, between
 
+from metadata_backend.conf.conf import API_PREFIX
+
 testfiles_root = Path(__file__).parent.parent / "test_files"
 
 
@@ -30,13 +32,13 @@ class BasicUser(HttpUser):
 
         # Create new submission
         test_submission = {"name": "test1", "description": "test submission"}
-        with self.client.post("/submissions", json=test_submission, catch_response=True) as resp:
+        with self.client.post(f"{API_PREFIX}/submissions", json=test_submission, catch_response=True) as resp:
             if resp.status_code != 201:
                 resp.failure("Submission was not added successfully.")
             submission_id = resp.json()["submissionId"]
 
         # Post a study object
-        with self.client.post("/objects/study", json=json_file, catch_response=True) as resp:
+        with self.client.post(f"{API_PREFIX}/objects/study", json=json_file, catch_response=True) as resp:
             if resp.status_code != 201:
                 resp.failure("Object was not added successfully.")
             accession_id = resp.json()["accessionId"]
@@ -46,7 +48,10 @@ class BasicUser(HttpUser):
             {"op": "add", "path": "/metadataObjects/-", "value": {"accessionId": accession_id, "schema": "study"}}
         ]
         with self.client.patch(
-            f"/submissions/{submission_id}", json=patch_object, name="/submissions/{submissionId}", catch_response=True
+            f"{API_PREFIX}/submissions/{submission_id}",
+            json=patch_object,
+            name=f"{API_PREFIX}/submissions/{{submissionId}}",
+            catch_response=True,
         ) as resp:
             if resp.status_code != 200:
                 resp.failure("Object was not patched to submission successfully.")
@@ -62,13 +67,13 @@ class BasicUser(HttpUser):
 
         # Create new submission
         test_submission = {"name": "test2", "description": "another test submission"}
-        with self.client.post("/submissions", json=test_submission, catch_response=True) as resp:
+        with self.client.post(f"{API_PREFIX}/submissions", json=test_submission, catch_response=True) as resp:
             if resp.status_code != 201:
                 resp.failure("Submission was not added successfully.")
             submission_id = resp.json()["submissionId"]
 
         # Post a study object
-        with self.client.post("/objects/study", json=json_file1, catch_response=True) as resp:
+        with self.client.post(f"{API_PREFIX}/objects/study", json=json_file1, catch_response=True) as resp:
             if resp.status_code != 201:
                 resp.failure("Object was not added successfully.")
             accession_id1 = resp.json()["accessionId"]
@@ -78,13 +83,16 @@ class BasicUser(HttpUser):
             {"op": "add", "path": "/metadataObjects/-", "value": {"accessionId": accession_id1, "schema": "study"}}
         ]
         with self.client.patch(
-            f"/submissions/{submission_id}", json=patch_object1, name="/submissions/{submissionId}", catch_response=True
+            f"{API_PREFIX}/submissions/{submission_id}",
+            json=patch_object1,
+            name=f"{API_PREFIX}/submissions/{{submissionId}}",
+            catch_response=True,
         ) as resp:
             if resp.status_code != 200:
                 resp.failure("Object was not patched to submission successfully.")
 
         # Post an experiment object
-        with self.client.post("/objects/experiment", json=json_file2, catch_response=True) as resp:
+        with self.client.post(f"{API_PREFIX}/objects/experiment", json=json_file2, catch_response=True) as resp:
             if resp.status_code != 201:
                 resp.failure("Object was not added successfully.")
             accession_id2 = resp.json()["accessionId"]
@@ -94,7 +102,10 @@ class BasicUser(HttpUser):
             {"op": "add", "path": "/metadataObjects/-", "value": {"accessionId": accession_id2, "schema": "experiment"}}
         ]
         with self.client.patch(
-            f"/submissions/{submission_id}", json=patch_object2, name="/submissions/{submissionId}", catch_response=True
+            f"{API_PREFIX}/submissions/{submission_id}",
+            json=patch_object2,
+            name=f"{API_PREFIX}/submissions/{submission_id}",
+            catch_response=True,
         ) as resp:
             if resp.status_code != 200:
                 resp.failure("Object was not patched to submission successfully.")
@@ -112,7 +123,7 @@ class BasicUser(HttpUser):
     def get_submissions_and_objects(self):
         """Get users submissions, read one of the objects in a submission and get the object by accession ID."""
 
-        with self.client.get("/submissions", catch_response=True) as resp:
+        with self.client.get(f"{API_PREFIX}/submissions", catch_response=True) as resp:
             if resp.status_code != 200:
                 resp.failure("Getting submissions was unsuccesful.")
             elif resp.json()["page"]["totalSubmissions"] == 0:
@@ -122,7 +133,9 @@ class BasicUser(HttpUser):
             obj_schema = resp.json()["submissions"][0]["metadataObjects"][0]["schema"]
 
         with self.client.get(
-            f"/objects/{obj_schema}/{obj_acc_id}", name="/objects/{schema}/{accessionId}", catch_response=True
+            f"{API_PREFIX}/objects/{obj_schema}/{obj_acc_id}",
+            name=f"{API_PREFIX}/objects/{{schema}}/{{accessionId}}",
+            catch_response=True,
         ) as resp:
             if resp.status_code != 200:
                 resp.failure("Getting an object was unsuccesful.")

--- a/tests/test_files/analysis/ERZ266973.json
+++ b/tests/test_files/analysis/ERZ266973.json
@@ -44,108 +44,108 @@
     "processedReads": {
       "assembly": {
         "refname": "GRCh37",
-        "accessionId": "GCA_000001405.1"
+        "accession": "GCA_000001405.1"
       },
       "sequence": [
         {
           "label": "1",
-          "accessionId": "CM000663.1"
+          "accession": "CM000663.1"
         },
         {
           "label": "10",
-          "accessionId": "CM000672.1"
+          "accession": "CM000672.1"
         },
         {
           "label": "11",
-          "accessionId": "CM000673.1"
+          "accession": "CM000673.1"
         },
         {
           "label": "12",
-          "accessionId": "CM000674.1"
+          "accession": "CM000674.1"
         },
         {
           "label": "13",
-          "accessionId": "CM000675.1"
+          "accession": "CM000675.1"
         },
         {
           "label": "14",
-          "accessionId": "CM000676.1"
+          "accession": "CM000676.1"
         },
         {
           "label": "15",
-          "accessionId": "CM000677.1"
+          "accession": "CM000677.1"
         },
         {
           "label": "16",
-          "accessionId": "CM000678.1"
+          "accession": "CM000678.1"
         },
         {
           "label": "17",
-          "accessionId": "CM000679.1"
+          "accession": "CM000679.1"
         },
         {
           "label": "18",
-          "accessionId": "CM000680.1"
+          "accession": "CM000680.1"
         },
         {
           "label": "19",
-          "accessionId": "CM000681.1"
+          "accession": "CM000681.1"
         },
         {
           "label": "2",
-          "accessionId": "CM000664.1"
+          "accession": "CM000664.1"
         },
         {
           "label": "20",
-          "accessionId": "CM000682.1"
+          "accession": "CM000682.1"
         },
         {
           "label": "21",
-          "accessionId": "CM000683.1"
+          "accession": "CM000683.1"
         },
         {
           "label": "22",
-          "accessionId": "CM000684.1"
+          "accession": "CM000684.1"
         },
         {
           "label": "3",
-          "accessionId": "CM000665.1"
+          "accession": "CM000665.1"
         },
         {
           "label": "4",
-          "accessionId": "CM000666.1"
+          "accession": "CM000666.1"
         },
         {
           "label": "5",
-          "accessionId": "CM000667.1"
+          "accession": "CM000667.1"
         },
         {
           "label": "6",
-          "accessionId": "CM000668.1"
+          "accession": "CM000668.1"
         },
         {
           "label": "7",
-          "accessionId": "CM000669.1"
+          "accession": "CM000669.1"
         },
         {
           "label": "8",
-          "accessionId": "CM000670.1"
+          "accession": "CM000670.1"
         },
         {
           "label": "9",
-          "accessionId": "CM000671.1"
+          "accession": "CM000671.1"
         },
         {
           "label": "MT",
-          "accessionId": "J01415.2"
+          "accession": "J01415.2"
         },
         {
           "label": "X",
-          "accessionId": "CM000685.1"
+          "accession": "CM000685.1"
         },
         {
           "label": "Y",
-          "accessionId": "CM000686.1"
+          "accession": "CM000686.1"
         }
       ]
     }

--- a/tests/test_files/run/ERR000076.json
+++ b/tests/test_files/run/ERR000076.json
@@ -11,18 +11,20 @@
       "value": "BGI-FC304RWAAXX"
     }
   },
-  "experimentRef": {
-    "refname": "g1k-bgi-NA18542-HUMsgR2ACDECBPE",
-    "refcenter": "BGI",
-    "accessionId": "ERX000037",
-    "identifiers": {
-      "primaryId": "ERX000037",
-      "submitterId": {
-        "namespace": "BGI",
-        "value": "g1k-bgi-NA18542-HUMsgR2ACDECBPE"
+  "experimentRef": [
+    {
+      "refname": "g1k-bgi-NA18542-HUMsgR2ACDECBPE",
+      "refcenter": "BGI",
+      "accessionId": "ERX000037",
+      "identifiers": {
+        "primaryId": "ERX000037",
+        "submitterId": {
+          "namespace": "BGI",
+          "value": "g1k-bgi-NA18542-HUMsgR2ACDECBPE"
+        }
       }
     }
-  },
+  ],
   "files": [
     {
       "filename": "ERA000/ERA000014/srf/BGI-FC304RWAAXX_5.srf",

--- a/tests/test_files/sample/SRS001433.json
+++ b/tests/test_files/sample/SRS001433.json
@@ -18,14 +18,12 @@
     "scientificName": "Homo sapiens"
   },
   "description": "Human HapMap individual NA18758",
-  "sampleLinks": {
-    "urlLinks": [
-      {
-        "label": "DNA source",
-        "url": "http://ccr.coriell.org/Sections/Collections/NHGRI/hapmap.aspx?PgId=266"
-      }
-    ]
-  },
+  "sampleLinks": [
+    {
+      "label": "DNA source",
+      "url": "http://ccr.coriell.org/Sections/Collections/NHGRI/hapmap.aspx?PgId=266"
+    }
+  ],
   "sampleAttributes": [
     {
       "tag": "population",

--- a/tests/test_middlewares.py
+++ b/tests/test_middlewares.py
@@ -7,6 +7,7 @@ from aiohttp import FormData
 from aiohttp.test_utils import AioHTTPTestCase
 from pathlib import Path
 
+from metadata_backend.conf.conf import API_PREFIX
 from metadata_backend.server import init
 
 
@@ -52,18 +53,18 @@ class ErrorMiddlewareTestCase(AioHTTPTestCase):
         """Test that middleware reformats 400 error with problem details."""
         data = _create_improper_data()
         with self.p_get_sess_restapi:
-            response = await self.client.post("/submit", data=data)
+            response = await self.client.post(f"{API_PREFIX}/submit", data=data)
             self.assertEqual(response.status, 400)
             self.assertEqual(response.content_type, "application/problem+json")
             resp_dict = await response.json()
             self.assertIn("Bad Request", resp_dict["title"])
             self.assertIn("There must be a submission.xml file in submission.", resp_dict["detail"])
-            self.assertIn("/submit", resp_dict["instance"])
+            self.assertIn(f"{API_PREFIX}/submit", resp_dict["instance"])
 
     async def test_bad_url_returns_json_response(self):
         """Test that unrouted API url returns a 404 in JSON format."""
         with self.p_get_sess_restapi:
-            response = await self.client.get("/objects/swagadagamaster")
+            response = await self.client.get(f"{API_PREFIX}/objects/swagadagamaster")
             self.assertEqual(response.status, 404)
             self.assertEqual(response.content_type, "application/problem+json")
             resp_dict = await response.json()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -50,7 +50,7 @@ class AppTestCase(AioHTTPTestCase):
 
         """
         server = await self.get_application()
-        self.assertIs(len(server.router.resources()), 21)
+        self.assertIs(len(server.router.routes()), 47)
 
     async def test_frontend_routes_are_set(self):
         """Test correct routes are set when frontend folder exists."""
@@ -60,7 +60,7 @@ class AppTestCase(AioHTTPTestCase):
             Path(temppath / "static").mkdir()
             with patch(frontend_static, temppath):
                 server = await self.get_application()
-                routes = str([x for x in server.router.resources()])
+                routes = str([x for x in server.router.routes()])
                 self.assertIn(f"{tempdir}/static", routes)
                 self.assertIn("DynamicResource  /{path}", routes)
 
@@ -70,8 +70,9 @@ class AppTestCase(AioHTTPTestCase):
         with tempfile.TemporaryDirectory() as tempdir:
             temppath = Path(tempdir)
             Path(temppath / "swagger").mkdir()
-            with patch(swagger_static, temppath):
+            open(temppath / "swagger" / "index.html", "w").write("<html></html>")
+            with patch(swagger_static, temppath / "swagger" / "index.html"):
                 server = await self.get_application()
-                routes = str([x for x in server.router.resources()])
+                routes = str([x for x in server.router.routes()])
                 self.assertIn("/swagger", routes)
                 self.assertIn("PlainResource  /swagger", routes)


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
This allows to properly check for authentication only of API routes, while frontend can be served as a catch-all rule, and session is not checked for public routes.

Made the session checking more strict and removed redirects from the API.

The error handling is also stricter, and some test files had wrong schema, but were silently failing because of middleware. Had to fix a couple of json files for them to work again.

`asyncio.gather` in integrations tests was hiding errors, making it more difficult to debug, so I refactored it.


### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
- #421 


### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Changes Made

<!-- List changes made. -->
- Fixes issues with the `aiohttp_session` PR #421.
- Mount API under `/v1` as an AIOHTTP sub application.
- `/logout` doesn't redirect to frontend any more. Returns 204, and frontend needs to handle it.
- Only API routes have auth check. Other routes are public, and forward requests as a catch-all to front-end. This fixes refreshing the page issues.
- Fix integration tests.
- Refactor `asyncio.gather` for easier debugging.

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

As a refactor, tests should continue to work.

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
