### PR TITLE
add support for LSAAI groups #548

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added mapping for subjects from submission doi info to Metax field_of_science #556
 - Run integration tests with pytest
   - run integration tests with `--nocleanup` option 
+- Support for LifeScience groups as a substitute to CSC projects #548
 
 ### Changed
 - schema loader now matches schema files by exact match with schema #481. This means that schema file naming in metadata_backend/helpers/schemas now have rules:

--- a/docs/dictionary/wordlist.txt
+++ b/docs/dictionary/wordlist.txt
@@ -117,7 +117,7 @@ covid
 cp
 cpg
 crai
-createdFrom
+createdfrom
 createfromjson
 createfromxml
 createnewdraftsubmission
@@ -212,7 +212,7 @@ experimentlinks
 experimentref
 experimenttype
 externalid
-extractedFrom
+extractedfrom
 extrainfo
 fairdata
 faire
@@ -286,7 +286,7 @@ http
 httperror
 https
 httpseeother
-HTTPSuccessful
+httpsuccessful
 identifiertype
 identitypython
 ido
@@ -346,6 +346,7 @@ librarysource
 librarystrategy
 librarytype
 lifecycle
+lifescience
 limburgish
 lims
 lingala
@@ -483,6 +484,7 @@ pdb
 pdbcls
 pdf
 peerreview
+perun
 pgm
 phenome
 physicalobject
@@ -578,7 +580,7 @@ sampleattributes
 sampledata
 sampledemuxdirective
 sampledescriptor
-sampledFrom
+sampledfrom
 samplelinks
 samplename
 samplephenotype
@@ -623,7 +625,7 @@ src
 srf
 ssl
 ssrna
-StackOverflow
+stackoverflow
 stepindex
 studyabstract
 studyattribute
@@ -639,10 +641,10 @@ subjectsschema
 submissionid
 submissionslice
 submissiontype
-submitter's
 submitterdemultiplexed
 submitterid
 submitters
+submitter's
 svg
 swati
 tabix

--- a/metadata_backend/api/auth.py
+++ b/metadata_backend/api/auth.py
@@ -152,7 +152,8 @@ class AccessHandler:
             for group in session["userinfo"]["eduperson_entitlement"]:
                 projects.append(
                     {
-                        "project_name": group,
+                        # remove the oidc client information, as it's not important to the user
+                        "project_name": group.split("#")[0],
                         "origin": "lifescience",
                     }
                 )

--- a/metadata_backend/api/auth.py
+++ b/metadata_backend/api/auth.py
@@ -115,12 +115,10 @@ class AccessHandler:
             raise web.HTTPUnauthorized(reason="Invalid OIDC callback.")
 
         # User data is read from AAI /userinfo and is used to create the user model in database
-        user_data = {
+        user_data: Dict[str, Union[str, List[Dict[str, str]]]] = {
             "user_id": "",
             "real_name": f"{session['userinfo']['given_name']} {session['userinfo']['family_name']}",
-            # projects come from AAI in this form: "project1 project2 project3"
-            # if user is not affiliated to any projects the `sdSubmitProjects` key will be missing
-            "projects": session["userinfo"]["sdSubmitProjects"].split(" "),
+            "projects": [],
         }
         if "CSCUserName" in session["userinfo"]:
             user_data["user_id"] = session["userinfo"]["CSCUserName"]
@@ -136,8 +134,36 @@ class AccessHandler:
                 reason="Could not set user, missing claim CSCUserName, remoteUserIdentifier or sub."
             )
 
+        # Handle projects, they come in different formats depending on the service used.
+        # Current project sources: CSC projects, LS AAI groups
+        projects: List[Dict[str, str]] = []
+        if "sdSubmitProjects" in session["userinfo"]:
+            # CSC projects come in format "project1 project2"
+            csc_projects = session["userinfo"]["sdSubmitProjects"].split(" ")
+            for csc_project in csc_projects:
+                projects.append(
+                    {
+                        "project_name": csc_project,
+                        "origin": "csc",
+                    }
+                )
+        if "eduperson_entitlement" in session["userinfo"]:
+            # LS AAI groups come in format ["group1", "group2"]
+            for group in session["userinfo"]["eduperson_entitlement"]:
+                projects.append(
+                    {
+                        "project_name": group,
+                        "origin": "lifescience",
+                    }
+                )
+
+        if len(projects) == 0:
+            # No project group information received, abort, as metadata-submitter
+            # object hierarchy depends on a project group to act as owner for objects
+            raise web.HTTPUnauthorized(reason="User is not a member of any project.")
+
         # Process project external IDs into the database and return accession IDs back to user_data
-        user_data["projects"] = await self._process_projects(req, user_data["projects"])
+        user_data["projects"] = await self._process_projects(req, projects)
 
         browser_session = await aiohttp_session.new_session(req)
         browser_session["at"] = time.time()
@@ -145,8 +171,6 @@ class AccessHandler:
         # Inject cookie to this request to let _set_user work as expected.
         browser_session["oidc_state"] = params["state"]
         browser_session["access_token"] = session["token"]
-
-        await self._set_user(req, browser_session, user_data)
 
         await self._set_user(req, browser_session, user_data)
         response = web.HTTPSeeOther(f"{self.redirect}/home")
@@ -181,7 +205,7 @@ class AccessHandler:
 
         return response
 
-    async def _process_projects(self, req: Request, projects: List[str]) -> List[Dict[str, str]]:
+    async def _process_projects(self, req: Request, projects: List[Dict[str, str]]) -> List[Dict[str, str]]:
         """Process project external IDs to internal accession IDs by getting IDs\
             from database and creating projects that are missing.
 
@@ -190,16 +214,16 @@ class AccessHandler:
         :param projects: A list of project external IDs
         :returns: A list of objects containing project accession IDs and project numbers
         """
-        projects.sort()  # sort project numbers to be increasing in order
         new_project_ids: List[Dict[str, str]] = []
 
         db_client = req.app["db_client"]
         operator = ProjectOperator(db_client)
         for project in projects:
-            project_id = await operator.create_project(project)
+            project_id = await operator.create_project(project["project_name"])
             project_data = {
                 "projectId": project_id,  # internal ID
-                "projectNumber": project,  # human friendly
+                "projectNumber": project["project_name"],  # human friendly
+                "origin": project["origin"],  # where this project came from: [csc | lifescience]
             }
             new_project_ids.append(project_data)
 

--- a/tests/integration/mock_auth.py
+++ b/tests/integration/mock_auth.py
@@ -153,6 +153,11 @@ async def userinfo(request: web.Request) -> web.Response:
         "family_name": user_family_name,
         "email": user_sub,
         "sdSubmitProjects": "1000 2000 3000",
+        "eduperson_entitlement": [
+            "test_namespace:test_root:group1#client",
+            "test_namespace:test_root:group2#client",
+            "test_namespace:test_root:group3#client",
+        ],
     }
 
     LOG.info(user_info)


### PR DESCRIPTION
### Description
Add support for LifeScience AAI groups for users that don't have access to CSC projects. LS groups are a non-breaking substitute for CSC projects.

### Related issues
Closes #548 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update ~(this needs a follow up PR)~

### Changes Made
- modified `auth.py` to be able to handle projects/groups from `userinfo` endpoint in both CSC way and LS way
- projects have a new `origin` key in database to denote where the project came from for use in workflows

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests
- [x] Mockauth Manual Test

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
ELIXIR-CZ for helping with setting up LS groups.