### PR TITLE
Change age_at_extraction to numeric attribute in test file

### DIFF
--- a/tests/integration/test_submissions.py
+++ b/tests/integration/test_submissions.py
@@ -48,7 +48,6 @@ class TestSubmissions:
             LOG.debug(f"Reading submission {submission_id}")
             assert resp.status == 200, f"HTTP Status code error, got {resp.status}"
             response = await resp.json()
-            LOG.error(response)
             assert len(response["submissions"]) == 1, len(response["submissions"])
             assert response["page"] == {
                 "page": 1,

--- a/tests/test_files/bpsample/template_samples.xml
+++ b/tests/test_files/bpsample/template_samples.xml
@@ -29,10 +29,10 @@
                 <TAG>specimen_type</TAG>
                 <VALUE>histology</VALUE>
             </ATTRIBUTE>
-            <ATTRIBUTE>
+            <NUMERIC_ATTRIBUTE>
                 <TAG>age_at_extraction</TAG>
                 <VALUE>65</VALUE>
-            </ATTRIBUTE>
+            </NUMERIC_ATTRIBUTE>
             <ATTRIBUTE>
                 <TAG>extraction_method</TAG>
                 <VALUE>biopsy</VALUE>
@@ -50,10 +50,10 @@
                 <TAG>specimen_type</TAG>
                 <VALUE>histology</VALUE>
             </ATTRIBUTE>
-            <ATTRIBUTE>
+            <NUMERIC_ATTRIBUTE>
                 <TAG>age_at_extraction</TAG>
                 <VALUE>50</VALUE>
-            </ATTRIBUTE>
+            </NUMERIC_ATTRIBUTE>
             <ATTRIBUTE>
                 <TAG>extraction_method</TAG>
                 <VALUE>biopsy</VALUE>

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -167,6 +167,7 @@ class ParserTestCase(unittest.TestCase):
         self.assertEqual(10, len(bp_sample_json))
         self.assertEqual("BiologicalBeing_qLNZYjYjyZ", bp_sample_json[0]["biologicalBeing"]["alias"])
         self.assertEqual("BiologicalBeing_qLNZYjYjyZ", bp_sample_json[2]["specimen"]["extractedFrom"]["refname"])
+        self.assertEqual(65.0, bp_sample_json[2]["specimen"]["attributes"]["numericAttribute"]["value"])
         self.assertEqual("sample_preparation", bp_sample_json[4]["block"]["attributes"]["attribute"]["tag"])
         self.assertEqual(2, len(bp_sample_json[7]["slide"]["attributes"]["attributeSet"]["attributeSet"]))
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
The age_at_extraction value should be a number and not a string and the bp common xml schema specifies a NUMERIC_ATTRIBUTE tag. The current bp sample test file wrongly assigned it as a general ATTRIBUTE so this quick change fixes that confusion.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
Technically related to #557 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

<!-- List changes made. -->
- update bp sample test file
- update unit test
- remove some logs from integration tests

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests