### PR TITLE
Revert change to keep parallel upload test

### DIFF
--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -2240,8 +2240,12 @@ async def main(url):
         basic_submission_id = await post_submission(sess, basic_submission)
 
         # test XML files
+        gather_items = []
         for schema, file in test_xml_files:
-            await test_crud_works(sess, schema, file, basic_submission_id)
+            gather_items.append(test_crud_works(sess, schema, file, basic_submission_id))
+        # Run in parallel to test concurrent uploads
+        await asyncio.gather(*gather_items)
+
         await test_crud_with_multi_xml(sess, basic_submission_id)
 
         # test CSV files
@@ -2265,8 +2269,11 @@ async def main(url):
         }
         draft_submission_id = await post_submission(sess, draft_submission)
 
+        gather_items = []
         for schema, file, file2 in test_json_files:
-            await test_crud_drafts_works(sess, schema, file, file2, draft_submission_id)
+            gather_items.append(test_crud_drafts_works(sess, schema, file, file2, draft_submission_id))
+        # Run in parallel to test concurrent uploads
+        await asyncio.gather(*gather_items)
 
         # Test patch and put
         LOG.debug("=== Testing patch and put drafts operations ===")


### PR DESCRIPTION


### Description

<!-- Please include a summary of the change or any information deemed important. -->
To fix linting issues, the `asyncio.gather` statements were removed
in #476 (commit c96f76cfc29209d47d06a62fde066945b5873dfd).

The point was to test concurrent uploads, so reverting to use
`asyncio.gather`.

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
Nice that @blankdots spotted it!