### PR TITLE
REMS integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,10 @@ METAX_ENABLED=True
 METAX_USER=sd
 METAX_PASS=demo_pass
 METAX_URL=http://mockmetax:8002
+
+# rems
+# Must be 'True' to enable
+REMS_ENABLED=True
+REMS_USER_ID=sd
+REMS_KEY=demo_key
+REMS_URL=http://mockrems:8003

--- a/.github/config/.wordlist.txt
+++ b/.github/config/.wordlist.txt
@@ -25,8 +25,8 @@ analysisdate
 analysislinks
 analysisref
 analysistype
-annotinfo
 annotationref
+annotinfo
 anonymized
 antibiogram
 api
@@ -78,6 +78,7 @@ bugfix
 bugfixes
 buildkit
 buildx
+catalogueitemid
 cdd
 cdna
 centername
@@ -251,7 +252,7 @@ github
 githubusercontent
 givenname
 gridion
-grossImage
+grossimage
 groupedbyschema
 gtr
 guaraní
@@ -272,7 +273,7 @@ html
 http
 httperror
 https
-HTTPSeeOther
+httpseeother
 identifiertype
 identitypython
 ido
@@ -443,6 +444,7 @@ ontologies
 openapi
 openid
 orcid
+organizationid
 orgtrack
 oromo
 oss
@@ -528,6 +530,7 @@ relativeorder
 remoteuseridentifier
 reqs
 resequencing
+resourceid
 resourcetypegeneral
 rnaseq
 rojopolis
@@ -604,7 +607,7 @@ studyref
 studytitle
 studytype
 subjectscheme
-subjectsSchema
+subjectsschema
 submissionid
 submissionslice
 submissiontype
@@ -678,7 +681,8 @@ wizardsteps
 wizardsubmissionslice
 wolof
 wordlist
-wsiImage
+workflowid
+wsiimage
 wxs
 xl
 xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Endpoint with swagger documentation `/swagger`
 - added `aiohttp_session` as dependency and removed old way of handling cookies
 - Create a new ServiceHandler class to share error handling, retry mechanism, custom request logic between service integrations.
+- Integration with REMS #498
+  - New rems service handler
+  - New rems mock api service for integration tests
+  - New API endpoint `/v1/rems` for the frontend to retrieve DAC and Policies
+  - Submission now can have a new field, `dac`, with `workflowId`, `organizationId`, and `licenses` (array of int)
+  - Published datasets have a new field `dac` with `workflowId`, `organizationId`, `resourceId`, and `catalogueItemId`
 
 ### Changed
 - schema loader now matches schema files by exact match with schema #481. This means that schema file naming in metadata_backend/helpers/schemas now have rules: 

--- a/Procfile
+++ b/Procfile
@@ -2,4 +2,5 @@ db: docker  run -v ${PWD}/scripts/init_mongo.js:/docker-entrypoint-initdb.d/init
 mockauth:   gunicorn --reload --worker-class aiohttp.GunicornUVLoopWebWorker --workers 1 --log-level debug --graceful-timeout 60 --timeout 120 --bind ${BACKEND_HOST}:8000              tests.integration.mock_auth:init
 mockdoi:    gunicorn --reload --worker-class aiohttp.GunicornUVLoopWebWorker --workers 1 --log-level debug --graceful-timeout 60 --timeout 120 --bind ${BACKEND_HOST}:8001              tests.integration.mock_doi_api:init
 mockmetax:  gunicorn --reload --worker-class aiohttp.GunicornUVLoopWebWorker --workers 1 --log-level debug --graceful-timeout 60 --timeout 120 --bind ${BACKEND_HOST}:8002              tests.integration.mock_metax_api:init
+mockrems:   gunicorn --reload --worker-class aiohttp.GunicornUVLoopWebWorker --workers 1 --log-level debug --graceful-timeout 60 --timeout 120 --bind ${BACKEND_HOST}:8003              tests.integration.mock_rems_api:init
 backend:    gunicorn --reload --worker-class aiohttp.GunicornUVLoopWebWorker --workers 1 --log-level debug --graceful-timeout 60 --timeout 120 --bind ${BACKEND_HOST}:${BACKEND_PORT}   metadata_backend.server:init

--- a/docker-compose-tls.yml
+++ b/docker-compose-tls.yml
@@ -40,6 +40,10 @@ services:
       - "METAX_USER=${METAX_USER}"
       - "METAX_PASS=${METAX_PASS}"
       - "METAX_URL=${METAX_URL}"
+      - "REMS_ENABLED=${REMS_ENABLED}"
+      - "REMS_USER_ID=${REMS_USER_ID}"
+      - "REMS_KEY=${REMS_KEY}"
+      - "REMS_URL=${REMS_URL}"
   database:
     image: "mongo"
     container_name: "metadata_submitter_database_dev"
@@ -102,5 +106,19 @@ services:
     volumes:
       - ./tests/integration/mock_metax_api.py:/mock_metax_api.py
     entrypoint: ["python", "/mock_metax_api.py", "0.0.0.0", "8002"]
+  mockrems:
+    build:
+      dockerfile: Dockerfile-dev
+      context: .
+      target: develop
+    image: cscfi/metadata-submitter-dev
+    hostname: mockrems
+    expose:
+      - 8003
+    ports:
+      - "8003:8003"
+    volumes:
+      - ./tests/integration/mock_rems_api.py:/mock_rems_api.py
+    entrypoint: ["python", "/mock_rems_api.py", "0.0.0.0", "8003"]
 volumes:
   data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,10 @@ services:
       - "METAX_USER=${METAX_USER}"
       - "METAX_PASS=${METAX_PASS}"
       - "METAX_URL=${METAX_URL}"
