### PR TITLE
fix Any typing and cleanup code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
       exclude: tests/test_files/study/SRP000539_invalid[0-9]?.xml
 
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 22.8.0
     hooks:
     - id: black
       args: [-l, "120"]
@@ -41,7 +41,7 @@ repos:
       args: [--profile, black, --filter-files]
 
   - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
     - id: flake8
       additional_dependencies:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Published datasets have a new field `dac` with `workflowId`, `organizationId`, `resourceId`, and `catalogueItemId`
 - Pylint static checks
 - Run integration tests with pytest
+  - run integration tests with `--nocleanup` option 
 
 ### Changed
 - schema loader now matches schema files by exact match with schema #481. This means that schema file naming in metadata_backend/helpers/schemas now have rules:
@@ -49,8 +50,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - we removed `namedtype` for `contributors` and `creators` we therefore allow `additionalProperties`
   - `subjectsSchema` is a given by frontend thus we allow via `additionalProperties`
 
+- remove unused code related to change from user to project ownership caused by faulty rebase or rollback of certain features #579
+
 ### Fixed
-- Schemas endpoint returned 400 for /v1/schemas/datacite #554
+- Schemas endpoint returned `400` for `/v1/schemas/datacite` #554
+- XML delete when an object or submission is deleted #579
+- small pylint issues e.g. web.HTTPSuccessful was never being raised #579
+- fix `Any` type wherever that is possible. #579
 
 ## [0.13.0] - 2022-04-07
 

--- a/docs/dictionary/wordlist.txt
+++ b/docs/dictionary/wordlist.txt
@@ -283,6 +283,7 @@ http
 httperror
 https
 httpseeother
+HTTPSuccessful
 identifiertype
 identitypython
 ido
@@ -533,6 +534,7 @@ readspec
 readthedocs
 readtype
 realpath
+rebase
 redux
 refcenter
 referencealignment

--- a/docs/dictionary/wordlist.txt
+++ b/docs/dictionary/wordlist.txt
@@ -423,6 +423,7 @@ neic
 newdraft
 nextseq
 nlmcatalog
+nocleanup
 noindex
 nominallength
 nominalsdev
@@ -630,9 +631,9 @@ subjectsschema
 submissionid
 submissionslice
 submissiontype
+submitter's
 submitterdemultiplexed
 submitterid
-submitter's
 submitters
 svg
 swati

--- a/docs/test.rst
+++ b/docs/test.rst
@@ -61,6 +61,13 @@ Basically, a fixture is run before a new module/class/function/<fixture scope he
 is executed, according to its defined ``scope``. Statements before a ``yield`` statement function as a ``Setup``, and
 statements after are ``Teardown``. When there's no ``yield``, there's no teardown either, only setup.
 
+Running the tests without cleaning the database use the ``--nocleanup`` option, as follows:
+
+- ``pytest --nocleanup tests/integration`` for the whole test suite;
+- ``pytest --nocleanup tests/integration/test_module.py::TestClass::test_method`` for specific tests.
+
+Note that this option might cause some tests to fail and it is only recommended for debugging the data from the integration tests.
+
 Debugging tests
 ~~~~~~~~~~~~~~~
 

--- a/metadata_backend/__init__.py
+++ b/metadata_backend/__init__.py
@@ -1,5 +1,5 @@
 """Backend for submitting and validating XML Files containing ENA metadata."""
 
 __title__ = "metadata_backend"
-__version__ = VERSION = "0.13.0"
+__version__ = "0.13.0"
 __author__ = "CSC Developers"

--- a/metadata_backend/api/handlers/object.py
+++ b/metadata_backend/api/handlers/object.py
@@ -274,6 +274,9 @@ class ObjectAPIHandler(RESTAPIIntegrationHandler):
                 )
 
         accession_id = await operator.delete_metadata_object(collection, accession_id)
+        # we try to delete the object from the xml-{schema_type} collection
+        xml_operator = XMLOperator(db_client)
+        await xml_operator.delete_metadata_object(f"xml-{collection}", accession_id)
 
         # Delete draft dataset from Metax catalog
         if self.metax_handler.enabled and collection in METAX_SCHEMAS:

