### PR TITLE
Change how BP samples are parsed from XML format and added to db

### DIFF
--- a/docs/dictionary/wordlist.txt
+++ b/docs/dictionary/wordlist.txt
@@ -111,6 +111,7 @@ covid
 cp
 cpg
 crai
+createdFrom
 createfromjson
 createfromxml
 createnewdraftsubmission
@@ -205,6 +206,7 @@ experimentlinks
 experimentref
 experimenttype
 externalid
+extractedFrom
 extrainfo
 fairdata
 faire
@@ -556,6 +558,7 @@ sampleattributes
 sampledata
 sampledemuxdirective
 sampledescriptor
+sampledFrom
 samplelinks
 samplename
 samplephenotype

--- a/metadata_backend/helpers/parser.py
+++ b/metadata_backend/helpers/parser.py
@@ -391,35 +391,25 @@ class XMLToJSONParser:
         :param data: BP sample objects in JSON format
         :returns: Organized BP sample objects
         """
+
+        # Helper function for separating sample objects
+        def _separate_samples(item: Union[Dict, List[Dict]], title: str) -> List[Dict]:
+            if isinstance(item, list) and len(item) > 0:
+                return [{title: i} for i in item]
+            return [{title: item}] if isinstance(item, dict) else []
+
         # Separate biological beings, specimen, blocks and slides from the data that was extracted from the XML
         bio_beings = data["biologicalBeing"] if "biologicalBeing" in data else []
-        bio_beings = bio_beings if isinstance(bio_beings, list) else [bio_beings]
+        bio_beings = _separate_samples(bio_beings, "biologicalBeing")
         specimens = data["specimen"] if "specimen" in data else []
-        specimens = specimens if isinstance(specimens, list) else [specimens]
+        specimens = _separate_samples(specimens, "specimen")
         blocks = data["block"] if "block" in data else []
-        blocks = blocks if isinstance(blocks, list) else [blocks]
+        blocks = _separate_samples(blocks, "block")
         slides = data["slide"] if "slide" in data else []
-        slides = slides if isinstance(slides, list) else [slides]
+        slides = _separate_samples(slides, "slide")
 
-        # Create sample object from biological beings, specimen, blocks and slides that relate to each other
-        samples: List[Dict] = []
-        for being in bio_beings:
-            sample: Dict[str, Any] = {"biologicalBeing": None, "specimen": None, "block": [], "slide": []}
-            sample["biologicalBeing"] = being
-            being_alias = being["alias"]
-            for specimen in specimens:
-                if specimen["extractedFrom"]["refname"] == being_alias:
-                    sample["specimen"] = specimen
-                    specimen_alias = specimen["alias"]
-                    for block in blocks:
-                        if block["sampledFrom"]["refname"] == specimen_alias:
-                            sample["block"].append(block)
-                            block_alias = block["alias"]
-                            for slide in slides:
-                                if slide["createdFrom"]["refname"] == block_alias:
-                                    sample["slide"].append(slide)
-            samples.append(sample)
-
+        # Return all samples as an array under bpsample schema name
+        samples: List[Dict] = bio_beings + specimens + blocks + slides
         return {"bpsample": samples}
 
 

--- a/metadata_backend/helpers/schemas/bp_bpsample.json
+++ b/metadata_backend/helpers/schemas/bp_bpsample.json
@@ -1,5 +1,5 @@
 {
-    "title": "Sample",
+    "title": "BP Sample",
     "definitions": {
         "Block": {
             "$id": "#/definitions/Block",
@@ -66,80 +66,140 @@
         }
     },
     "type": "object",
-    "required": [
-        "biologicalBeing",
-        "specimen",
-        "block",
-        "slide"
-    ],
     "additionalProperties": true,
-    "properties": {
-        "biologicalBeing": {
-            "title": "Biological Being Type",
-            "description": "A human being or animal.",
+    "oneOf": [
+        {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
-                "gender": {
-                    "title": "Gender",
-                    "type": "string",
-                    "enum": [
-                        "male",
-                        "female",
-                        "unknown"
-                    ]
-                },
-                "animal_species": {
-                    "title": "Animal Species",
-                    "type": "string"
+                "biologicalBeing": {
+                    "title": "Biological Being Type",
+                    "description": "A human being or animal.",
+                    "type": "object",
+                    "properties": {
+                        "alias": {
+                            "title": "Alias Type",
+                            "type": "string"
+                        },
+                        "attributes": {
+                            "title": "Sample Attributes",
+                            "description": "Properties and attributes of the sample set. These can be entered as free-form tag-value pairs. Submitters may be asked to follow a community established ontology when describing the work.",
+                            "type": "object",
+                            "properties": {
+                                "$ref": "#/definitions/sampleAttribute"
+                            }
+                        }
+                    }
                 }
             }
         },
-        "specimen": {
-            "title": "Specimen Type",
-            "description": "A removed part of a human/animal being.",
+        {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
-                "specimen_type": {
+                "specimen": {
                     "title": "Specimen Type",
-                    "type": "string"
-                },
-                "age_at_extraction": {
-                    "title": "Age At Extraction",
-                    "type": "integer"
-                },
-                "extraction_method": {
-                    "title": "Extraction Method",
-                    "type": "string"
-                },
-                "anatomical_site": {
-                    "title": "Anatomical Site",
-                    "type": "string"
+                    "description": "A removed part of a human/animal being.",
+                    "type": "object",
+                    "properties": {
+                        "alias": {
+                            "title": "Alias Type",
+                            "type": "string"
+                        },
+                        "attributes": {
+                            "title": "Sample Attributes",
+                            "description": "Properties and attributes of the sample set. These can be entered as free-form tag-value pairs. Submitters may be asked to follow a community established ontology when describing the work.",
+                            "type": "object",
+                            "properties": {
+                                "$ref": "#/definitions/sampleAttribute"
+                            }
+                        },
+                        "extractedFrom": {
+                            "title": "Extracted From Type",
+                            "description": "The alias of the biological being object where specimen is extracted from.",
+                            "type": "object",
+                            "properties": {
+                                "refname": {
+                                    "title": "Reference name",
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },
-        "block": {
-            "title": "Block Type",
-            "description": "A part or a collection of parts of one or many Specimens that has/have been sampled and processed for further investigation.",
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/Block"
+        {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "block": {
+                    "title": "Block Type",
+                    "description": "A part or a collection of parts of one or many Specimens that has/have been sampled and processed for further investigation.",
+                    "type": "object",
+                    "properties": {
+                        "alias": {
+                            "title": "Alias Type",
+                            "type": "string"
+                        },
+                        "attributes": {
+                            "title": "Sample Attributes",
+                            "description": "Properties and attributes of the sample set. These can be entered as free-form tag-value pairs. Submitters may be asked to follow a community established ontology when describing the work.",
+                            "type": "object",
+                            "properties": {
+                                "$ref": "#/definitions/sampleAttribute"
+                            }
+                        },
+                        "sampledFrom": {
+                            "title": "Sampled From Type",
+                            "description": "The alias of the specimen object where block is sampled from.",
+                            "type": "object",
+                            "properties": {
+                                "refname": {
+                                    "title": "Reference name",
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
             }
         },
-        "slide": {
-            "title": "Slide Type",
-            "description": "A physical slide that has been created out of one or more Blocks.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/Slide"
-            }
-        },
-        "attributes": {
-            "type": "array",
-            "title": "Sample Attributes",
-            "description": "Properties and attributes of the sample set. These can be entered as free-form tag-value pairs. Submitters may be asked to follow a community established ontology when describing the work.",
-            "items": {
-                "$ref": "#/definitions/sampleAttribute"
+        {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "slide": {
+                    "title": "Slide Type",
+                    "description": "A physical slide that has been created out of one or more Blocks.",
+                    "type": "object",
+                    "properties": {
+                        "alias": {
+                            "title": "Alias Type",
+                            "type": "string"
+                        },
+                        "attributes": {
+                            "title": "Sample Attributes",
+                            "description": "Properties and attributes of the sample set. These can be entered as free-form tag-value pairs. Submitters may be asked to follow a community established ontology when describing the work.",
+                            "type": "object",
+                            "properties": {
+                                "$ref": "#/definitions/sampleAttribute"
+                            }
+                        },
+                        "createdFrom": {
+                            "title": "Sampled From Type",
+                            "description": "The alias of the block object where slide is created from.",
+                            "type": "object",
+                            "properties": {
+                                "refname": {
+                                    "title": "Reference name",
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
-    }
+    ]
 }

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -722,6 +722,10 @@ async def test_crud_works(sess, schema, filename, submission_id):
 async def test_crud_with_multi_xml(sess, submission_id):
     """Test CRUD for a submitted XML file with multiple metadata objects.
 