+      - "REMS_ENABLED=${REMS_ENABLED}"
+      - "REMS_USER_ID=${REMS_USER_ID}"
+      - "REMS_KEY=${REMS_KEY}"
+      - "REMS_URL=${REMS_URL}"
   database:
     image: "mongo"
     container_name: "metadata_submitter_database_dev"
@@ -95,5 +99,19 @@ services:
     volumes:
       - ./tests/integration/mock_metax_api.py:/mock_metax_api.py
     entrypoint: ["python", "/mock_metax_api.py", "0.0.0.0", "8002"]
+  mockrems:
+    build:
+      dockerfile: Dockerfile-dev
+      context: .
+      target: develop
+    image: cscfi/metadata-submitter-dev
+    hostname: mockrems
+    expose:
+      - 8003
+    ports:
+      - "8003:8003"
+    volumes:
+      - ./tests/integration/mock_rems_api.py:/mock_rems_api.py
+    entrypoint: ["python", "/mock_rems_api.py", "0.0.0.0", "8003"]
 volumes:
   data:

--- a/docs/specification.yml
+++ b/docs/specification.yml
@@ -16,6 +16,36 @@ tags:
   - name: Manage
     description: Endpoints used for managing data
 paths:
+  /v1/rems:
+    get:
+      tags:
+        - Query
+      summary: Get data from REMS
+      parameters:
+        - name: language
+          in: query
+          description: language code to retrieve the results in. Falls back and defaults to English ("en")
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/REMS"
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/401Unauthorized"
+        403:
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/403Forbidden"
   /v1/submit:
     post:
       tags:
@@ -1171,7 +1201,7 @@ paths:
     put:
       tags:
         - Manage
-      summary: Delete an object submission with a specified submission ID.
+      summary: Update DOI for the submission with a specified submission ID.
       parameters:
         - name: submissionId
           in: path
@@ -1184,6 +1214,48 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/DoiInfo"
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SubmissionCreated"
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/400BadRequest"
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/401Unauthorized"
+        403:
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/403Forbidden"
+  /v1/submissions/{submissionId}/dac:
+    put:
+      tags:
+        - Manage
+      summary: Update DAC for the submission with a specified submission ID.
+      parameters:
+        - name: submissionId
+          in: path
+          description: ID of the object submission.
+          schema:
+            type: string
+          required: true
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DAC"
       responses:
         200:
           description: OK
@@ -1811,6 +1883,63 @@ components:
                 type: string
                 description: Subject scheme name
                 example: "Fields of Science and Technology (FOS)"
+    DAC:
+      type: object
+      required:
+        - workflowId
+        - organizationId
+        - licenses
+      properties:
+        organizationId:
+          type: integer
+          description: ID of an organization in REMS
+        workflowId:
+          type: integer
+          description: ID of a Workflow, obtained from REMS
+        licenses:
+          type: array
+          items:
+            type: integer
+            description: ID of a license, obtained from REMS, and must belong to organizationId
+    REMS:
+      type: array
+      description: Array of organizations with workflows and licenses from REMS database
+      items:
+        type: object
+        properties:
+          id:
+            type: string
+            description: ID of the organization
+            example: "CSC"
+          name:
+            type: string
+            description: Name of the organization
+            example: "CSC – IT CENTER FOR SCIENCE LTD."
+          workflows:
+            type: array
+            description: Workflows from REMS
+            items:
+              type: object
+              properties:
+                id:
+                  type: integer
+                title:
+                  type: string
+                  description: Name of the workflow
+          licenses:
+            type: array
+            description: Licenses from REMS
+            items:
+              type: object
+              properties:
+                id:
+                  type: integer
+                title:
+                  type: string
+                  description: Name of the license
+                textcontent:
+                  type: string
+                  description: Content of the license
     JSONPatch:
       type: array
       items:

--- a/metadata_backend/api/handlers/rems_proxy.py
+++ b/metadata_backend/api/handlers/rems_proxy.py
@@ -1,0 +1,78 @@
+"""Get and process REMS data for the frontend."""
+from typing import Union, Dict, TypedDict, List
+
+from aiohttp import web
+
+from ...api.handlers.restapi import RESTAPIIntegrationHandler
+
+
+class Organization(TypedDict):
+    """Type for organization."""
+
+    id: str
+    name: str
+    workflows: List[Dict[str, str]]
+    licenses: List[Dict[str, str]]
+
+
+class RemsAPIHandler(RESTAPIIntegrationHandler):
+    """API Handler for REMS.
+
+    Frontend can't access REMS directly.
+    """
+
+    @staticmethod
+    def _get_localized(language: str, _dict: dict, fallback_language: str = "en") -> Union[str, dict]:
+        """Get correct language string from dict.
+
+        REMS provides certain properties as a dict with language, but no way to know which are available.
+
+        """
+        if len(_dict) == 0:
+            return ""
+        if not isinstance(_dict, dict):
+            if isinstance(_dict, str):
+                return _dict
+            return ""
+        if language in _dict:
+            return _dict[language]
+        elif fallback_language in _dict:
+            return _dict[fallback_language]
+
+        # return first element
+        return next(iter(_dict.values()))
+
+    async def get_workflows_licenses_from_rems(self, request: web.Request) -> web.Response:
+        """Get workflows and Policies for frontend."""
+
+        language = request.query.get("language", "en").split("_")[0]
+        workflows = await self.rems_handler.get_workflows()
+        licenses = await self.rems_handler.get_licenses()
+
+        organizations: Dict[str, Organization] = {}
+
+        def add_organization(organization_id: str, organization_name: str) -> None:
+            organizations[organization_id] = {
+                "id": organization_id,
+                "name": organization_name,
+                "workflows": [],
+                "licenses": [],
+            }
+
+        for workflow in workflows:
+            title = workflow["title"]
+            org_name = self._get_localized(language, workflow["organization"]["organization/name"])
+            org_id = workflow["organization"]["organization/id"]
+            if org_id not in organizations:
+                add_organization(str(org_id), str(org_name))
+            organizations[org_id]["workflows"].append({"id": workflow["id"], "title": title})
+
+        for license in licenses:
+            title = self._get_localized(language, license["localizations"])
+            org_name = self._get_localized(language, license["organization"]["organization/name"])
+            org_id = license["organization"]["organization/id"]
+            if org_id not in organizations:
+                add_organization(str(org_id), str(org_name))
+            organizations[org_id]["licenses"].append({"id": license["id"], **title})
+
+        return web.json_response(data=list(organizations.values()))

--- a/metadata_backend/api/handlers/submission.py
+++ b/metadata_backend/api/handlers/submission.py
@@ -545,21 +545,16 @@ class SubmissionAPIHandler(RESTAPIIntegrationHandler):
         if "doiInfo" not in submission:
             raise web.HTTPBadRequest(reason=f"Submission '{submission_id}' must have the required DOI metadata.")
         has_study = False
-        # has_ega_dac = False
         for _obj in submission["metadataObjects"]:
             accession_id = _obj["accessionId"]
             schema = _obj["schema"]
             object_data, _ = await obj_op.read_metadata_object(schema, accession_id)
             if schema == "study":
                 has_study = True
-            # if schema == "dac":
-            #     has_ega_dac = True
             if self.rems_handler.enabled and "dac" not in submission:
                 raise web.HTTPBadRequest(reason=f"Submission '{accession_id}' must have DAC.")
         if not has_study:
             raise web.HTTPBadRequest(reason=f"Submission '{submission_id}' must have a study.")
-        # if not has_ega_dac:
-        #     raise web.HTTPBadRequest(reason=f"Submission '{submission_id}' must have an EGA DAC.")
 
         # we first try to publish the DOI before actually publishing the submission
         obj_ops = Operator(db_client)

--- a/metadata_backend/api/handlers/submission.py
+++ b/metadata_backend/api/handlers/submission.py
@@ -242,7 +242,7 @@ class SubmissionAPIHandler(RESTAPIIntegrationHandler):
 
                     # there are cases where datasets are added first
                     if len(datacite_datasets) > 0:
-                        LOG.info(datacite_datasets)
+                        LOG.info(f"datacite datasets: {datacite_datasets}")
                         for ds in datacite_datasets:
                             ds["data"]["attributes"]["relatedIdentifiers"].append(
                                 {

--- a/metadata_backend/conf/conf.py
+++ b/metadata_backend/conf/conf.py
@@ -161,7 +161,7 @@ aai_config = {
 }
 
 
-# 6) Set the DataCite REST API values
+# 6) Setup integration config
 
 doi_config = {
     "api": os.getenv("DOI_API", "http://localhost:8001/dois"),
@@ -188,3 +188,10 @@ if METAX_ENABLED and not METAX_REFERENCE_FILE.is_file():
     raise RuntimeError(
         "You must generate the metax references to run submitter: `bash scripts/metax_mappings/fetch_refs.sh`"
     )
+
+REMS_ENABLED = os.getenv("REMS_ENABLED", "") == "True"
+rems_config = {
+    "id": os.getenv("REMS_USER_ID", "sd"),
+    "key": os.getenv("REMS_KEY", "test"),
+    "url": os.getenv("REMS_URL", "http://mockrems:8003"),
+}

--- a/metadata_backend/helpers/schemas/submissions.json
+++ b/metadata_backend/helpers/schemas/submissions.json
@@ -1101,6 +1101,41 @@
         }
       },
       "uniqueItems": true
+    },
+    "dac": {
+      "type": "object",
+      "title": "REMS DAC for datasets",
+      "required": [
+        "workflowId",
+        "organizationId",
+        "licenses"
+      ],
+      "properties": {
+        "workflowId": {
+          "type": "integer",
+          "title": "REMS id of the dac/workflow"
+        },
+        "organizationId": {
+          "type": "string",
+          "title": "REMS id of the organization"
+        },
+        "licenses": {
+          "type": "array",
+          "title": "REMS ids of each policy/license",
+          "items": {
+            "type": "integer",
+            "title": "REMS id of a policy/license"
+          }
+        },
+        "resourceId": {
+          "type": "string",
+          "title": "REMS id of the resource created. Created automatically during the publication process"
+        },
+        "catalogueItemId": {
+          "type": "string",
+          "title": "REMS id of the catalogue created. Created automatically during the publication process"
+        }
+      }
     }
   },
   "additionalProperties": false

--- a/metadata_backend/helpers/validator.py
+++ b/metadata_backend/helpers/validator.py
@@ -145,7 +145,7 @@ class JSONValidator:
             if len(e.path) > 0:
                 reason = f"Provided input does not seem correct for field: '{e.path[0]}'"
                 LOG.debug(f"Provided JSON input: '{e.instance}'")
-                LOG.error(reason)
+                LOG.exception(reason)
                 raise web.HTTPBadRequest(reason=reason)
             else:
                 reason = f"Provided input does not seem correct because: '{e.message}'"

--- a/metadata_backend/services/datacite_service_handler.py
+++ b/metadata_backend/services/datacite_service_handler.py
@@ -107,19 +107,19 @@ class DataciteServiceHandler(ServiceHandler):
 
         return doi_data
 
-    async def set_state(self, doi_payload: Dict) -> None:
+    async def publish(self, datacite_payload: Dict) -> None:
         """Set DOI and associated metadata.
 
         We will only support publish event type, and we expect the data to be
         prepared for the update.
         Partial updates are possible.
 
-        :param doi_payload: Dictionary with payload to send to Datacite
+        :param datacite_payload: Dictionary with payload to send to Datacite
         :raises: HTTPInternalServerError if the Datacite DOI update fails
         :returns: None
         """
-        _id = doi_payload["id"]
-        await self._request(method="PUT", path=_id, json_data=doi_payload)
+        _id = datacite_payload["id"]
+        await self._request(method="PUT", path=_id, json_data=datacite_payload)
         LOG.info(f"Datacite doi {_id} updated ")
 
     async def delete(self, doi: str) -> None:

--- a/metadata_backend/services/metax_service_handler.py
+++ b/metadata_backend/services/metax_service_handler.py
@@ -1,4 +1,8 @@
-"""Class for handling calls to METAX API."""
+"""Class for handling calls to METAX API.
+
+API docs https://metax.fairdata.fi/docs/
+Swagger https://metax.fairdata.fi/swagger/v2
+"""
 from typing import Any, Dict, List
 
 from aiohttp import BasicAuth
@@ -226,6 +230,19 @@ class MetaxServiceHandler(ServiceHandler):
             bulk_data.append({"identifier": id["metaxIdentifier"], "research_dataset": mapped_metax_data})
 
         await self._bulk_patch(bulk_data)