--- a/metadata_backend/api/handlers/restapi.py
+++ b/metadata_backend/api/handlers/restapi.py
@@ -1,13 +1,12 @@
 """Handle HTTP methods for server."""
 import json
 from math import ceil
-from typing import AsyncGenerator, Dict, List, Tuple
+from typing import Dict, Tuple
 
 import aiohttp_session
 import ujson
 from aiohttp import web
 from aiohttp.web import Request, Response
-from motor.motor_asyncio import AsyncIOMotorClient
 from multidict import CIMultiDict
 
 from ...conf.conf import schema_types
@@ -113,23 +112,6 @@ class RESTAPIHandler:
             raise web.HTTPUnauthorized(reason=reason)
 
         return _check, project_id
-
-    async def _get_collection_objects(
-        self, submission_op: AsyncIOMotorClient, collection: str, seq: List
-    ) -> AsyncGenerator:
-        """Get objects ids based on submission and collection.
-
-        Considering that many objects will be returned good to have a generator.
-
-        :param req: HTTP request
-        :param collection: collection or schema of document
-        :param seq: list of submissions
-        :returns: AsyncGenerator
-        """
-        for el in seq:
-            result = await submission_op.get_collection_objects(el, collection)
-
-            yield result
 
     async def _get_data(self, req: Request) -> Dict:
         """Get the data content from a request.

--- a/metadata_backend/api/handlers/submission.py
+++ b/metadata_backend/api/handlers/submission.py
@@ -546,7 +546,7 @@ class SubmissionAPIHandler(RESTAPIIntegrationHandler):
         for _obj in submission["metadataObjects"]:
             accession_id = _obj["accessionId"]
             schema = _obj["schema"]
-            object_data, _ = await obj_op.read_metadata_object(schema, accession_id)  # pylint: disable=unused-variable
+            _, _ = await obj_op.read_metadata_object(schema, accession_id)
             if schema == "study":
                 has_study = True
             if self.rems_handler.enabled and "dac" not in submission:
@@ -727,7 +727,7 @@ class SubmissionAPIHandler(RESTAPIIntegrationHandler):
             raise web.HTTPNotFound(reason=f"'{req.path}' does not exist")
 
         submission[schema] = data
-        JSONValidator(submission, "submission").validate  # pylint: disable=expression-not-assigned
+        JSONValidator(submission, "submission").validate
 
         op = "add"
         if schema in submission:

--- a/metadata_backend/api/handlers/submission.py
+++ b/metadata_backend/api/handlers/submission.py
@@ -13,7 +13,13 @@ from multidict import CIMultiDict
 from ...conf.conf import DATACITE_SCHEMAS, METAX_SCHEMAS, doi_config
 from ...helpers.logger import LOG
 from ...helpers.validator import JSONValidator
-from ..operators import Operator, ProjectOperator, SubmissionOperator, UserOperator
+from ..operators import (
+    Operator,
+    ProjectOperator,
+    SubmissionOperator,
+    UserOperator,
+    XMLOperator,
+)
 from .restapi import RESTAPIIntegrationHandler
 
 
@@ -531,6 +537,7 @@ class SubmissionAPIHandler(RESTAPIIntegrationHandler):
         db_client = req.app["db_client"]
         operator = SubmissionOperator(db_client)
         obj_op = Operator(db_client)
+        xml_ops = XMLOperator(db_client)
 
         await operator.check_submission_exists(submission_id)
 
@@ -638,6 +645,7 @@ class SubmissionAPIHandler(RESTAPIIntegrationHandler):
         # Delete draft objects from the submission
         for obj in submission["drafts"]:
             await obj_ops.delete_metadata_object(obj["schema"], obj["accessionId"])
+            await xml_ops.delete_metadata_object(f"xml-{obj['schema']}", obj["accessionId"])
 
         # Patch the submission into a published state
         _now = int(datetime.now().timestamp())
@@ -686,11 +694,13 @@ class SubmissionAPIHandler(RESTAPIIntegrationHandler):
         await self._handle_check_ownership(req, "submission", submission_id)
 
         obj_ops = Operator(db_client)
+        xml_ops = XMLOperator(db_client)
 
         submission = await operator.read_submission(submission_id)
 
         for obj in submission["drafts"] + submission["metadataObjects"]:
             await obj_ops.delete_metadata_object(obj["schema"], obj["accessionId"])
+            await xml_ops.delete_metadata_object(f"xml-{obj['schema']}", obj["accessionId"])
 
         _submission_id = await operator.delete_submission(submission_id)
 

--- a/metadata_backend/api/handlers/user.py
+++ b/metadata_backend/api/handlers/user.py
@@ -1,14 +1,9 @@
 """Handle HTTP methods for server."""
 
-import re
-from math import ceil
-from typing import Any, Dict, Tuple
-
 import aiohttp_session
 import ujson
 from aiohttp import web
 from aiohttp.web import Request, Response
-from multidict import CIMultiDict
 
 from ...helpers.logger import LOG
 from ..operators import UserOperator
@@ -17,62 +12,6 @@ from .restapi import RESTAPIHandler
 
 class UserAPIHandler(RESTAPIHandler):
     """API Handler for users."""
-
-    def _check_patch_user(self, patch_ops: Any) -> None:
-        """Check patch operations in request are valid.
-
-        We check that ``submissions`` have string values (one or a list)
-        and ``drafts`` have ``_required_values``.
-        For tags we check that the ``submissionType`` takes either ``XML`` or
-        ``Form`` as values.
-        :param patch_ops: JSON patch request
-        :raises: HTTPBadRequest if request does not fullfil one of requirements
-        :raises: HTTPUnauthorized if request tries to do anything else than add or replace
-        :returns: None
-        """
-        _arrays = {"/templates/-", "/submissions/-"}
-        _required_values = {"schema", "accessionId"}
-        _tags = re.compile("^/(templates)/[0-9]*/(tags)$")
-        for op in patch_ops:
-            if _tags.match(op["path"]):
-                LOG.info(f"{op['op']} on tags in submission")
-                if "submissionType" in op["value"].keys() and op["value"]["submissionType"] not in {
-                    "XML",
-                    "CSV",
-                    "Form",
-                }:
-                    reason = "submissionType is restricted to either 'XML' or 'Form' values."
-                    LOG.error(reason)
-                    raise web.HTTPBadRequest(reason=reason)
-            else:
-                if all(i not in op["path"] for i in _arrays):
-                    reason = f"Request contains '{op['path']}' key that cannot be updated to user object"
-                    LOG.error(reason)
-                    raise web.HTTPBadRequest(reason=reason)
-                if op["op"] in {"remove", "copy", "test", "move", "replace"}:
-                    reason = f"{op['op']} on {op['path']} is not allowed."
-                    LOG.error(reason)
-                    raise web.HTTPUnauthorized(reason=reason)
-                if op["path"] == "/submissions/-":
-                    if not isinstance(op["value"], (list, str)):
-                        reason = "We only accept string submission IDs."
-                        LOG.error(reason)
-                        raise web.HTTPBadRequest(reason=reason)
-                if op["path"] == "/templates/-":
-                    _ops = op["value"] if isinstance(op["value"], list) else [op["value"]]
-                    for item in _ops:
-                        if not all(key in item.keys() for key in _required_values):
-                            reason = "accessionId and schema are required fields."
-                            LOG.error(reason)
-                            raise web.HTTPBadRequest(reason=reason)
-                        if (
-                            "tags" in item
-                            and "submissionType" in item["tags"]
-                            and item["tags"]["submissionType"] not in {"XML", "CSV", "Form"}
-                        ):
-                            reason = "submissionType is restricted to either 'XML' or 'Form' values."
-                            LOG.error(reason)
-                            raise web.HTTPBadRequest(reason=reason)
 
     async def get_user(self, req: Request) -> Response:
         """Get one user by its user ID.
