### PR TITLE
Process multiple objects from same XML file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Published datasets have a new field `dac` with `workflowId`, `organizationId`, `resourceId`, and `catalogueItemId`
 
 ### Changed
-- schema loader now matches schema files by exact match with schema #481. This means that schema file naming in metadata_backend/helpers/schemas now have rules: 
-  - file name starts with schema provider separated with dot or underscore (e.g. EGA.policy.xsd, ena_policy.json) or 
-  - if schema is local then no schema provider needs to be added (e.g users.json) 
+- schema loader now matches schema files by exact match with schema #481. This means that schema file naming in metadata_backend/helpers/schemas now have rules:
+  - file name starts with schema provider separated with dot or underscore (e.g. EGA.policy.xsd, ena_policy.json) or
+  - if schema is local then no schema provider needs to be added (e.g users.json)
   - schema name and mongo database collection name must be the same
 - migrated to variables used by motor 3 for ssl https://motor.readthedocs.io/en/stable/migrate-to-motor-3.html?highlight=ssl_certfile#renamed-uri-options
   - env vars `MONGO_SSL_CLIENT_KEY` and `MONGO_SSL_CLIENT_CERT` are replaced with `MONGO_SSL_CLIENT_CERT_KEY`
@@ -39,19 +39,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Recreate DB before integration tests run and cleanup after integration tests have run #448
 - Make using of discovery service (METAX) optional #467
 - Refactor api handlers to share a single instance of service handlers
+- Refactor metadata creation methods to parse and add separate metadata objects to db from a single XML file #525
 
 ### Removed
 
 - remove `datacite.json` to render the form from `folder["doiInfo"]`
   - we removed `namedtype` for `contributors` and `creators` we therefore allow `additionalProperties`
   - `subjectsSchema` is a given by frontend thus we allow via `additionalProperties`
-  
+
 ## [0.13.0] - 2022-04-07
 
 ### Added
 
 - Submission endpoint update #371
-  - Adds mandatory query parameter `folder` for submit endpoint POST 
+  - Adds mandatory query parameter `folder` for submit endpoint POST
   - On actions add and modify object is added or updated to folder(submission) where it belongs with it's accession ID, schema, submission type, title and filename
   - Adds metax integration to submit endpoint
 - Integration with Metax service #356 #387
@@ -62,7 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Adds new handler MetaxServiceHandler to take care of mapping Submitter metadata to Metax metadata and to connect to Metax API
   - Adds new mapper class to adjust incoming metadata to Metax schema
 - Add patching of folders after object save and update operations #354
-  - Adds mandatory query parameter `folder` for objects endpoint POST 
+  - Adds mandatory query parameter `folder` for objects endpoint POST
   - Object is added or updated to folder(submission) where it belongs with it's accession ID, schema, submission type, title and filename in the case of CSV and XML upload
   - Adds configuration for mypy linting to VScode devcontainer setup
 - Templates API #256
@@ -117,7 +118,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - README updated with tox command, development build instructions, and prettify Dockerfile.
 - Update ENA XML and JSON schemas #299
 - Github actions changed the use of https://git.io/misspell to rojopolis/spellcheck-github-actions #316
-- Separated most of the handlers to own files inside the handlers folder #319 
+- Separated most of the handlers to own files inside the handlers folder #319
 - allow inserting only one study in folder #332
 - JSON schemas #332
    - introduce `keywords` required for Metax in `doiInfo`
@@ -234,13 +235,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.0] - 2021-01-06
 
-### Added 
+### Added
 
 - CodeQL github action #162
 - `/health` endpoint #173
 
 - Map `users` to `folders` with `_handle_check_ownedby_user` #158
-  - querying for objects is restricted to only the objects that belong to user 
+  - querying for objects is restricted to only the objects that belong to user
   - return folders owned by user or published
   - added a few db operators some used (aggregate, remove)
   - process json patch to mongo query so that there is addition and replace instead of full rewrite of the document causing race condition
@@ -261,7 +262,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.1] - 2020-11-23
 
-### Added 
+### Added
 
 - CSRF session #142
 
@@ -277,7 +278,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.0] - 2020-10-08
 
-### Added 
+### Added
 
 - Authentication with OIDC  #133
 - Only 3.7 support going further #134
@@ -310,7 +311,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixes
 
 - Dockerfile build fixes #115
-- Fix JSON Schema details #117 
+- Fix JSON Schema details #117
 - Missing env from github actions #119
 - Typo fixes #120
 - Await responses #122

--- a/metadata_backend/api/handlers/template.py
+++ b/metadata_backend/api/handlers/template.py
@@ -160,6 +160,7 @@ class TemplatesAPIHandler(RESTAPIHandler):
             # Move projectId to template structure, so that it is saved in mongo
             content["template"]["projectId"] = content["projectId"]
             json_data = await operator.create_metadata_object(collection, content["template"])
+            json_data = json_data[0] if isinstance(json_data, list) else json_data
             data = [{"accessionId": json_data["accessionId"], "schema": collection}]
             if "tags" in content:
                 data[0]["tags"] = content["tags"]

--- a/metadata_backend/api/handlers/xml_submission.py
+++ b/metadata_backend/api/handlers/xml_submission.py
@@ -174,6 +174,7 @@ class XMLSubmissionAPIHandler(ObjectAPIHandler):
                 raise web.HTTPBadRequest(reason=reason)
 
         json_data = await XMLOperator(db_client).create_metadata_object(schema, content)
+        json_data = json_data[0]
 
         result = {
             "accessionId": json_data["accessionId"],

--- a/metadata_backend/api/operators.py
+++ b/metadata_backend/api/operators.py
@@ -469,7 +469,7 @@ class Operator(BaseOperator):
 
         :param schema_type: Schema type of the object to create.
         :param data: Metadata object
-        :returns: Tuple of Accession Id for object inserted to database and its title
+        :returns: Metadata object with some additional keys/values
         """
         accession_id = self._generate_accession_id()
         data["accessionId"] = accession_id
@@ -495,7 +495,7 @@ class Operator(BaseOperator):
         :param schema_type: Schema type of the object to replace.
         :param accession_id: Identifier of object to replace.
         :param data: Metadata object
-        :returns: Tuple of Accession Id for object replaced in database and its title
+        :returns: Metadata object with some additional keys/values
         """
         forbidden_keys = {"accessionId", "publishDate", "dateCreated", "metaxIdentifier", "doi"}
         if any(i in data for i in forbidden_keys):
@@ -606,7 +606,7 @@ class XMLOperator(BaseOperator):
 
         :param schema_type: Schema type of the object to read.
         :param data: Original XML content
-        :returns: Tuple of Accession Id for object inserted to database and its title
+        :returns: List of metadata objects extracted from the XML content
         """
         db_client = self.db_service.db_client
         # remove `draft-` from schema type
@@ -635,7 +635,7 @@ class XMLOperator(BaseOperator):
         :param schema_type: Schema type of the object to replace.
         :param accession_id: Identifier of object to replace.
         :param data: Original XML content
-        :returns: Accession Id for object inserted to database
+        :returns: Metadata object extracted from the XML content
         """
         db_client = self.db_service.db_client
         # remove `draft-` from schema type

--- a/metadata_backend/api/operators.py
+++ b/metadata_backend/api/operators.py
@@ -39,7 +39,7 @@ class BaseOperator(ABC):
         self.db_service = DBService(db_name, db_client)
         self.content_type = content_type
 
-    async def create_metadata_object(self, schema_type: str, data: Union[Dict, str]) -> Dict:
+    async def create_metadata_object(self, schema_type: str, data: Union[Dict, str]) -> Any:
         """Create new metadata object to database.
 
         Data formatting and addition step for JSON or XML must be implemented
@@ -47,11 +47,11 @@ class BaseOperator(ABC):
 
         :param schema_type: Schema type of the object to create.
         :param data: Data to be saved to database.
-        :returns: Tuple of Accession id for the object inserted to database and its title
+        :returns: Dict of Accession id for the object inserted to database and its title
         """
         data = await self._format_data_to_create_and_add_to_db(schema_type, data)
-        data_list = data if isinstance(data, list) else [data]
-        acc_ids: list = []
+        data_list: List = data if isinstance(data, list) else [data]
+        acc_ids = []
         for object in data_list:
             acc_ids.append(object["accessionId"])
         LOG.info(f"Inserting object with schema {schema_type} to database succeeded with accession id(s): {acc_ids}")
@@ -254,7 +254,7 @@ class BaseOperator(ABC):
             raise web.HTTPNotFound(reason=reason)
 
     @abstractmethod
-    async def _format_data_to_create_and_add_to_db(self, schema_type: str, data: Any) -> Dict:
+    async def _format_data_to_create_and_add_to_db(self, schema_type: str, data: Any) -> Any:
         """Format and add data to database.
 
         Must be implemented by subclass.
@@ -599,7 +599,7 @@ class XMLOperator(BaseOperator):
         """
         super().__init__(mongo_database, "text/xml", db_client)
 
-    async def _format_data_to_create_and_add_to_db(self, schema_type: str, data: str) -> Dict:
+    async def _format_data_to_create_and_add_to_db(self, schema_type: str, data: str) -> List:
         """Format XML metadata object and add it to db.
 
         XML is validated, then parsed to JSON, which is added to database.

--- a/metadata_backend/helpers/parser.py
+++ b/metadata_backend/helpers/parser.py
@@ -351,8 +351,11 @@ class XMLToJSONParser:
         # however we expect any type as it is easier to work with
         result: Any = schema.to_dict(content, converter=MetadataXMLConverter, decimal_type=float, dict_class=dict)
         _schema_type: str = schema_type.lower()
+        # Validate each JSON object separately if an array of objects is parsed
+        results = result[_schema_type] if isinstance(result[_schema_type], list) else [result[_schema_type]]
         if _schema_type != "submission":
-            JSONValidator(result[_schema_type], _schema_type).validate
+            for object in results:
+                JSONValidator(object, _schema_type).validate
         return result[_schema_type]
 
     @staticmethod

--- a/tests/test_files/policy/policy2.xml
+++ b/tests/test_files/policy/policy2.xml
@@ -1,0 +1,21 @@
+<?xml version = '1.0' encoding = 'UTF-8'?>
+<POLICY_SET>
+    <POLICY alias="asgsasg" center_name="TEST" broker_name="EGA" accession="EGAP50003522">
+        <TITLE>Some policy</TITLE>
+        <DAC_REF accession="EGAC500003259"/>
+        <POLICY_TEXT>Do this, don't do that</POLICY_TEXT>
+        <DATA_USES>
+            <DATA_USE ontology="test" code="test2" version="1"/>
+            <DATA_USE ontology="test1" code="test3" version="2"/>
+        </DATA_USES>
+    </POLICY>
+    <POLICY alias="asgsasgaSas" center_name="TEST2" broker_name="EGA" accession="EGAP50003523">
+        <TITLE>Some other policy</TITLE>
+        <DAC_REF accession="EGAC500003260"/>
+        <POLICY_TEXT>Something else</POLICY_TEXT>
+        <DATA_USES>
+            <DATA_USE ontology="test" code="test2" version="1"/>
+            <DATA_USE ontology="test1" code="test3" version="2"/>
+        </DATA_USES>
+    </POLICY>
+</POLICY_SET>

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -179,7 +179,7 @@ class HandlersTestCase(AioHTTPTestCase):
 
     async def fake_xmloperator_create_metadata_object(self, schema_type, content):
         """Fake create operation to return mocked accessionId."""
-        return {"accessionId": self.test_ega_string}
+        return [{"accessionId": self.test_ega_string}]
 
     async def fake_xmloperator_replace_metadata_object(self, schema_type, accession_id, content):
         """Fake replace operation to return mocked accessionId."""

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -307,7 +307,7 @@ class TestOperators(IsolatedAsyncioTestCase):
             with patch("metadata_backend.api.operators.XMLToJSONParser"):
                 data = await operator.create_metadata_object("study", "<MOCK_ELEM></MOCK_ELEM>")
         operator.db_service.create.assert_called_once()
-        self.assertEqual(data["accessionId"], self.accession_id)
+        self.assertEqual(data[0]["accessionId"], self.accession_id)
 
     async def test_correct_data_is_set_to_json_when_creating(self):
         """Test operator creates object and adds necessary info."""
@@ -428,7 +428,7 @@ class TestOperators(IsolatedAsyncioTestCase):
                     m_insert.assert_called_once_with(
                         "xml-study", {"accessionId": self.accession_id, "content": xml_data}
                     )
-                    self.assertEqual(acc["accessionId"], self.accession_id)
+                    self.assertEqual(acc[0]["accessionId"], self.accession_id)
 
     async def test_correct_data_is_set_to_xml_when_replacing(self):
         """Test XMLoperator replaces object and adds necessary info."""

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -96,8 +96,29 @@ class ParserTestCase(unittest.TestCase):
         self.assertEqual(2, len(dataset_json["datasetType"]))
         self.assertEqual(8, len(dataset_json["runRef"]))
 
+    def test_policy_is_parsed(self):
+        """Test that policy is parsed correctly.
+
+        Tests for some values that converted JSON should have.
+        """
+        policy_xml = self.load_file_to_text("policy", "policy.xml")
+        policy_json = self.xml_parser.parse("policy", policy_xml)
+        self.assertIn("accessionId", policy_json["dacRef"])
+        self.assertEqual(2, len(policy_json["dataUses"]))
+
+    def test_multi_policy_is_parsed(self):
+        """Test that xml with 2 policies is parsed correctly.
+
+        Tests for some values that converted JSON should have.
+        """
+        policy_xml = self.load_file_to_text("policy", "policy2.xml")
+        policy_json = self.xml_parser.parse("policy", policy_xml)
+        self.assertEqual(2, len(policy_json))
+        self.assertEqual("asgsasg", policy_json[0]["alias"])
+        self.assertEqual("asgsasgaSas", policy_json[1]["alias"])
+
     def test_image_is_parsed(self):
-        """Test that dataset is parsed correctly.
+        """Test that BP image is parsed correctly.
 
         Tests for some values that converted JSON should have.
         """
@@ -107,6 +128,18 @@ class ParserTestCase(unittest.TestCase):
         self.assertEqual(6, len(image_json["attributes"]["attribute"]))
         self.assertEqual(4, len(image_json["attributes"]["attributeSet"]))
         self.assertEqual("asdf", image_json["files"][0]["filename"])
+
+    def test_multi_image_is_parsed(self):
+        """Test that multiple BP images are parsed correctly.
+
+        Tests for some values that converted JSON should have.
+        """
+        image_xml = self.load_file_to_text("image", "images_multi.xml")
+        image_json = self.xml_parser.parse("image", image_xml)
+        self.assertEqual(2, len(image_json))
+        self.assertEqual("Image_tSQsAkvutz", image_json[0]["alias"])
+        self.assertEqual("Image_ReLyCtLAWo", image_json[1]["alias"])
+        self.assertEqual("asdf", image_json[1]["files"][0]["filename"])
 
     def test_bp_dataset_is_parsed(self):
         """Test that BP dataset is parsed correctly.


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
This PR implements a change to the `post_object()` method so that if an XML file contains multiple children under the main element (see the `policy2.xml` file for an example with 2 `<POLICY>` elements under `<POLICY_SET>`), it parses, validates and adds the objects to the database separately in the same request and returns with a single response. 

This shouldn't be a breaking change, since submitting single objects via XML still functions and returns with same responses as before. Also in the current state it seems to be possible to submit multiple objects from separate XML files at once so this change wasn't that big of a refactor. One thing to note however is that while each object gets added separately in JSON format, the entire XML is saved as text under the same accession ID in XML format. Not the smartest thing but probably fine for now since we don't do much with the XMLs after they've been parsed to JSON. 

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
Fixes #479 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

<!-- List changes made. -->
- Changed the methods that extract and post objects from xml files so that mutiple objects can be posted from the same file in the same request
- Added some new and altered some previous unit tests
- Added a test file with that has two policies within the policy set element
- Added new integration tests for the multi object submission from single files 
- Fixed some docstrings

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests
- [x] Integration Tests
