### PR TITLE
Dependabot weekly -> monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
     labels:
       - "pip dependencies"
@@ -12,7 +12,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
     labels:
       - "github actions"
@@ -21,7 +21,7 @@ updates:
   - package-ecosystem: docker
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
     labels:
       - "docker dependencies"


### PR DESCRIPTION
Weekly updates are a bit too much for the size of our team, and frequency of releases. Let's do it monthly instead.