@@ -124,46 +63,3 @@ class UserAPIHandler(RESTAPIHandler):
 
         LOG.debug(f"Logged out user {user_id}")
         return web.HTTPNoContent()
-
-    async def _get_user_items(self, req: Request, user: Dict, item_type: str) -> Tuple[Dict, CIMultiDict[str]]:
-        """Get draft templates owned by the user with pagination values.
-
-        :param req: GET request
-        :param user: User object
-        :param item_type: Name of the items ("templates" or "submissions")
-        :raises: HTTPUnauthorized if not current user
-        :returns: Tuple with paginated list of user draft templates and link headers
-        """
-        # Check item_type parameter is not faulty
-        if item_type not in {"templates", "submission"}:
-            reason = f"{item_type} is a faulty item parameter. Should be either submission or templates"
-            LOG.error(reason)
-            raise web.HTTPBadRequest(reason=reason)
-
-        page = self._get_page_param(req, "page", 1)
-        per_page = self._get_page_param(req, "per_page", 5)
-
-        db_client = req.app["db_client"]
-        operator = UserOperator(db_client)
-        user_id = req.match_info["userId"]
-
-        query = {"userId": user}
-
-        items, total_items = await operator.filter_user(query, item_type, page, per_page)
-        LOG.info(f"GET user with ID {user_id} was successful.")
-
-        result = {
-            "page": {
-                "page": page,
-                "size": per_page,
-                "totalPages": ceil(total_items / per_page),
-                "total" + item_type.title(): total_items,
-            },
-            item_type: items,
-        }
-
-        url = f"{req.scheme}://{req.host}{req.path}"
-        link_headers = self._header_links(url, page, per_page, total_items)
-        LOG.debug(f"Pagination header links: {link_headers}")
-        LOG.info(f"Querying for user's {item_type} resulted in {total_items} {item_type}")
-        return result, link_headers

--- a/metadata_backend/api/health.py
+++ b/metadata_backend/api/health.py
@@ -1,6 +1,6 @@
 """Handle health check endpoint."""
 import time
-from typing import Any, Dict, Union
+from typing import Dict, Union
 
 import ujson
 from aiohttp import web
@@ -48,7 +48,7 @@ class HealthHandler:
         LOG.info("Initialised a new DB client as a test")
         return new_client
 
-    async def try_db_connection(self, db_client: AsyncIOMotorClient) -> Any:
+    async def try_db_connection(self, db_client: AsyncIOMotorClient) -> Union[None, float]:
         """Check the connection to database.
 
         :param db_client: Motor client used for database connections

--- a/metadata_backend/api/middlewares.py
+++ b/metadata_backend/api/middlewares.py
@@ -27,8 +27,8 @@ async def http_error_handler(req: web.Request, handler: aiohttp_session.Handler)
     try:
         response = await handler(req)
         return response
-    except (web.HTTPSuccessful, web.HTTPRedirection):  # pylint: disable=try-except-raise
-        # Catches 200s and 300s
+    except web.HTTPRedirection:
+        # Catches 300s
         raise
     except web.HTTPError as error:
         # Catch 400s and 500s

--- a/metadata_backend/api/operators.py
+++ b/metadata_backend/api/operators.py
@@ -211,7 +211,7 @@ class BaseOperator(ABC):
         LOG.error(reason)
         raise web.HTTPBadRequest(reason=reason)
 
-    async def _remove_object_from_db(self, operator: Any, schema_type: str, accession_id: str) -> bool:
+    async def _remove_object_from_db(self, schema_type: str, accession_id: str) -> bool:
         """Delete object from database.
 
         We can omit raising error for XMLOperator if id is not
@@ -252,29 +252,37 @@ class BaseOperator(ABC):
             LOG.error(reason)
             raise web.HTTPNotFound(reason=reason)
 
+    # no way around type Any here without breaking Liskov substitution principle
+
     @abstractmethod
-    async def _format_data_to_create_and_add_to_db(self, schema_type: str, data: Any) -> Union[Dict, List[dict]]:
+    async def _format_data_to_create_and_add_to_db(
+        self, schema_type: str, data: Any  # noqa: ANN401
+    ) -> Union[Dict, List[dict]]:
         """Format and add data to database.
 
         Must be implemented by subclass.
         """
 
     @abstractmethod
-    async def _format_data_to_replace_and_add_to_db(self, schema_type: str, accession_id: str, data: Any) -> Dict:
+    async def _format_data_to_replace_and_add_to_db(
+        self, schema_type: str, accession_id: str, data: Any  # noqa: ANN401
+    ) -> Dict:
         """Format and replace data in database.
 
         Must be implemented by subclass.
         """
 
     @abstractmethod
