### PR TITLE
Make Metax integration optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,8 @@ DOI_KEY=key
 DISCOVERY_URL=https://etsin.demo.fairdata.fi/dataset/
 
 # metax
+# Must be 'True' to enable
+METAX_ENABLED=True
 METAX_USER=sd
 METAX_PASS=demo_pass
 METAX_URL=http://mockmetax:8002

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Prefix API endpoint with /v1
   - Refactor authentication checking, fixing issues from #421 and remove HTTPSeeOther from the API
 - Recreate DB before integration tests run and cleanup after integration tests have run #448
+- Make using of discovery service (METAX) optional #467
 
 ### Removed
 

--- a/docker-compose-tls.yml
+++ b/docker-compose-tls.yml
@@ -36,6 +36,7 @@ services:
       - "DOI_USER=${DOI_USER}"
       - "DOI_KEY=${DOI_KEY}"
       - "DISCOVERY_URL=${DISCOVERY_URL}"
+      - "METAX_ENABLED=${METAX_ENABLED}"
       - "METAX_USER=${METAX_USER}"
       - "METAX_PASS=${METAX_PASS}"
       - "METAX_URL=${METAX_URL}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - "DOI_USER=${DOI_USER}"
       - "DOI_KEY=${DOI_KEY}"
       - "DISCOVERY_URL=${DISCOVERY_URL}"
+      - "METAX_ENABLED=${METAX_ENABLED}"
       - "METAX_USER=${METAX_USER}"
       - "METAX_PASS=${METAX_PASS}"
       - "METAX_URL=${METAX_URL}"

--- a/metadata_backend/api/operators.py
+++ b/metadata_backend/api/operators.py
@@ -432,7 +432,7 @@ class Operator(BaseOperator):
         )
         return data, page_num, page_size, total_objects[0]["total"]
 
-    async def create_metax_info(self, schema_type: str, accession_id: str, data: Dict) -> bool:
+    async def create_datacite_info(self, schema_type: str, accession_id: str, data: Dict) -> bool:
         """Update study or dataset object with metax info.
 
         :param schema_type: Schema type of the object to replace.

--- a/metadata_backend/conf/conf.py
+++ b/metadata_backend/conf/conf.py
@@ -174,6 +174,7 @@ doi_config = {
     "discovery_url": os.getenv("DISCOVERY_URL", "https://etsin.fairdata.fi/dataset/"),
 }
 
+METAX_ENABLED = os.getenv("METAX_ENABLED", "") == "True"
 metax_config = {
     "username": os.getenv("METAX_USER", "sd"),
     "password": os.getenv("METAX_PASS", "test"),

--- a/metadata_backend/services/datacite_service_handler.py
+++ b/metadata_backend/services/datacite_service_handler.py
@@ -58,6 +58,8 @@ class DataciteServiceHandler(ServiceHandler):
         """
         if not error:
             return error
+        if isinstance(error, str):
+            return error
 
         error_messages = []
         try:

--- a/metadata_backend/services/metax_service_handler.py
+++ b/metadata_backend/services/metax_service_handler.py
@@ -6,7 +6,7 @@ from aiohttp import BasicAuth, web
 from yarl import URL
 
 from ..api.operators import UserOperator
-from ..conf.conf import metax_config
+from ..conf.conf import metax_config, METAX_ENABLED
 from ..helpers.logger import LOG
 from .metax_mapper import MetaDataMapper
 from .service_handler import ServiceHandler
@@ -63,11 +63,10 @@ class MetaxServiceHandler(ServiceHandler):
             },
         }
 
-    # @property
-    # def enabled(self) -> bool:
-    #     """True when service is enabled."""
-    #     # return metax_config["enabled"]
-    #     return True
+    @property
+    def enabled(self) -> bool:
+        """Indicate whether service is enabled."""
+        return METAX_ENABLED
 
     async def get_metadata_provider_user(self) -> str:
         """Get current user's external id.
@@ -224,7 +223,7 @@ class MetaxServiceHandler(ServiceHandler):
     async def update_dataset_with_doi_info(self, datacite_info: Dict, _metax_ids: List) -> None:
         """Update dataset for publishing.
 
-        :param doi_info: Dict containing info to complete metax dataset metadata
+        :param datacite_info: Dict containing info to complete metax dataset metadata
         :param _metax_ids: List of Metax id of dataset to be updated
         """
         LOG.info(

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -1076,7 +1076,7 @@ async def test_metax_publish_dataset(sess, submission_id):
         async with sess.get(f"{metax_url}/{metax_id}") as metax_resp:
             assert metax_resp.status == 200, f"HTTP Status code error, got {metax_resp.status}"
             metax_res = await metax_resp.json()
-            assert metax_res["state"] == "published"
+            assert metax_res["state"] == "published", f"{schema}  {metax_res}"
 
             # this data is synced with /test_files/doi/test_doi.json
             # if data changes inside the file it must data must be reflected here

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -109,7 +109,7 @@ class HandlersTestCase(AioHTTPTestCase):
             "delete_metadata_object.side_effect": self.fake_operator_delete_metadata_object,
             "update_metadata_object.side_effect": self.fake_operator_update_metadata_object,
             "replace_metadata_object.side_effect": self.fake_operator_replace_metadata_object,
-            "create_metax_info.side_effect": self.fake_operator_create_metax_info,
+            "create_datacite_info.side_effect": self.fake_operator_create_datacite_info,
         }
         self.xmloperator_config = {
             "read_metadata_object.side_effect": self.fake_xmloperator_read_metadata_object,
@@ -221,7 +221,7 @@ class HandlersTestCase(AioHTTPTestCase):
         """Fake delete operation to await successful operation indicator."""
         return True
 
-    async def fake_operator_create_metax_info(self, schema_type, accession_id, data):
+    async def fake_operator_create_datacite_info(self, schema_type, accession_id, data):
         """Fake update operation to await successful operation indicator."""
         return True
 
@@ -422,7 +422,7 @@ class ObjectHandlerTestCase(HandlersTestCase):
 
         await super().setUpAsync()
 
-        self._mock_draft_doi = "metadata_backend.api.handlers.object.ObjectAPIHandler._draft_doi"
+        self._mock_draft_doi = "metadata_backend.api.handlers.object.ObjectAPIHandler.create_draft_doi"
 
         class_doihandler = "metadata_backend.api.handlers.object.DataciteServiceHandler"
         self.patch_doihandler = patch(class_doihandler, **self.doi_handler, spec=True)


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
Make Metax integration optional, so that new use cases can be supported.



### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
- Closes #467
- Follow-up on #512 
- Follow-up on #513
### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
It is actually breaking, because it needs configuration update in the deployment, adding environment variable to enable the integration `METAX_ENABLED=True`. It doesn't break the frontend though.

### Changes Made

<!-- List changes made. -->
- New environment variable to indicate the use of Metax integration.
- Surround metax calls with a check if metax is enabled.

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Needs testing (start an issue or do a follow up PR about it) #513

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