+
+    async def update_draft_dataset_description(self, metax_id: str, description: str) -> None:
+        """Update the description of the draft dataset.
+
+        :param metax_id: metax dataset id
+        :param description: New description
+        :raises: HTTPError depending on returned error from Metax
+        """
+        LOG.info(f"Updating the description of '{metax_id}'.")
+        data = await self._get(metax_id)
+        data["research_dataset"]["description"]["en"] = description
+        metax_data = await self._put(metax_id, data)
+        LOG.debug(f"Updated description of '{metax_id}', new metadata is: {metax_data}")
 
     async def publish_dataset(self, _metax_ids: List[Dict]) -> None:
         """Publish draft dataset to Metax service.

--- a/metadata_backend/services/rems_service_handler.py
+++ b/metadata_backend/services/rems_service_handler.py
@@ -1,0 +1,160 @@
+"""Integrate with REMS service.
+
+This integration allows pushing of datasets to REMS, so that researchers can apply for access to research datasets.
+https://github.com/CSCfi/rems
+
+
+Terminology translation
+REMS                metadata-submitter
+workflow    ->  	DAC
+license     ->  	policy
+resource    ->  	dataset
+
+"""
+from typing import Dict, List
+
+from aiohttp import web
+from yarl import URL
+
+from .service_handler import ServiceHandler
+from ..conf.conf import rems_config, REMS_ENABLED
+from ..helpers.logger import LOG
+
+
+class RemsServiceHandler(ServiceHandler):
+    """REMS dataset access integration."""
+
+    service_name = "Rems"
+
+    def __init__(self) -> None:
+        """Get REMS credentials from config."""
+        super().__init__(
+            base_url=URL(rems_config["url"]) / "api",
+            http_client_headers={
+                "x-rems-api-key": rems_config["key"],
+                "x-rems-user-id": rems_config["id"],
+                "accept": "application/json",
+            },
+        )
+
+    @property
+    def enabled(self) -> bool:
+        """Indicate whether service is enabled."""
+        return REMS_ENABLED
+
+    @staticmethod
+    def application_url(catalogue_id: str) -> str:
+        """Return URL for data access application."""
+        return "{}/application?items={}".format(rems_config["url"], catalogue_id)
+
+    async def get_workflows(self) -> List[Dict]:
+        """Get all active workflows.
+
+        Workflow in REMS = DAC in metadata-submitter
+        """
+        return await self._request(method="GET", path="/workflows", params={"disabled": "false", "archived": "false"})
+
+    async def get_licenses(self) -> List[Dict]:
+        """Get all active licenses.
+
+        License in REMS = policy in metadata-submitter
+        """
+        return await self._request(method="GET", path="/licenses", params={"disabled": "false", "archived": "false"})
+
+    async def create_resource(self, doi: str, organization_id: str, licenses: List[int]) -> int:
+        """Create a REMS resource for a dataset.
+
+        :param doi: DOI id of the dataset
+        :param organization_id: REMS organization/id
+        :param licenses: List of REMS license ids
+        :returns: id of the created resource
+        """
+        resource = {"resid": doi, "organization": {"organization/id": organization_id}, "licenses": licenses}
+        LOG.debug(f"Creating new resource '{resource}'")
+        created = await self._request(method="POST", path="/resources/create", json_data=resource)
+        return int(created["id"])
+
+    async def create_catalogue_item(
+        self, resource_id: int, workflow_id: int, organization_id: str, localizations: Dict[str, Dict[str, str]]
+    ) -> str:
+        """Create a REMS resource for a dataset.
+
+        :param resource_id: id of the REMS resource
+        :param workflow_id: id of the REMS workflow/DAC
+        :param organization_id: REMS organization/id
+        :param localizations: Dictionary of languages and title of the dataset
+        :returns: id of the created resource
+        """
+        catalogue = {
+            "form": None,
+            "resid": resource_id,
+            "wfid": workflow_id,
+            "organization": {"organization/id": organization_id},
+            "localizations": localizations,
+            "enabled": True,
+            "archived": False,
+        }
+        LOG.debug(f"Creating new catalogue item '{catalogue}'")
+        created = await self._request(method="POST", path="/catalogue-items/create", json_data=catalogue)
+        return created["id"]
+
+    async def item_ok(self, item_type: str, organization_id: str, _id: int) -> bool:
+        """Check that item exists.
+
+        :param item_type: 'workflow' or 'license'
+        :param organization_id: REMS organization/id
+        :param _id: REMS item id
+        :raises HTTPError
+        :returns: True or raises
+        """
+        LOG.debug(f"Checking that {item_type} '{_id}' is ok.")
+        capitalized_item_type = item_type.capitalize()
+
+        try:
+            item = await self._request(method="GET", path=f"/{item_type}s/{_id}")
+            if not item["enabled"]:
+                raise self.make_exception(reason=f"{capitalized_item_type} '{_id}' is disabled", status=400)
+            if item["archived"]:
+                raise self.make_exception(reason=f"{capitalized_item_type} '{_id}' is archived", status=400)
+            if item["organization"]["organization/id"] != organization_id:
+                raise self.make_exception(
+                    reason=f"{capitalized_item_type} '{_id}' doesn't belong to organization '{organization_id}'",
+                    status=400,
+                )
+        except KeyError:
+            raise self.make_exception(reason=f"{capitalized_item_type} '{_id}' has unexpected structure.", status=400)
+        except web.HTTPNotFound:
+            raise self.make_exception(reason=f"{capitalized_item_type} '{_id}' doesn't exist.", status=400)
+
+        LOG.debug(f"{capitalized_item_type} '{_id}' is ok.")
+        return True
+
+    async def validate_workflow_licenses(self, organization_id: str, workflow_id: int, licenses: List[int]) -> bool:
+        """Check that workflow and policies exist.
+
+        :param organization_id: REMS organization/id
+        :param workflow_id: REMS workflow id
+        :param licenses: List of REMS license ids
+        :raises HTTPError
+        :returns: True
+        """
+        LOG.debug(
+            f"Checking that workflow '{workflow_id}' and licenses '{licenses}' "
+            f"belong to organization {organization_id}, and pass other checks."
+        )
+        if not isinstance(organization_id, str):
+            raise self.make_exception(reason=f"Organization id '{organization_id}' must be a string.", status=400)
+        if not isinstance(workflow_id, int):
+            raise self.make_exception(reason=f"Workflow id '{workflow_id}' must be an integer.", status=400)
+        if not isinstance(licenses, list):
+            raise self.make_exception(reason=f"Licenses '{licenses}' must be a list of integers.", status=400)
+
+        await self.item_ok("workflow", organization_id, workflow_id)
+
+        for license_id in licenses:
+            if not isinstance(license_id, int):
+                raise self.make_exception(reason=f"Workflow id '{license_id}' must be an integer.", status=400)
+
+            await self.item_ok("license", organization_id, license_id)
+        LOG.debug("All ok.")
+        return True

--- a/metadata_backend/services/service_handler.py
+++ b/metadata_backend/services/service_handler.py
@@ -82,10 +82,10 @@ class ServiceHandler:
         if self._http_client is not None:
             await self._http_client.close()
 
-    # @property
-    # def enabled(self) -> bool:
-    #     """True when service is enabled."""
-    #     return False
+    @property
+    def enabled(self) -> bool:
+        """Indicate whether service is enabled."""
+        return True
 
     async def check_connection(self, timeout: int = 2) -> None:
         """Check service is reachable.