-    async def _format_data_to_update_and_add_to_db(self, schema_type: str, accession_id: str, data: Any) -> str:
+    async def _format_data_to_update_and_add_to_db(
+        self, schema_type: str, accession_id: str, data: Any  # noqa: ANN401
+    ) -> str:
         """Format and update data in database.
 
         Must be implemented by subclass.
         """
 
     @abstractmethod
-    async def _format_read_data(self, schema_type: str, data_raw: Any) -> Any:
+    async def _format_read_data(self, schema_type: str, data_raw: Any) -> Any:  # noqa: ANN401
         """Format data for API response.
 
         Must be implemented by subclass.
@@ -508,7 +516,7 @@ class Operator(BaseOperator):
         await self._replace_object_from_db(schema_type, accession_id, data)
         return data
 
-    async def _format_data_to_update_and_add_to_db(self, schema_type: str, accession_id: str, data: Any) -> str:
+    async def _format_data_to_update_and_add_to_db(self, schema_type: str, accession_id: str, data: Dict) -> str:
         """Format and update data in database.
 
         Will not allow to update ``metaxIdentifier`` and ``doi`` for ``study`` and ``dataset``

--- a/metadata_backend/database/db_service.py
+++ b/metadata_backend/database/db_service.py
@@ -307,17 +307,6 @@ class DBService:
         return self.database[collection].find(query, projection)
 
     @auto_reconnect
-    async def get_count(self, collection: str, query: Dict) -> int:
-        """Get (estimated) count of documents matching given query.
-
-        :param collection: Collection where document should be searched from
-        :param query: query to be used
-        :returns: Estimate of the number of documents
-        """
-        LOG.debug(f"DB doc count performed in {collection}.")
-        return await self.database[collection].count_documents(query)
-
-    @auto_reconnect
     async def do_aggregate(self, collection: str, query: List) -> List:
         """Peform aggregate query.
 

--- a/metadata_backend/database/db_service.py
+++ b/metadata_backend/database/db_service.py
@@ -15,7 +15,7 @@ def auto_reconnect(db_func: Callable) -> Callable:
     """Auto reconnection decorator."""
 
     @wraps(db_func)
-    async def retry(*args: Any, **kwargs: Any) -> Any:
+    async def retry(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
         """Retry given function for many times with increasing interval.
 
         By default increases interval by clients default timeout for five
@@ -165,7 +165,7 @@ class DBService:
             return False
 
     @auto_reconnect
-    async def update_study(self, collection: str, accession_id: str, patch_data: Any) -> bool:
+    async def update_study(self, collection: str, accession_id: str, patch_data: List[Dict]) -> bool:
         """Update and avoid duplicates for study object.
 
         Currently we don't allow duplicate studies in the same submission,
@@ -206,7 +206,7 @@ class DBService:
         return result.acknowledged
 
     @auto_reconnect
-    async def remove(self, collection: str, accession_id: str, data_to_be_removed: Any) -> bool:
+    async def remove(self, collection: str, accession_id: str, data_to_be_removed: Union[str, Dict]) -> bool:
         """Remove element of object by its accessionId.
 
         :param collection: Collection where document should be searched from
@@ -225,7 +225,7 @@ class DBService:
         return result
 
     @auto_reconnect
-    async def append(self, collection: str, accession_id: str, data_to_be_addded: Any) -> bool:
+    async def append(self, collection: str, accession_id: str, data_to_be_addded: Union[str, Dict]) -> bool:
         """Append data by to object with accessionId in collection.
 
         :param collection: Collection where document should be searched from

--- a/metadata_backend/helpers/logger.py
+++ b/metadata_backend/helpers/logger.py
@@ -2,7 +2,7 @@
 
 import logging
 import os
-from typing import Any, Dict
+from typing import Dict
 
 import ujson
 
@@ -15,7 +15,7 @@ LOG = logging.getLogger("server")
 LOG.setLevel(os.getenv("LOG_LEVEL", "INFO"))
 
 
-def get_attributes(obj: Any) -> None:
+def get_attributes(obj: Dict) -> None:
     """Print all attributes of given object.
 
     :param obj: Any kind of object