+    Tries to create new objects, gets accession ids and checks if correct
+    resource is returned with those ids. Finally deletes the objects and checks it
+    was deleted.
+
     :param sess: HTTP session in which request call is made
     :param submission_id: id of the submission used to group submission
     """
@@ -764,6 +768,7 @@ async def test_crud_with_multi_xml(sess, submission_id):
             LOG.debug(f"Checking that {item['accessionId']} XML is in {_schema}")
             assert resp.status == 200, f"HTTP Status code error, got {resp.status}"
 
+    assert len(items) == 14, "Wrong amount of items were added during previous requests."
     for item in items:
         _id, _schema = item["accessionId"], item["schema"]
         await delete_object(sess, _schema, _id)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -164,14 +164,11 @@ class ParserTestCase(unittest.TestCase):
         """
         bp_sample_xml = self.load_file_to_text("bpsample", "template_samples.xml")
         bp_sample_json = self.xml_parser.parse("bpsample", bp_sample_xml)
-        self.assertEqual(2, len(bp_sample_json))
-        self.assertEqual(1, len(bp_sample_json[0]["block"]))
-        self.assertEqual(2, len(bp_sample_json[1]["block"]))
-        self.assertEqual(1, len(bp_sample_json[0]["slide"]))
-        self.assertEqual(2, len(bp_sample_json[1]["slide"]))
-        self.assertEqual("Slide_BkyUrCfBxx", bp_sample_json[0]["slide"][0]["alias"])
-        self.assertEqual("Slide_OYFDfQXRhr", bp_sample_json[1]["slide"][0]["alias"])
-        self.assertEqual("Slide_OYFDfQXRhr", bp_sample_json[1]["slide"][1]["alias"])
+        self.assertEqual(10, len(bp_sample_json))
+        self.assertEqual("BiologicalBeing_qLNZYjYjyZ", bp_sample_json[0]["biologicalBeing"]["alias"])
+        self.assertEqual("BiologicalBeing_qLNZYjYjyZ", bp_sample_json[2]["specimen"]["extractedFrom"]["refname"])
+        self.assertEqual("sample_preparation", bp_sample_json[4]["block"]["attributes"]["attribute"]["tag"])
+        self.assertEqual(2, len(bp_sample_json[7]["slide"]["attributes"]["attributeSet"]["attributeSet"]))
 
     def test_error_raised_when_schema_not_found(self):
         """Test 400 is returned when schema type is invalid."""


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->

Turns out we had the wrong idea about BP samples after all. Here is a quick fix that instead adds all the BP samples as separate objects so that a single `biologicalBeing`, `specimen`, `block` and `slide` are treated as their own objects.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
Fixes the functionality originally added in #491 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

<!-- List changes made. -->
- edited bp sample handling method in parser
- edited bp sample json schema
- edited the related tests a little

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests
