### PR TITLE
Parse age_at_extraction value to integer

### DIFF
--- a/metadata_backend/helpers/parser.py
+++ b/metadata_backend/helpers/parser.py
@@ -408,6 +408,12 @@ class XMLToJSONParser:
         slides = data["slide"] if "slide" in data else []
         slides = _separate_samples(slides, "slide")
 
+        # Turn age_at_extraction value to int
+        for specimen in specimens:
+            for attribute in specimen["specimen"]["attributes"]["attribute"]:
+                if attribute["tag"] == "age_at_extraction":
+                    attribute["value"] = int(attribute["value"])
+
         # Return all samples as an array under bpsample schema name
         samples: List[Dict] = bio_beings + specimens + blocks + slides
         return {"bpsample": samples}

--- a/metadata_backend/helpers/schemas/bp_bpsample.json
+++ b/metadata_backend/helpers/schemas/bp_bpsample.json
@@ -55,7 +55,7 @@
                     "title": "Tag title"
                 },
                 "value": {
-                    "type": "string",
+                    "type": ["string", "number"],
                     "title": "Description"
                 },
                 "units": {

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -778,8 +778,6 @@ async def test_crud_with_multi_xml(sess, submission_id):
         async with sess.get(f"{objects_url}/{_schema}/{item['accessionId']}") as resp:
             LOG.debug(f"Checking that {item['accessionId']} JSON is in {_schema}")
             assert resp.status == 200, f"HTTP Status code error, got {resp.status}"
-            res = await resp.json()
-            LOG.debug(res)
         async with sess.get(f"{objects_url}/{_schema}/{item['accessionId']}?format=xml") as resp:
             LOG.debug(f"Checking that {item['accessionId']} XML is in {_schema}")
             assert resp.status == 200, f"HTTP Status code error, got {resp.status}"
@@ -1959,7 +1957,6 @@ async def test_get_submissions(sess, submission_id: str, project_id: str):
         LOG.debug(f"Reading submission {submission_id}")
         assert resp.status == 200, f"HTTP Status code error, got {resp.status}"
         response = await resp.json()
-        LOG.error(response)
         assert len(response["submissions"]) == 1, len(response["submissions"])
         assert response["page"] == {"page": 1, "size": 5, "totalPages": 1, "totalSubmissions": 1}
         assert response["submissions"][0]["submissionId"] == submission_id

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -167,6 +167,7 @@ class ParserTestCase(unittest.TestCase):
         self.assertEqual(10, len(bp_sample_json))
         self.assertEqual("BiologicalBeing_qLNZYjYjyZ", bp_sample_json[0]["biologicalBeing"]["alias"])
         self.assertEqual("BiologicalBeing_qLNZYjYjyZ", bp_sample_json[2]["specimen"]["extractedFrom"]["refname"])
+        self.assertEqual(65, bp_sample_json[2]["specimen"]["attributes"]["attribute"][1]["value"])
         self.assertEqual("sample_preparation", bp_sample_json[4]["block"]["attributes"]["attribute"]["tag"])
         self.assertEqual(2, len(bp_sample_json[7]["slide"]["attributes"]["attributeSet"]["attributeSet"]))
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
This PR changes the `age_at_extraction` value found in BP samples (added in #491) from string to integer.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
Fixes #557 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

<!-- List changes made. -->
- Added a check for the `age_at_extraction` value and simple test to prove it works

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