--- a/metadata_backend/helpers/parser.py
+++ b/metadata_backend/helpers/parser.py
@@ -8,11 +8,13 @@ from typing import Any, Dict, List, Optional, Type, Union
 from aiohttp import web
 from pymongo import UpdateOne
 from xmlschema import (
+    ElementData,
     XMLSchema,
     XMLSchemaConverter,
     XMLSchemaException,
     XsdElement,
     XsdType,
+    aliases,
 )
 
 from .logger import LOG
@@ -31,10 +33,11 @@ class MetadataXMLConverter(XMLSchemaConverter):
 
     def __init__(
         self,
-        namespaces: Any = None,
+        namespaces: Optional[aliases.NamespacesType] = None,
         dict_class: Optional[Type[Dict[str, Any]]] = None,
         list_class: Optional[Type[List[Any]]] = None,
-        **kwargs: Any,
+        # difficult to pinpoint type as xmlschema library does the same
+        **kwargs: Any,  # noqa: ANN401
     ) -> None:
         """Initialize converter and settings.
 
@@ -52,7 +55,7 @@ class MetadataXMLConverter(XMLSchemaConverter):
         _under_regex = re.compile(r"_([a-z])")
         return _under_regex.sub(lambda x: x.group(1).upper(), name)
 
-    def _flatten(self, data: Any) -> Union[Dict, List, str, None]:
+    def _flatten(self, data: ElementData) -> Union[Dict, List, str, None]:
         """Address corner cases.
 
         :param schema_type: XML data
@@ -252,10 +255,10 @@ class MetadataXMLConverter(XMLSchemaConverter):
 
     def element_decode(
         self,
-        data: Any,
+        data: ElementData,
         xsd_element: XsdElement,
         xsd_type: XsdType = None,
-        level: int = 0,
+        level: int = 0,  # this is required for XMLSchemaConverter
     ) -> Union[Dict, List, str, None]:
         """Decode XML to JSON.
 
@@ -480,7 +483,7 @@ class CSVToJSONParser:
         return _parsed
 
 
-def jsonpatch_mongo(identifier: Dict, json_patch: List[Dict[str, Any]]) -> List:
+def jsonpatch_mongo(identifier: Dict, json_patch: List[Dict]) -> List:
     """Convert JSONpatch object to mongo query.
 
     :param identifier: object database ID

--- a/metadata_backend/helpers/schema_loader.py
+++ b/metadata_backend/helpers/schema_loader.py
@@ -7,7 +7,7 @@ probably be replaced with database searching in the future.
 import re
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any
+from typing import Union
 
 import ujson
 from xmlschema import XMLSchema
@@ -55,7 +55,7 @@ class SchemaLoader(ABC):
         return schema_file
 
     @abstractmethod
-    def get_schema(self, schema_type: str) -> Any:
+    def get_schema(self, schema_type: str) -> Union[XMLSchema, dict]:
         """Find schema which is used to match files against.
 
         Must be implemented by subclass.

--- a/metadata_backend/services/service_handler.py
+++ b/metadata_backend/services/service_handler.py
@@ -2,7 +2,7 @@
 
 It provides a http client with optional basic auth, and requests that retry automatically and come with error handling
 """
-from typing import Any, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from aiohttp import BasicAuth, ClientSession, ClientTimeout
 from aiohttp.web import HTTPError, HTTPGatewayTimeout, HTTPInternalServerError
@@ -24,7 +24,8 @@ class ServiceClientError(HTTPError):
     def __init__(
         self,
         status_code: int,
-        **kwargs: Any,
+        # difficult to pinpoint type
+        **kwargs: Any,  # noqa: ANN401
     ) -> None:
         """Class to raise for http client errors.
 
@@ -104,9 +105,9 @@ class ServiceHandler:
         url: URL = None,
         path: str = "",
         params: Union[str, dict] = None,
-        json_data: Any = None,
+        json_data: Union[Dict, List[Dict]] = None,
         timeout: int = 10,
-    ) -> Any:
+    ) -> Union[dict, str]:
         """Request to service REST API.
 
         :param method: HTTP method

