### PR TITLE
Refactor api handlers to share service handler instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Refactor authentication checking, fixing issues from #421 and remove HTTPSeeOther from the API
 - Recreate DB before integration tests run and cleanup after integration tests have run #448
 - Make using of discovery service (METAX) optional #467
+- Refactor api handlers to share a single instance of service handlers
 
 ### Removed
 

--- a/metadata_backend/api/middlewares.py
+++ b/metadata_backend/api/middlewares.py
@@ -31,7 +31,7 @@ async def http_error_handler(req: web.Request, handler: aiohttp_session.Handler)
         raise
     except web.HTTPError as error:
         # Catch 400s and 500s
-        LOG.info(HTTP_ERROR_MESSAGE, req.method, req.path, error.status)
+        LOG.error(HTTP_ERROR_MESSAGE, req.method, req.path, error.status)
         problem = _json_problem(error, req.url)
         LOG.debug("Response payload is %r", problem)
 

--- a/metadata_backend/api/operators.py
+++ b/metadata_backend/api/operators.py
@@ -432,13 +432,13 @@ class Operator(BaseOperator):
         )
         return data, page_num, page_size, total_objects[0]["total"]
 
-    async def create_datacite_info(self, schema_type: str, accession_id: str, data: Dict) -> bool:
+    async def update_identifiers(self, schema_type: str, accession_id: str, data: Dict) -> bool:
         """Update study or dataset object with metax info.
 
         :param schema_type: Schema type of the object to replace.
         :param accession_id: Identifier of object to replace.
         :param data: Metadata object
-        :returns: True on successed database update
+        :returns: True on successful database update
         """
         if schema_type not in {"study", "dataset"}:
             LOG.error("Object schema type must be either study or dataset")

--- a/metadata_backend/services/service_handler.py
+++ b/metadata_backend/services/service_handler.py
@@ -67,7 +67,7 @@ class ServiceHandler:
         self.http_client_headers = http_client_headers
 
     @property
-    def http_client(self) -> ClientSession:
+    def _client(self) -> ClientSession:
         """Singleton http client, customized for the service."""
         if self._http_client is None or self._http_client.closed:
             self._http_client = ClientSession(
@@ -127,15 +127,17 @@ class ServiceHandler:
         #     LOG.error(reason)
         #     raise HTTPInternalServerError(reason=reason)
 
+        LOG.debug(
+            f"{method} request to '{url or self.base_url}' path '{path}', params '{params}', payload '{json_data}'"
+        )
         if url is None:
             url = self.base_url
             if path and path.startswith("/"):
                 path = path[1:]
             if path:
                 url = url / path
-        LOG.debug(f"making a {method} request to {url}, params {params}, payload {json_data}")
         try:
-            async with self.http_client.request(
+            async with self._client.request(
                 auth=self.auth,
                 method=method,
                 url=url,


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->

I made this as part of implementing the Rems integration #498. But thought it's better to split into a separate PR.

Makes it more clear where calls to integration services are coming
from, improving maintainability of the code.

Mocking Datacite and Metax is not necessary in places where errors are ignored (most object endpoints). Otherwise, they are mocked where needed. Thus becoming more clear.

I wonder if the changes to unit tests are actually good overwall. At least for me it makes things easier to follow and understand what's happening.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->


### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

<!-- List changes made. -->
- Reuse instance of service handlers.
- Properly close HTTP clients.

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