@@ -122,10 +122,10 @@ class ServiceHandler:
         :returns: Response body parsed as JSON
         """
 
-        # if not self.enabled:
-        #     reason = f"{self.service_name} is disabled, yet attempted to '{method}' '{url}'"
-        #     LOG.error(reason)
-        #     raise HTTPInternalServerError(reason=reason)
+        if not self.enabled:
+            reason = f"{self.service_name} is disabled, yet attempted to '{method}' '{url}' path '{path}'"
+            LOG.error(reason)
+            raise HTTPInternalServerError(reason=reason)
 
         LOG.debug(
             f"{method} request to '{url or self.base_url}' path '{path}', params '{params}', payload '{json_data}'"

--- a/tests/http/publication_rems.http
+++ b/tests/http/publication_rems.http
@@ -61,6 +61,16 @@ POST {{backend_url}}/v1/objects/study
 ### Get study
 GET {{backend_url}}/v1/objects/study/{{study_id}}
 
+### Add dataset to submission
+# @name dataset_id_req
+POST {{backend_url}}/v1/objects/dataset
+    ?submission={{submission_id}}
+
+< ../test_files/dataset/dataset.json
+
+### Get dataset
+GET {{backend_url}}/v1/objects/dataset/{{dataset_id}}
+
 ### Update DOI in submission
 PUT {{backend_url}}/v1/submissions/{{submission_id}}/doi
 

--- a/tests/http/rems.http
+++ b/tests/http/rems.http
@@ -1,0 +1,113 @@
+# https://github.com/Huachao/vscode-restclient
+# https://jsonpath.com/
+
+
+@backend_url = http://localhost:5430
+# @auth_url = http://localhost:8000
+@rems_url = https://test-rems.sd.csc.fi/api
+# @rems_url = http://localhost:8003/api
+@rems_user_id = sd-submit-robot
+@rems_api_key = sd-submit-test-key
+
+@auth_email = mock_user@test.what
+
+@resid = {{resid_req.response.body.id}}
+@wfid = {{dac_req.response.body.$[0].id}}
+@orgid = {{dac_req.response.body.$[0].organization.organization/id}}
+@application_id = {{catalogue_req.response.body.id}}
+
+### Mock authentication
+GET {{auth_url}}/setmock
+    ?sub={{auth_email}}
+    &given=Mock
+    &family=Family
+
+###
+GET {{backend_url}}/aai
+
+### Get from REMS proxy
+GET {{backend_url}}/v1/rems
+    ?language=fi
+
+### Get workflows
+# @name dac_req
+GET {{rems_url}}/workflows
+    ?disabled=false
+    &archived=false
+x-rems-user-id: {{rems_user_id}}
+x-rems-api-key: {{rems_api_key}}
+
+### Get workflow
+# @name dac_req
+GET {{rems_url}}/workflows/1
+    ?disabled=false
+    &archived=false
+x-rems-user-id: {{rems_user_id}}
+x-rems-api-key: {{rems_api_key}}
+
+### Get licenses
+GET {{rems_url}}/licenses
+    ?disabled=false
+    &archived=false
+x-rems-user-id: {{rems_user_id}}
+x-rems-api-key: {{rems_api_key}}
+
+### Get license
+# @name dac_req
+GET {{rems_url}}/licenses/1
+    ?disabled=false
+    &archived=false
+x-rems-user-id: {{rems_user_id}}
+x-rems-api-key: {{rems_api_key}}
+
+### Create resource
+# @name resid_req
+POST {{rems_url}}/resources/create
+x-rems-user-id: {{rems_user_id}}
+x-rems-api-key: {{rems_api_key}}
+Content-Type: application/json
+
+{
+  "resid": "test-doi-here",
+  "organization": {
+    "organization/id": "another_org"
+  },
+  "licenses": [
+    1
+  ]
+}
+
+### Create catalogue item
+# @name catalogue_req
+POST {{rems_url}}/catalogue-items/create
+x-rems-user-id: {{rems_user_id}}
+x-rems-api-key: {{rems_api_key}}
+Content-Type: application/json
+
+{
+  "form": null,
+  "resid": {{resid}},
+  "wfid": {{wfid}},
+  "organization": {
+    "organization/id": "{{orgid}}"
+  },
+  "localizations": {
+    "fi": {
+      "title": "SD Testiaineisto 2",
+      "infourl": "http://example.fi"
+    },
+    "en": {
+      "title": "SD Test Dataset 2",
+      "infourl": "http://example.com"
+    }
+  },
+  "enabled": true,
+  "archived": false
+}
+
+
+### Get application - only with mock api
+GET {{rems_url}}/application
+    ?items=2
+x-rems-user-id: {{rems_user_id}}
+x-rems-api-key: {{rems_api_key}}

--- a/tests/integration/mock_rems_api.py
+++ b/tests/integration/mock_rems_api.py
@@ -1,0 +1,318 @@
+"""Mock aiohttp.web server for REMS API calls."""
+
+import logging
+from json import JSONDecodeError
+from os import getenv
+
+import ujson
+from aiohttp import web
+
+FORMAT = "[%(asctime)s][%(levelname)-8s](L:%(lineno)s) %(funcName)s: %(message)s"
+logging.basicConfig(format=FORMAT, datefmt="%Y-%m-%d %H:%M:%S")
+
+LOG = logging.getLogger("server")
+LOG.setLevel(getenv("LOG_LEVEL", "DEBUG"))
+
+handlers = {
+    "user_id_1": {"name": "test_user", "email": "test.user@example.org"},
+    "user_id_2": {"name": "test_user_2", "email": "test.user.2@example.org"},
+}
+forms = {
+    1: {"internal-name": "Base form", "external-title": {"en": "Base form"}},
+    2: {"internal-name": "Test Form", "external-title": {"en": "Test Application"}},
+}
+organizations = {
+    "CSC": {
+        "short-name": {"en": "Another organization"},
+        "name": {"en": "Another organization"},
+        "handlers": ["user_id_2", "user_id_1"],
+        "workflows": [1],
+        "licenses": [1],
+        "resources": {},
+        "catalogue-items": {},
+    },
+    "testorg": {
+        "short-name": {"en": "Test Organization"},
+        "name": {"en": "Test Organization"},
+        "workflows": [3],
+        "licenses": [2],
+        "resources": {},
+        "catalogue-items": {},
+    },
+}
+workflows = {
+    1: {
+        "id": 1,
+        "title": "another_org workflow 1",
+        "organization": {
+            "organization/id": "CSC",
+            "organization/short-name": organizations["CSC"]["short-name"],
+            "organization/name": organizations["CSC"]["name"],
+        },
+        "workflow": {
+            "type": "workflow/default",
+            "handlers": ["user_id_1", "user_id_2"],
+            "forms": [1],
+        },
+        "licenses": [],
+        "enabled": True,
+        "archived": False,
+    },
+    3: {
+        "id": 3,
+        "title": "Test Workflow",
+        "organization": {
+            "organization/id": "testorg",
+            "organization/short-name": organizations["testorg"]["short-name"],
+            "organization/name": organizations["testorg"]["name"],
+        },
+        "workflow": {
+            "type": "workflow/default",
+            "handlers": ["user_id_1"],
+            "forms": [2],
+        },
+        "licenses": [],
+        "enabled": True,
+        "archived": True,
+    },
+}
+licenses = {
+    1: {
+        "id": 1,
+        "licensetype": "link",
+        "organization": {
+            "organization/id": "CSC",
+            "organization/short-name": organizations["CSC"]["short-name"],
+            "organization/name": organizations["CSC"]["name"],
+        },
+        "localizations": {
+            "fi": {
+                "title": "Nimeä 4.0 Kansainvälinen (CC BY 4.0)",
+                "textcontent": "https://creativecommons.org/licenses/by/4.0/deed.fi",
+                "attachment-id": None,
+            },
+            "en": {
+                "title": "Creative Commons Attribution 4.0 International (CC BY 4.0)",
+                "textcontent": "https://creativecommons.org/licenses/by/4.0/",
+                "attachment-id": None,
+            },
+        },
+        "enabled": True,
+        "archived": False,
+    },
+    2: {
+        "id": 2,
+        "licensetype": "text",
+        "organization": {
+            "organization/id": "testorg",
+            "organization/short-name": organizations["testorg"]["short-name"],
+            "organization/name": organizations["testorg"]["name"],
+        },
+        "localizations": {
+            "en": {"title": "Test License", "textcontent": "Everything is prohibited!", "attachment-id": None}
+        },
+        "enabled": True,
+        "archived": False,
+    },
+}
+resource_id = 0
+catalogue_id = 0
+catalogue = {}
+
+
+def make_handlers(user_ids: list):
+    """Make handler into response format."""
+    return [{"userid": user_id, **handlers[user_id]} for user_id in user_ids]
+
+
+def make_forms(form_ids: list):
+    """Make form into response format."""
+    return [
+        {
+            "form/id": form_id,
+            "form/internal-name": forms[form_id]["internal-name"],
+            "form/external-title": forms[form_id]["external-title"],
+        }
+        for form_id in form_ids
+    ]
+
+
+def make_workflow_response():
+    """Convert organization into workflow response."""
+    response = []
+    for oid, org in organizations.items():
+        for wid in org["workflows"]:
+            workflow = workflows[wid]
+            response.append(
+                {
+                    "id": wid,
+                    "title": workflow["title"],
+                    "organization": {
+                        "organization/id": oid,
+                        "organization/short-name": org["short-name"],
+                        "organization/name": org["name"],
+                    },
+                    "workflow": {
+                        "type": workflow["workflow"]["type"],
+                        "handlers": make_handlers(workflow["workflow"]["handlers"]),
+                        "forms": make_forms(workflow["workflow"]["forms"]),
+                    },
+                    "licenses": workflow["licenses"],
+                    "enabled": workflow["enabled"],
+                    "archived": workflow["archived"],
+                }
+            )
+    return response
+
+
+def make_license_response():
+    """Convert organization into workflow response."""
+    response = []
+    for oid, org in organizations.items():
+        for lid in org["licenses"]:
+            license = licenses[lid]
+            response.append(
+                {
+                    "id": lid,
+                    "licensetype": license["licensetype"],
+                    "organization": {
+                        "organization/id": oid,
+                        "organization/short-name": org["short-name"],
+                        "organization/name": org["name"],
+                    },
+                    "localizations": license["localizations"],
+                    "enabled": license["enabled"],
+                    "archived": license["archived"],
+                }
+            )
+    return response
+
+
+async def get_workflows(_: web.Request) -> web.Response:
+    """REMS workflows."""
+    return web.json_response(data=make_workflow_response())
+
+
+async def get_workflow(request: web.Request) -> web.Response:
+    """REMS workflow."""
+    workflow_id = int(request.match_info["workflow_id"])
+    workflow = workflows[workflow_id]
+    try:
+        return web.json_response(
+            data={
+                "id": workflow_id,
+                "title": workflow["title"],
+                "organization": workflow["organization"],
+                "workflow": {
+                    "type": workflow["workflow"]["type"],
+                    "handlers": make_handlers(workflow["workflow"]["handlers"]),
+                    "forms": make_forms(workflow["workflow"]["forms"]),
+                },
+                "licenses": workflow["licenses"],
+                "enabled": workflow["enabled"],
+                "archived": workflow["archived"],
+            }
+        )
+    except KeyError:
+        raise web.HTTPNotFound(reason=f"Workflow with id '{workflow_id}' was not found.")
+
+
+async def get_licenses(_: web.Request) -> web.Response:
+    """REMS licenses."""
+    return web.json_response(data=make_license_response())
+
+
+async def get_license(request: web.Request) -> web.Response:
+    """REMS license."""
+    license_id = int(request.match_info["license_id"])
+    try:
+        return web.json_response(data=licenses[license_id])
+    except KeyError:
+        raise web.HTTPNotFound(reason=f"License with id '{license_id}' was not found.")
+
+
+async def get_application(request: web.Request) -> web.Response:
+    """REMS application."""
+    try:
+        items = int(request.query["items"])
+        item = catalogue[items]
+    except (KeyError, TypeError) as e:
+        LOG.exception(e)
+        LOG.debug(request)
+        return web.HTTPNotFound(reason="Catalogue item was not found")
+    return web.json_response(data=item)
+
+
+async def post_resource(request: web.Request) -> web.Response:
+    """REMS create resource and return id."""
+    global resource_id
+    try:
+
+        resource = await request.json()
+        oid = resource["organization"]["organization/id"]
+        if oid not in organizations:
+            raise web.HTTPNotFound(reason=f"Organization '{oid}' was not found.")
+        for lic in resource["licenses"]:
+            if lic not in organizations[oid]["licenses"]:
+                raise web.HTTPNotFound(reason=f"License '{lic}' was not found in organization '{oid}'.")
+        resource_id += 1
+        organizations[oid]["resources"][resource_id] = {
+            "resid": resource["resid"],  # DOI
+            "licenses": resource["licenses"],
+        }
+    except (KeyError, TypeError, JSONDecodeError) as e:
+        LOG.exception(e)
+        raise web.HTTPBadRequest(text=ujson.dumps({"errors": ["check the logs ^^"]}))
+
+    return web.json_response(data={"success": True, "id": resource_id})
+
+
+async def post_catalogue_item(request: web.Request) -> web.Response:
+    """REMS create resource and return id."""
+    global catalogue, catalogue_id
+    try:
+        catalogue_request = await request.json()
+        catalogue_id += 1
+        oid = catalogue_request["organization"]["organization/id"]
+        resid = catalogue_request["resid"]
+        wfid = catalogue_request["wfid"]
+        form = catalogue_request["form"]
+        if form and form not in forms:
+            raise web.HTTPNotFound(reason=f"Form '{form}' was not found.")
+        if resource_id not in organizations[oid]["resources"]:
+            raise web.HTTPNotFound(reason=f"Resource '{resid}' was not found in organization '{oid}'.")
+        if wfid not in organizations[oid]["workflows"]:
+            raise web.HTTPNotFound(reason=f"Workflow '{wfid}' was not found in organization '{oid}'.")
+        catalogue_item = {
+            "form": form,
+            "resid": resid,
+            "wfid": wfid,
+            "localizations": catalogue_request["localizations"],
+            "enabled": catalogue_request["enabled"],
+            "archived": catalogue_request["archived"],
+        }
+        organizations[oid]["catalogue-items"][catalogue_id] = catalogue_item
+        catalogue[catalogue_id] = catalogue_item
+    except (KeyError, TypeError, JSONDecodeError) as e:
+        LOG.exception(e)
+        LOG.debug(await request.text())
+        raise web.HTTPBadRequest(text=ujson.dumps({"errors": ["check the logs ^^"]}))
+
+    return web.json_response(data={"success": True, "id": catalogue_id})
+
+
+async def init() -> web.Application:
+    """Start server."""
+    app = web.Application()
+    app.router.add_get("/api/workflows", get_workflows)
+    app.router.add_get("/api/workflows/{workflow_id}", get_workflow)
+    app.router.add_get("/api/licenses", get_licenses)
+    app.router.add_get("/api/licenses/{license_id}", get_license)
+    app.router.add_post("/api/resources/create", post_resource)
+    app.router.add_post("/api/catalogue-items/create", post_catalogue_item)
+    app.router.add_get("/application", get_application)
+    return app
+
+
+if __name__ == "__main__":
+    web.run_app(init(), port=8003)

--- a/tests/test_files/dac/dac_rems.json
+++ b/tests/test_files/dac/dac_rems.json
@@ -1,0 +1,5 @@
+{
+  "workflowId": 1,
+  "organizationId": "CSC",
+  "licenses": [1]
+}

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -810,7 +810,7 @@ class SubmissionHandlerTestCase(HandlersTestCase):
 
         await super().setUpAsync()
 
-        self._mock_prepare_doi = "metadata_backend.api.handlers.submission.SubmissionAPIHandler._prepare_doi_update"
+        self._mock_prepare_doi = "metadata_backend.api.handlers.submission.SubmissionAPIHandler._prepare_for_publishing"
 
         class_submissionoperator = "metadata_backend.api.handlers.submission.SubmissionOperator"
         self.patch_submissionoperator = patch(class_submissionoperator, **self.submissionoperator_config, spec=True)
@@ -973,9 +973,17 @@ class SubmissionHandlerTestCase(HandlersTestCase):
                     {"doi": "prefix/suffix-study", "metaxIdentifier": "metax_id"},
                     {"doi": "prefix/suffix-dataset", "metaxIdentifier": "metax_id"},
                 ],
+                [
+                    {
+                        "accession_id": "accId",
+                        "doi": "prefix/suffix-dataset",
+                        "description": "Dataset description",
+                        "localizations": {"en": "Dataset title"},
+                    }
+                ],
             ),
         ), patch(
-            "metadata_backend.services.datacite_service_handler.DataciteServiceHandler.set_state", return_value=None
+            "metadata_backend.services.datacite_service_handler.DataciteServiceHandler.publish", return_value=None
         ), patch(
             "metadata_backend.services.metax_service_handler.MetaxServiceHandler.update_dataset_with_doi_info",
             return_value=None,


### PR DESCRIPTION
### Description
<!-- Please include a summary of the change or any information deemed important. -->

Adds integration with REMS, so that researchers can apply for access to published datasets.

A DAC is added for a submission, and REMS resources are created for each dataset using the same DAC for all datasets in the same submission.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
- Closes #487
- Closes #488
- Closes #432
- Closes #291

I added a check that when REMS is in use, submissions must have a DAC, and implemented similar checks that fix following issues:
- Fixes #465
- Fixes #464 
- Fixes #412
- Closes #422

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made
<!-- List changes made. -->
- Add REMS service handler
- New API endpoint `/v1/rems` for the frontend to retrieve DAC and Policies
- Make REMS integration optional
- API handlers share the same instance of service integrations

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests
- [x] Integration Tests

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