--- a/tests/unit/test_db_service.py
+++ b/tests/unit/test_db_service.py
@@ -120,13 +120,6 @@ class DatabaseTestCase(IsolatedAsyncioTestCase):
         self.test_service.query("testcollection", {})
         self.collection.find.assert_called_once_with({}, {"_id": False})
 
-    async def test_count_returns_amount(self):
-        """Test that get_count method works and returns amount."""
-        self.collection.count_documents.return_value = 100
-        count = await self.test_service.get_count("testcollection", {})
-        self.collection.count_documents.assert_called_once_with({})
-        self.assertEqual(count, 100)
-
     async def test_db_operation_is_retried_with_increasing_interval(self):
         """Patch timeout to be 0 sec instead of default, test autoreconnect."""
         self.collection.insert_one.side_effect = AutoReconnect

--- a/tests/unit/test_operators.py
+++ b/tests/unit/test_operators.py
@@ -452,14 +452,14 @@ class TestOperators(IsolatedAsyncioTestCase):
                     )
                     self.assertEqual(acc["accessionId"], self.accession_id)
 
-    async def test_deleting_metadata_deletes_json_and_xml(self):
+    async def test_deleting_metadata_deletes_json(self):
         """Test metadata is deleted."""
         operator = Operator(self.client)
         operator.db_service.db_client = self.client
         operator.db_service.exists.return_value = True
         operator.db_service.delete.return_value = True
         await operator.delete_metadata_object("sample", "EGA123456")
-        self.assertEqual(operator.db_service.delete.call_count, 2)
+        self.assertEqual(operator.db_service.delete.call_count, 1)
         operator.db_service.delete.assert_called_with("sample", "EGA123456")
 
     async def test_deleting_metadata_delete_raises(self):
@@ -470,7 +470,7 @@ class TestOperators(IsolatedAsyncioTestCase):
         operator.db_service.delete.return_value = True
         with self.assertRaises(HTTPNotFound):
             await operator.delete_metadata_object("sample", "EGA123456")
-            self.assertEqual(operator.db_service.delete.call_count, 2)
+            self.assertEqual(operator.db_service.delete.call_count, 1)
             operator.db_service.delete.assert_called_with("sample", "EGA123456")
 
     async def test_deleting_metadata_delete_raises_bad_request(self):
@@ -481,7 +481,7 @@ class TestOperators(IsolatedAsyncioTestCase):
         operator.db_service.delete.return_value = False
         with self.assertRaises(HTTPBadRequest):
             await operator.delete_metadata_object("sample", "EGA123456")
-            self.assertEqual(operator.db_service.delete.call_count, 2)
+            self.assertEqual(operator.db_service.delete.call_count, 1)
             operator.db_service.delete.assert_called_with("sample", "EGA123456")
 
     async def test_working_query_params_are_passed_to_db_query(self):

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,7 @@ asyncio_mode = auto
 
 [flake8]
 max-line-length = 120
-# ANN40 will be fixed with separate PR
-ignore = D202, D203, D212, D213, D404, W503, ANN101, ANN401
+ignore = D202, D203, D212, D213, D404, W503, ANN101
 exclude = .git/, ./env/, ./venv/, ./.tox/, build/, metadata_backend.egg-info/
 # Not using type hints in tests, ignore all errors
 per-file-ignores =


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
closes #389 
closes #575 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Changes Made

<!-- List changes made. -->
1.  fix `Any` type wherever that is possible. There were some instances like ABC class where this could not be easily satisfied as well as with decorators and some custom classes we extend from `xmlschema` and `aiohttp`. However it might be that python 3.10 + might bring better options for that 
2. remove unused code, which i suspect is the result of faulty rebase or rollback of certain features + the fact that our `master` and `develop` branches are out of sync.
3. remove some `pylint` ignores that were not required e.g. i did not see `web.HTTPSuccessful` ever being raised and did not follow why it was handled in the exception middleware
4. xml object was not properly deleted from the corresponding schema in the db, and it made unnecessary calls for some objects, as the only places it was required was for deleting `objects` and `submissions`
5. add command line options for ``--nocleanup`` integ tests and docs about it
6. update pre-commit config dependencies

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests
- [x] Integration Tests

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
this also addresses some of the dead code in #577 