### PR TITLE
Validate schemas

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,3 +39,5 @@ jobs:
         pip install tox tox-gh-actions
     - name: Run docs tests
       run: tox -e docs
+  - name: Run jsonschema validation
+      run: tox -e jsonschema

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,6 +72,16 @@ repos:
       args: [validate]
       files: docs/specification.yml
 
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.18.3
+    hooks:
+      - id: check-metaschema
+        name: Validate schemas
+        files: ^metadata_backend/helpers/schemas/.*\.json$
+
+      - id: check-dependabot
+      - id: check-github-workflows
+
   - repo: local
     hooks:
     - id: pylint
@@ -85,6 +95,7 @@ repos:
           -rn, # Only display messages
           -sn, # Don't display the score
         ]
+
     - id: pyspelling-docs
       name: pyspelling-docs
       entry: ./scripts/pyspelling.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added mapping for languages between the submitter and Metax-service #514
 - Added mapping for subjects from submission doi info to Metax field_of_science #556
 - Run integration tests with pytest
-  - run integration tests with `--nocleanup` option 
+  - run integration tests with `--nocleanup` option
 
 ### Changed
 - schema loader now matches schema files by exact match with schema #481. This means that schema file naming in metadata_backend/helpers/schemas now have rules:
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make using of discovery service (METAX) optional #467
 - Refactor api handlers to share a single instance of service handlers
 - Refactor metadata creation methods to parse and add separate metadata objects to db from a single XML file #525
+- Validate schema definitions, updating them to JSON schema 2020-12 #581
 
 ### Removed
 

--- a/metadata_backend/helpers/parser.py
+++ b/metadata_backend/helpers/parser.py
@@ -103,6 +103,17 @@ class MetadataXMLConverter(XMLSchemaConverter):
                 children[key] = attrs[0] if isinstance(attrs[0], list) else attrs
                 continue
 
+            if key == "attributes" and "attributeSet" not in value:
+                attribs = list(value.values())
+                attr_list = []
+                for i in attribs:
+                    if isinstance(i, list):
+                        attr_list += i
+                    else:
+                        attr_list.append(i)
+                children[key] = attr_list
+                continue
+
             if "studyType" in key:
                 children[key] = value["existingStudyType"]
                 continue

--- a/metadata_backend/helpers/schemas/bp_bpdataset.json
+++ b/metadata_backend/helpers/schemas/bp_bpdataset.json
@@ -1,8 +1,8 @@
 {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "Dataset",
-    "definitions": {
+    "$defs": {
         "identifiers": {
-            "$id": "#/definitions/identifiers",
             "title": "Identifiers",
             "description": "Identifiers to be used in the International Nucleotide Sequence Database Collaboration (INSDC) namespace.",
             "type": "object",
@@ -55,7 +55,6 @@
             }
         },
         "reference": {
-            "$id": "#/definitions/reference",
             "additionalProperties": true,
             "type": "object",
             "properties": {
@@ -75,7 +74,7 @@
                     "title": "Center Namespace"
                 },
                 "identifiers": {
-                    "$ref": "#/definitions/identifiers"
+                    "$ref": "#/$defs/identifiers"
                 }
             }
         }
@@ -129,14 +128,14 @@
             "title": "Policy Reference",
             "description": "Identifies the data access policy controlling this data set.",
             "type": "object",
-            "$ref": "#/definitions/reference"
+            "$ref": "#/$defs/reference"
         },
         "imageRef": {
             "title": "Image Reference",
             "description": "Identifies the images which are part of this dataset.",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/reference"
+                "$ref": "#/$defs/reference"
             }
         },
         "annotationRef": {
@@ -144,7 +143,7 @@
             "description": "Identifies the annotations which are part of this dataset.",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/reference"
+                "$ref": "#/$defs/reference"
             }
         },
         "observationsRef": {
@@ -152,7 +151,7 @@
             "description": "Identifies the observations which are part of this dataset.",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/reference"
+                "$ref": "#/$defs/reference"
             }
         },
         "complementsDatasetRef": {
@@ -160,7 +159,7 @@
             "title": "Complements Dataset Reference",
             "description": "Identifies the datasets which this dataset complements.",
             "items": {
-                "$ref": "#/definitions/reference"
+                "$ref": "#/$defs/reference"
             }
         }
     }

--- a/metadata_backend/helpers/schemas/bp_bpsample.json
+++ b/metadata_backend/helpers/schemas/bp_bpsample.json
@@ -1,8 +1,8 @@
 {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "BP Sample",
-    "definitions": {
+    "$defs": {
         "Block": {
-            "$id": "#/definitions/Block",
             "title": "Block",
             "type": "object",
             "properties": {
@@ -13,7 +13,6 @@
             }
         },
         "Slide": {
-            "$id": "#/definitions/Slide",
             "title": "Slide",
             "type": "object",
             "properties": {
@@ -21,13 +20,12 @@
                     "title": "Staining Information",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/Stain"
+                        "$ref": "#/$defs/Stain"
                     }
                 }
             }
         },
         "Stain": {
-            "$id": "#/definitions/Stain",
             "title": "Stain",
             "type": "object",
             "properties": {
@@ -42,25 +40,35 @@
             }
         },
         "sampleAttribute": {
-            "$id": "#/definitions/sampleAttribute",
             "type": "object",
-            "title": "Sample Attribute",
-            "required": [
-                "tag",
-                "value"
-            ],
+            "title": "Sample Attributes",
+            "description": "Properties and attributes of the sample set. These can be entered as free-form tag-value pairs. Submitters may be asked to follow a community established ontology when describing the work.",
             "properties": {
-                "tag": {
-                    "type": "string",
-                    "title": "Tag title"
-                },
-                "value": {
-                    "type": "string",
-                    "title": "Description"
-                },
-                "units": {
-                    "type": "string",
-                    "title": "Optional scientific units."
+                "attribute": {
+                    "type": "array",
+                    "title": "Sample attribute list",
+                    "items": {
+                        "type": "object",
+                        "title": "Sample attribute item",
+                        "required": [
+                            "tag",
+                            "value"
+                        ],
+                        "properties": {
+                            "tag": {
+                                "type": "string",
+                                "title": "Tag title"
+                            },
+                            "value": {
+                                "type": "string",
+                                "title": "Description"
+                            },
+                            "units": {
+                                "type": "string",
+                                "title": "Optional scientific units."
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -82,12 +90,7 @@
                             "type": "string"
                         },
                         "attributes": {
-                            "title": "Sample Attributes",
-                            "description": "Properties and attributes of the sample set. These can be entered as free-form tag-value pairs. Submitters may be asked to follow a community established ontology when describing the work.",
-                            "type": "object",
-                            "properties": {
-                                "$ref": "#/definitions/sampleAttribute"
-                            }
+                            "$ref": "#/$defs/sampleAttribute"
                         }
                     }
                 }
@@ -107,12 +110,7 @@
                             "type": "string"
                         },
                         "attributes": {
-                            "title": "Sample Attributes",
-                            "description": "Properties and attributes of the sample set. These can be entered as free-form tag-value pairs. Submitters may be asked to follow a community established ontology when describing the work.",
-                            "type": "object",
-                            "properties": {
-                                "$ref": "#/definitions/sampleAttribute"
-                            }
+                            "$ref": "#/$defs/sampleAttribute"
                         },
                         "extractedFrom": {
                             "title": "Extracted From Type",
@@ -143,12 +141,7 @@
                             "type": "string"
                         },
                         "attributes": {
-                            "title": "Sample Attributes",
-                            "description": "Properties and attributes of the sample set. These can be entered as free-form tag-value pairs. Submitters may be asked to follow a community established ontology when describing the work.",
-                            "type": "object",
-                            "properties": {
-                                "$ref": "#/definitions/sampleAttribute"
-                            }
+                            "$ref": "#/$defs/sampleAttribute"
                         },
                         "sampledFrom": {
                             "title": "Sampled From Type",
@@ -179,12 +172,7 @@
                             "type": "string"
                         },
                         "attributes": {
-                            "title": "Sample Attributes",
-                            "description": "Properties and attributes of the sample set. These can be entered as free-form tag-value pairs. Submitters may be asked to follow a community established ontology when describing the work.",
-                            "type": "object",
-                            "properties": {
-                                "$ref": "#/definitions/sampleAttribute"
-                            }
+                            "$ref": "#/$defs/sampleAttribute"
                         },
                         "createdFrom": {
                             "title": "Sampled From Type",

--- a/metadata_backend/helpers/schemas/bp_bpsample.json
+++ b/metadata_backend/helpers/schemas/bp_bpsample.json
@@ -2,51 +2,12 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "BP Sample",
     "$defs": {
-        "Block": {
-            "title": "Block",
-            "type": "object",
-            "properties": {
-                "sample_preparation": {
-                    "type": "string",
-                    "title": "Sample Preparation"
-                }
-            }
-        },
-        "Slide": {
-            "title": "Slide",
-            "type": "object",
-            "properties": {
-                "staining_information": {
-                    "title": "Staining Information",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/$defs/Stain"
-                    }
-                }
-            }
-        },
-        "Stain": {
-            "title": "Stain",
-            "type": "object",
-            "properties": {
-                "staining_compound": {
-                    "title": "Staining Compound",
-                    "type": "string"
-                },
-                "staining_method": {
-                    "title": "Staining Method",
-                    "type": "string"
-                }
-            }
-        },
         "sampleAttribute": {
-            "type": "object",
             "title": "Sample Attributes",
             "description": "Properties and attributes of the sample set. These can be entered as free-form tag-value pairs. Submitters may be asked to follow a community established ontology when describing the work.",
-            "properties": {
-                "attribute": {
+            "anyOf": [
+                {
                     "type": "array",
-                    "title": "Sample attribute list",
                     "items": {
                         "type": "object",
                         "title": "Sample attribute item",
@@ -60,7 +21,7 @@
                                 "title": "Tag title"
                             },
                             "value": {
-                                "type": "string",
+                                "type": ["string","number"],
                                 "title": "Description"
                             },
                             "units": {
@@ -69,8 +30,58 @@
                             }
                         }
                     }
+                },
+                {
+                    "#ref": "#/$defs/sampleAttributeSet"
                 }
-            }
+            ]
+        },
+        "sampleAttributeSet": {
+            "title": "Sample Attribute Set",
+            "description": "Reusable set of attributes to encode multiple tag-value or tag-code value pairs.",
+            "anyOf": [
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "title": "Sample attribute item",
+                        "required": [
+                            "tag"
+                        ],
+                        "properties": {
+                            "tag": {
+                                "type": "string",
+                                "title": "Tag title"
+                            },
+                            "attribute": {
+                                "items": { "#ref": "#/$defs/sampleAttribute" }
+                            },
+                            "attributeSet": {
+                                "items": { "#ref": "#" }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "title": "Sample attribute item",
+                    "required": [
+                        "tag"
+                    ],
+                    "properties": {
+                        "tag": {
+                            "type": "string",
+                            "title": "Tag title"
+                        },
+                        "attribute": {
+                            "items": { "#ref": "#/$defs/sampleAttribute" }
+                        },
+                        "attributeSet": {
+                            "items": { "#ref": "#" }
+                        }
+                    }
+                }
+            ]
         }
     },
     "type": "object",
@@ -84,6 +95,10 @@
                     "title": "Biological Being Type",
                     "description": "A human being or animal.",
                     "type": "object",
+                    "required": [
+                        "alias",
+                        "attributes"
+                    ],
                     "properties": {
                         "alias": {
                             "title": "Alias Type",
@@ -104,6 +119,11 @@
                     "title": "Specimen Type",
                     "description": "A removed part of a human/animal being.",
                     "type": "object",
+                    "required": [
+                        "alias",
+                        "attributes",
+                        "extractedFrom"
+                    ],
                     "properties": {
                         "alias": {
                             "title": "Alias Type",
@@ -135,6 +155,11 @@
                     "title": "Block Type",
                     "description": "A part or a collection of parts of one or many Specimens that has/have been sampled and processed for further investigation.",
                     "type": "object",
+                    "required": [
+                        "alias",
+                        "attributes",
+                        "sampledFrom"
+                    ],
                     "properties": {
                         "alias": {
                             "title": "Alias Type",
@@ -166,6 +191,11 @@
                     "title": "Slide Type",
                     "description": "A physical slide that has been created out of one or more Blocks.",
                     "type": "object",
+                    "required": [
+                        "alias",
+                        "attributes",
+                        "createdFrom"
+                    ],
                     "properties": {
                         "alias": {
                             "title": "Alias Type",

--- a/metadata_backend/helpers/schemas/bp_image.json
+++ b/metadata_backend/helpers/schemas/bp_image.json
@@ -1,8 +1,8 @@
 {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "Image",
-    "definitions": {
+    "$defs": {
         "ImageFile": {
-            "$id": "#/definitions/ImageFile",
             "title": "Image File Type",
             "type": "object",
             "required": [
@@ -19,12 +19,11 @@
                 },
                 "fileBase": {
                     "title": "File Base Type",
-                    "$ref": "#/definitions/FileBase"
+                    "$ref": "#/$defs/FileBase"
                 }
             }
         },
         "FileBase": {
-            "$id": "#/definitions/FileBase",
             "title": "File Base",
             "type": "object",
             "required": [
@@ -60,7 +59,6 @@
             }
         },
         "identifiers": {
-            "$id": "#/definitions/identifiers",
             "title": "Identifiers",
             "description": "Identifiers to be used in the International Nucleotide Sequence Database Collaboration (INSDC) namespace.",
             "type": "object",
@@ -113,7 +111,6 @@
             }
         },
         "reference": {
-            "$id": "#/definitions/reference",
             "additionalProperties": true,
             "type": "object",
             "properties": {
@@ -133,7 +130,7 @@
                     "title": "Center Namespace"
                 },
                 "identifiers": {
-                    "$ref": "#/definitions/identifiers"
+                    "$ref": "#/$defs/identifiers"
                 }
             }
         }
@@ -276,14 +273,14 @@
             "title": "Study Reference",
             "description": "Identifies the parent study.",
             "type": "object",
-            "$ref": "#/definitions/reference"
+            "$ref": "#/$defs/reference"
         },
         "imageOf": {
             "title": "Image Of",
             "description": "One of more samples imaged by the image.",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/reference"
+                "$ref": "#/$defs/reference"
             }
         },
         "imageType": {
@@ -300,7 +297,7 @@
             "description": "Data files associated with the image.",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/ImageFile"
+                "$ref": "#/$defs/ImageFile"
             }
         }
     }

--- a/metadata_backend/helpers/schemas/ena_analysis.json
+++ b/metadata_backend/helpers/schemas/ena_analysis.json
@@ -1,23 +1,22 @@
 {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "Analysis",
-    "definitions": {
+    "$defs": {
         "Links": {
-            "$id": "#/definitions/Links",
             "title": "Link Type",
             "oneOf": [
                 {
-                    "$ref": "#/definitions/xrefLink"
+                    "$ref": "#/$defs/xrefLink"
                 },
                 {
-                    "$ref": "#/definitions/urlLink"
+                    "$ref": "#/$defs/urlLink"
                 },
                 {
-                    "$ref": "#/definitions/entrezLink"
+                    "$ref": "#/$defs/entrezLink"
                 }
             ]
         },
         "xrefLink": {
-            "$id": "#/definitions/xrefLink",
             "title": "XRef Link",
             "type": "object",
             "required": [
@@ -43,7 +42,6 @@
             }
         },
         "urlLink": {
-            "$id": "#/definitions/urlLink",
             "title": "URL Link",
             "type": "object",
             "required": [
@@ -65,7 +63,6 @@
             }
         },
         "entrezLink": {
-            "$id": "#/definitions/entrezLink",
             "title": "Entrez Link",
             "type": "object",
             "required": [
@@ -137,7 +134,6 @@
             }
         },
         "analysisAttribute": {
-            "$id": "#/definitions/analysisAttribute",
             "type": "object",
             "title": "Analysis Attribute",
             "required": [
@@ -160,7 +156,6 @@
             }
         },
         "sequenceType": {
-            "$id": "#/definitions/sequenceType",
             "title": "Reference Alignment",
             "additionalProperties": true,
             "type": "object",
@@ -243,7 +238,6 @@
             }
         },
         "identifiers": {
-            "$id": "#/definitions/identifiers",
             "title": "Identifiers",
             "description": "Identifiers to be used in the International Nucleotide Sequence Database Collaboration (INSDC) namespace.",
             "type": "object",
@@ -296,7 +290,6 @@
             }
         },
         "reference": {
-            "$id": "#/definitions/reference",
             "additionalProperties": true,
             "type": "object",
             "properties": {
@@ -316,12 +309,11 @@
                     "title": "Center Namespace"
                 },
                 "identifiers": {
-                    "$ref": "#/definitions/identifiers"
+                    "$ref": "#/$defs/identifiers"
                 }
             }
         },
         "file": {
-            "$id": "#/definitions/file",
             "type": "object",
             "title": "File",
             "required": [
@@ -394,7 +386,6 @@
             }
         },
         "referenceAlignment": {
-            "$id": "#/definitions/referenceAlignment",
             "type": "object",
             "title": "Reference Alignment",
             "required": [
@@ -404,12 +395,11 @@
                 "referenceAlignment": {
                     "type": "object",
                     "title": "Reference Alignment",
-                    "$ref": "#/definitions/sequenceType"
+                    "$ref": "#/$defs/sequenceType"
                 }
             }
         },
         "sequenceAssembly": {
-            "$id": "#/definitions/sequenceAssembly",
             "type": "object",
             "title": "Sequence Assembly",
             "required": [
@@ -483,7 +473,6 @@
             }
         },
         "sequenceVariation": {
-            "$id": "#/definitions/sequenceVariation",
             "type": "object",
             "title": "Sequence Variation",
             "required": [
@@ -600,7 +589,6 @@
             }
         },
         "sequenceFlatFile": {
-            "$id": "#/definitions/sequenceFlatFile",
             "type": "object",
             "title": "Sequence Flat File",
             "required": [
@@ -624,7 +612,6 @@
             }
         },
         "sequenceAnnotation": {
-            "$id": "#/definitions/sequenceAnnotation",
             "type": "object",
             "title": "Sequence Annotation",
             "required": [
@@ -634,12 +621,11 @@
                 "sequenceAnnotation": {
                     "type": "object",
                     "title": "Sequence Annotation",
-                    "$ref": "#/definitions/sequenceType"
+                    "$ref": "#/$defs/sequenceType"
                 }
             }
         },
         "processedReads": {
-            "$id": "#/definitions/processedReads",
             "type": "object",
             "title": "Processed Reads",
             "required": [
@@ -649,12 +635,11 @@
                 "processedReads": {
                     "type": "object",
                     "title": "Processed Reads",
-                    "$ref": "#/definitions/sequenceType"
+                    "$ref": "#/$defs/sequenceType"
                 }
             }
         },
         "referenceSequence": {
-            "$id": "#/definitions/referenceSequence",
             "type": "object",
             "title": "Reference Sequence",
             "required": [
@@ -675,7 +660,6 @@
             }
         },
         "samplePhenotype": {
-            "$id": "#/definitions/samplePhenotype",
             "type": "object",
             "title": "Sample Phenotype",
             "required": [
@@ -696,7 +680,6 @@
             }
         },
         "genomeMap": {
-            "$id": "#/definitions/genomeMap",
             "type": "object",
             "title": "Genome Map",
             "required": [
@@ -727,7 +710,6 @@
             }
         },
         "amrAntibiogram": {
-            "$id": "#/definitions/amrAntibiogram",
             "type": "object",
             "title": "AMR Antibiogram",
             "required": [
@@ -748,7 +730,6 @@
             }
         },
         "pathogenAnalysis": {
-            "$id": "#/definitions/pathogenAnalysis",
             "type": "object",
             "title": "Pathogen Analysis",
             "required": [
@@ -769,7 +750,6 @@
             }
         },
         "transcriptomeAssembly": {
-            "$id": "#/definitions/transcriptomeAssembly",
             "type": "object",
             "title": "Transcriptome Assembly",
             "required": [
@@ -818,7 +798,6 @@
             }
         },
         "taxonomicReferenceSet": {
-            "$id": "#/definitions/taxonomicReferenceSet",
             "type": "object",
             "title": "Taxonomic Reference Set",
             "required": [
@@ -865,7 +844,6 @@
             }
         },
         "assemblyAnnotation": {
-            "$id": "#/definitions/assemblyAnnotation",
             "type": "object",
             "title": "Assembly Annotation",
             "required": [
@@ -875,7 +853,7 @@
                 "assemblyAnnotation": {
                     "type": "object",
                     "title": "Assembly Annotation",
-                    "$ref": "#/definitions/sequenceType"
+                    "$ref": "#/$defs/sequenceType"
                 }
             }
         }
@@ -896,43 +874,43 @@
             "title": "Analysis Type",
             "oneOf": [
                 {
-                    "$ref": "#/definitions/referenceAlignment"
+                    "$ref": "#/$defs/referenceAlignment"
                 },
                 {
-                    "$ref": "#/definitions/sequenceVariation"
+                    "$ref": "#/$defs/sequenceVariation"
                 },
                 {
-                    "$ref": "#/definitions/sequenceAssembly"
+                    "$ref": "#/$defs/sequenceAssembly"
                 },
                 {
-                    "$ref": "#/definitions/sequenceFlatFile"
+                    "$ref": "#/$defs/sequenceFlatFile"
                 },
                 {
-                    "$ref": "#/definitions/sequenceAnnotation"
+                    "$ref": "#/$defs/sequenceAnnotation"
                 },
                 {
-                    "$ref": "#/definitions/referenceSequence"
+                    "$ref": "#/$defs/referenceSequence"
                 },
                 {
-                    "$ref": "#/definitions/samplePhenotype"
+                    "$ref": "#/$defs/samplePhenotype"
                 },
                 {
-                    "$ref": "#/definitions/processedReads"
+                    "$ref": "#/$defs/processedReads"
                 },
                 {
-                    "$ref": "#/definitions/amrAntibiogram"
+                    "$ref": "#/$defs/amrAntibiogram"
                 },
                 {
-                    "$ref": "#/definitions/pathogenAnalysis"
+                    "$ref": "#/$defs/pathogenAnalysis"
                 },
                 {
-                    "$ref": "#/definitions/transcriptomeAssembly"
+                    "$ref": "#/$defs/transcriptomeAssembly"
                 },
                 {
-                    "$ref": "#/definitions/taxonomicReferenceSet"
+                    "$ref": "#/$defs/taxonomicReferenceSet"
                 },
                 {
-                    "$ref": "#/definitions/assemblyAnnotation"
+                    "$ref": "#/$defs/assemblyAnnotation"
                 }
             ]
         },
@@ -955,19 +933,19 @@
         "studyRef": {
             "title": "Study Reference",
             "description": "Identifies the associated parent study.",
-            "$ref": "#/definitions/reference"
+            "$ref": "#/$defs/reference"
         },
         "experimentRef": {
             "title": "Experiment Reference",
             "description": "Identifies the associated experiment.",
-            "$ref": "#/definitions/reference"
+            "$ref": "#/$defs/reference"
         },
         "sampleRef": {
             "title": "Sample Reference",
             "description": "Identifies the associated sample(s).",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/reference"
+                "$ref": "#/$defs/reference"
             }
         },
         "runRef": {
@@ -975,7 +953,7 @@
             "description": "Identifies the associated run.",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/reference"
+                "$ref": "#/$defs/reference"
             }
         },
         "analysisRef": {
@@ -983,14 +961,14 @@
             "description": "Identifies the associated analysis.",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/reference"
+                "$ref": "#/$defs/reference"
             }
         },
         "files": {
             "type": "array",
             "title": "Files",
             "items": {
-                "$ref": "#/definitions/file"
+                "$ref": "#/$defs/file"
             }
         },
         "analysisLinks": {
@@ -998,7 +976,7 @@
             "title": "Analysis Links",
             "description": "Links to resources related to this experiment or experiment set (publication, datasets, online databases). Used to encode URL links, Entrez links, and xref DB links. ",
             "items": {
-                "$ref": "#/definitions/Links"
+                "$ref": "#/$defs/Links"
             }
         },
         "analysisAttributes": {
@@ -1006,7 +984,7 @@
             "title": "Analysis Attributes",
             "description": "Properties and attributes of the data set. These can be entered as free-form tag-value pairs. Submitters may be asked to follow a community established ontology when describing the work.",
             "items": {
-                "$ref": "#/definitions/analysisAttribute"
+                "$ref": "#/$defs/analysisAttribute"
             }
         }
     }

--- a/metadata_backend/helpers/schemas/ena_dac.json
+++ b/metadata_backend/helpers/schemas/ena_dac.json
@@ -1,23 +1,22 @@
 {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "DAC - Data Access Committee",
-    "definitions": {
+    "$defs": {
         "Links": {
-            "$id": "#/definitions/Links",
             "title": "Link Type",
             "oneOf": [
                 {
-                    "$ref": "#/definitions/xrefLink"
+                    "$ref": "#/$defs/xrefLink"
                 },
                 {
-                    "$ref": "#/definitions/urlLink"
+                    "$ref": "#/$defs/urlLink"
                 },
                 {
-                    "$ref": "#/definitions/entrezLink"
+                    "$ref": "#/$defs/entrezLink"
                 }
             ]
         },
         "xrefLink": {
-            "$id": "#/definitions/xrefLink",
             "title": "XRef Link",
             "type": "object",
             "required": [
@@ -43,7 +42,6 @@
             }
         },
         "urlLink": {
-            "$id": "#/definitions/urlLink",
             "title": "URL Link",
             "type": "object",
             "required": [
@@ -65,7 +63,6 @@
             }
         },
         "entrezLink": {
-            "$id": "#/definitions/entrezLink",
             "title": "Entrez Link",
             "type": "object",
             "required": [
@@ -137,7 +134,6 @@
             }
         },
         "contact": {
-            "$id": "#/definitions/contact",
             "type": "object",
             "title": "Contact",
             "required": [
@@ -175,7 +171,6 @@
             }
         },
         "dacAttribute": {
-            "$id": "#/definitions/dacAttribute",
             "type": "object",
             "title": "DAC Attribute",
             "required": [
@@ -209,13 +204,13 @@
             "title": "Contacts",
             "description": "List of persons that ar part of the Data Access Committee. At least one main contact is required.",
             "items": {
-                "$ref": "#/definitions/contact"
+                "$ref": "#/$defs/contact"
             },
             "minItems": 1,
             "contains": {
                 "allOf": [
                     {
-                        "$ref": "#/definitions/contact"
+                        "$ref": "#/$defs/contact"
                     },
                     {
                         "required": [
@@ -241,7 +236,7 @@
             "title": "DAC Links",
             "description": "Links to resources related to this experiment or experiment set (publication, datasets, online databases). Used to encode URL links, Entrez links, and xref DB links. ",
             "items": {
-                "$ref": "#/definitions/Links"
+                "$ref": "#/$defs/Links"
             }
         },
         "dacAttributes": {
@@ -249,7 +244,7 @@
             "title": "Study Attributes",
             "description": "Properties and attributes of the DAC. These can be entered as free-form tag-value pairs. Submitters may be asked to follow a community established ontology when describing the work.",
             "items": {
-                "$ref": "#/definitions/dacAttribute"
+                "$ref": "#/$defs/dacAttribute"
             }
         }
     }

--- a/metadata_backend/helpers/schemas/ena_dataset.json
+++ b/metadata_backend/helpers/schemas/ena_dataset.json
@@ -1,23 +1,22 @@
 {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "Dataset",
-    "definitions": {
+    "$defs": {
         "Links": {
-            "$id": "#/definitions/Links",
             "title": "Link Type",
             "oneOf": [
                 {
-                    "$ref": "#/definitions/xrefLink"
+                    "$ref": "#/$defs/xrefLink"
                 },
                 {
-                    "$ref": "#/definitions/urlLink"
+                    "$ref": "#/$defs/urlLink"
                 },
                 {
-                    "$ref": "#/definitions/entrezLink"
+                    "$ref": "#/$defs/entrezLink"
                 }
             ]
         },
         "xrefLink": {
-            "$id": "#/definitions/xrefLink",
             "title": "XRef Link",
             "type": "object",
             "required": [
@@ -43,7 +42,6 @@
             }
         },
         "urlLink": {
-            "$id": "#/definitions/urlLink",
             "title": "URL Link",
             "type": "object",
             "required": [
@@ -65,7 +63,6 @@
             }
         },
         "entrezLink": {
-            "$id": "#/definitions/entrezLink",
             "title": "Entrez Link",
             "type": "object",
             "required": [
@@ -137,7 +134,6 @@
             }
         },
         "datasetAttribute": {
-            "$id": "#/definitions/datasetAttribute",
             "type": "object",
             "title": "Dataset Attribute",
             "required": [
@@ -160,7 +156,6 @@
             }
         },
         "identifiers": {
-            "$id": "#/definitions/identifiers",
             "title": "Identifiers",
             "description": "Identifiers to be used in the International Nucleotide Sequence Database Collaboration (INSDC) namespace.",
             "type": "object",
@@ -213,7 +208,6 @@
             }
         },
         "reference": {
-            "$id": "#/definitions/reference",
             "additionalProperties": true,
             "type": "object",
             "properties": {
@@ -233,7 +227,7 @@
                     "title": "Center Namespace"
                 },
                 "identifiers": {
-                    "$ref": "#/definitions/identifiers"
+                    "$ref": "#/$defs/identifiers"
                 }
             }
         }
@@ -283,14 +277,14 @@
         "policyRef": {
             "title": "Policy Reference",
             "description": "Identifies the data access policy controlling this Dataset.",
-            "$ref": "#/definitions/reference"
+            "$ref": "#/$defs/reference"
         },
         "runRef": {
             "title": "Run Reference",
             "description": "Identifies the Runs which are part of this Dataset.",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/reference"
+                "$ref": "#/$defs/reference"
             }
         },
         "analysisRef": {
@@ -298,7 +292,7 @@
             "description": "Identifies the Analyses which are part of this Dataset.",
             "type": "array",
             "items": {
-                "$ref": "#/definitions/reference"
+                "$ref": "#/$defs/reference"
             }
         },
         "datasetLinks": {
@@ -306,7 +300,7 @@
             "title": "Dataset Links",
             "description": "Used to encode URL links, Entrez links, and xref DB links. These are links used to cross reference with other relevant resources.",
             "items": {
-                "$ref": "#/definitions/Links"
+                "$ref": "#/$defs/Links"
             }
         },
         "datasetAttributes": {
@@ -314,7 +308,7 @@
             "title": "Dataset Attributes",
             "description": "Properties and attributes of the data set. These can be entered as free-form tag-value pairs. Submitters may be asked to follow a community established ontology when describing the work.",
             "items": {
-                "$ref": "#/definitions/datasetAttribute"
+                "$ref": "#/$defs/datasetAttribute"
             }
         }
     }

--- a/metadata_backend/helpers/schemas/ena_experiment.json
+++ b/metadata_backend/helpers/schemas/ena_experiment.json
@@ -1,23 +1,22 @@
 {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "Experiment",
-    "definitions": {
+    "$defs": {
         "Links": {
-            "$id": "#/definitions/Links",
             "title": "Link Type",
             "oneOf": [
                 {
-                    "$ref": "#/definitions/xrefLink"
+                    "$ref": "#/$defs/xrefLink"
                 },
                 {
-                    "$ref": "#/definitions/urlLink"
+                    "$ref": "#/$defs/urlLink"
                 },
                 {
-                    "$ref": "#/definitions/entrezLink"
+                    "$ref": "#/$defs/entrezLink"
                 }
             ]
         },
         "xrefLink": {
-            "$id": "#/definitions/xrefLink",
             "title": "XRef Link",
             "type": "object",
             "required": [
@@ -43,7 +42,6 @@
             }
         },
         "urlLink": {
-            "$id": "#/definitions/urlLink",
             "title": "URL Link",
             "type": "object",
             "required": [
@@ -65,7 +63,6 @@
             }
         },
         "entrezLink": {
-            "$id": "#/definitions/entrezLink",
             "title": "Entrez Link",
             "type": "object",
             "required": [
@@ -137,7 +134,6 @@
             }
         },
         "experimentAttribute": {
-            "$id": "#/definitions/experimentAttribute",
             "type": "object",
             "title": "Experiment Attribute",
             "required": [
@@ -160,7 +156,6 @@
             }
         },
         "pool": {
-            "$id": "#/definitions/pool",
             "title": "List of group/pool/multiplex sample members",
             "type": "object",
             "additionalProperties": false,
@@ -173,19 +168,18 @@
                         "defaultMember": {
                             "type": "object",
                             "title": "Default Member",
-                            "$ref": "#/definitions/poolMemberType"
+                            "$ref": "#/$defs/poolMemberType"
                         },
                         "member": {
                             "type": "object",
                             "title": "Member",
-                            "$ref": "#/definitions/poolMemberType"
+                            "$ref": "#/$defs/poolMemberType"
                         }
                     }
                 }
             }
         },
         "poolMemberType": {
-            "$id": "#/definitions/poolMemberType",
             "title": "Pool Member Type",
             "type": "object",
             "properties": {
@@ -204,7 +198,6 @@
             }
         },
         "libraryType": {
-            "$id": "#/definitions/libraryType",
             "type": "object",
             "title": "Library used for experiment design.",
             "required": [
@@ -223,11 +216,11 @@
                     "description": "Pick a sample to associate this experiment with. The sample may be an individual or a pool, depending on how it is specified.",
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/pool"
+                            "$ref": "#/$defs/pool"
                         },
                         {
                             "title": "Individual Sample",
-                            "$ref": "#/definitions/reference"
+                            "$ref": "#/$defs/reference"
                         }
                     ]
                 },
@@ -553,7 +546,6 @@
             }
         },
         "processingType": {
-            "$id": "#/definitions/processingType",
             "type": "object",
             "title": "Processing Type",
             "description": "Information about the processing type such as pipeline and sequencing directives.",
@@ -646,7 +638,6 @@
             }
         },
         "identifiers": {
-            "$id": "#/definitions/identifiers",
             "title": "Identifiers",
             "description": "Identifiers to be used in the International Nucleotide Sequence Database Collaboration (INSDC) namespace.",
             "type": "object",
@@ -699,7 +690,6 @@
             }
         },
         "reference": {
-            "$id": "#/definitions/reference",
             "additionalProperties": false,
             "type": "object",
             "properties": {
@@ -719,7 +709,7 @@
                     "title": "Center Namespace"
                 },
                 "identifiers": {
-                    "$ref": "#/definitions/identifiers"
+                    "$ref": "#/$defs/identifiers"
                 }
             }
         }
@@ -814,23 +804,23 @@
         "studyRef": {
             "title": "Study Reference",
             "description": "Identifies the associated study.",
-            "$ref": "#/definitions/reference"
+            "$ref": "#/$defs/reference"
         },
         "design": {
             "title": "Design",
             "description": "The library design including library properties, layout, protocol, targeting information, and spot and gap descriptors. ",
-            "$ref": "#/definitions/libraryType"
+            "$ref": "#/$defs/libraryType"
         },
         "processing": {
             "title": "Processing",
-            "$ref": "#/definitions/processingType"
+            "$ref": "#/$defs/processingType"
         },
         "experimentLinks": {
             "type": "array",
             "title": "Experiment Links",
             "description": "Links to resources related to this experiment or experiment set (publication, datasets, online databases). Used to encode URL links, Entrez links, and xref DB links. ",
             "items": {
-                "$ref": "#/definitions/Links"
+                "$ref": "#/$defs/Links"
             }
         },
         "experimentAttributes": {
@@ -838,7 +828,7 @@
             "title": "Experiment Attributes",
             "description": "Properties and attributes of the data set. These can be entered as free-form tag-value pairs. Submitters may be asked to follow a community established ontology when describing the work.",
             "items": {
-                "$ref": "#/definitions/experimentAttribute"
+                "$ref": "#/$defs/experimentAttribute"
             }
         }
     }

--- a/metadata_backend/helpers/schemas/ena_policy.json
+++ b/metadata_backend/helpers/schemas/ena_policy.json
@@ -1,23 +1,22 @@
 {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "Policy",
-    "definitions": {
+    "$defs": {
         "Links": {
-            "$id": "#/definitions/Links",
             "title": "Link Type",
             "oneOf": [
                 {
-                    "$ref": "#/definitions/xrefLink"
+                    "$ref": "#/$defs/xrefLink"
                 },
                 {
-                    "$ref": "#/definitions/urlLink"
+                    "$ref": "#/$defs/urlLink"
                 },
                 {
-                    "$ref": "#/definitions/entrezLink"
+                    "$ref": "#/$defs/entrezLink"
                 }
             ]
         },
         "xrefLink": {
-            "$id": "#/definitions/xrefLink",
             "title": "XRef Link",
             "type": "object",
             "required": [
@@ -43,7 +42,6 @@
             }
         },
         "urlLink": {
-            "$id": "#/definitions/urlLink",
             "title": "URL Link",
             "type": "object",
             "required": [
@@ -65,7 +63,6 @@
             }
         },
         "entrezLink": {
-            "$id": "#/definitions/entrezLink",
             "title": "Entrez Link",
             "type": "object",
             "required": [
@@ -137,7 +134,6 @@
             }
         },
         "dataUseType": {
-            "$id": "#/definitions/dataUseType",
             "type": "object",
             "title": "Data Use Type",
             "description": "Data Use ontology",
@@ -157,7 +153,7 @@
                             "modifier": {
                                 "description": "Describes modifiers to the Data Use Restriction.",
                                 "title": "Modifier",
-                                "$ref": "#/definitions/xrefLink"
+                                "$ref": "#/$defs/xrefLink"
                             },
                             "url": {
                                 "type": "string",
@@ -188,7 +184,6 @@
             }
         },
         "policyAttribute": {
-            "$id": "#/definitions/policyAttribute",
             "type": "object",
             "title": "Policy Attribute",
             "required": [
@@ -211,7 +206,6 @@
             }
         },
         "identifiers": {
-            "$id": "#/definitions/identifiers",
             "title": "Identifiers",
             "description": "Identifiers to be used in the International Nucleotide Sequence Database Collaboration (INSDC) namespace.",
             "type": "object",
@@ -264,7 +258,6 @@
             }
         },
         "reference": {
-            "$id": "#/definitions/reference",
             "additionalProperties": true,
             "type": "object",
             "properties": {
@@ -284,7 +277,7 @@
                     "title": "Center Namespace"
                 },
                 "identifiers": {
-                    "$ref": "#/definitions/identifiers"
+                    "$ref": "#/$defs/identifiers"
                 }
             }
         }
@@ -304,7 +297,7 @@
         "dacRef": {
             "title": "Data Access Committee Reference",
             "description": "Identifies the data access committee to which this Policy pertains.",
-            "$ref": "#/definitions/reference"
+            "$ref": "#/$defs/reference"
         },
         "policy": {
             "title": "Policy",
@@ -345,7 +338,7 @@
             "type": "array",
             "description": "Data use ontologies (DUO) related to the Policy. More information at: https://github.com/EBISPOT/DUO .",
             "items": {
-                "$ref": "#/definitions/dataUseType"
+                "$ref": "#/$defs/dataUseType"
             },
             "title": "Data Use Ontology"
         },
@@ -354,7 +347,7 @@
             "title": "Policy Links",
             "description": "Links to resources related to this experiment or experiment set (publication, datasets, online databases). Used to encode URL links, Entrez links, and xref DB links. ",
             "items": {
-                "$ref": "#/definitions/Links"
+                "$ref": "#/$defs/Links"
             }
         },
         "policyAttributes": {
@@ -362,7 +355,7 @@
             "title": "Policy Attributes",
             "description": "Properties and attributes of the Policy. These can be entered as free-form tag-value pairs. Submitters may be asked to follow a community established ontology when describing the work.",
             "items": {
-                "$ref": "#/definitions/policyAttribute"
+                "$ref": "#/$defs/policyAttribute"
             }
         }
     }

--- a/metadata_backend/helpers/schemas/ena_run.json
+++ b/metadata_backend/helpers/schemas/ena_run.json
@@ -1,23 +1,22 @@
 {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "Run",
-    "definitions": {
+    "$defs": {
         "Links": {
-            "$id": "#/definitions/Links",
             "title": "Link Type",
             "oneOf": [
                 {
-                    "$ref": "#/definitions/xrefLink"
+                    "$ref": "#/$defs/xrefLink"
                 },
                 {
-                    "$ref": "#/definitions/urlLink"
+                    "$ref": "#/$defs/urlLink"
                 },
                 {
-                    "$ref": "#/definitions/entrezLink"
+                    "$ref": "#/$defs/entrezLink"
                 }
             ]
         },
         "xrefLink": {
-            "$id": "#/definitions/xrefLink",
             "title": "XRef Link",
             "type": "object",
             "required": [
@@ -43,7 +42,6 @@
             }
         },
         "urlLink": {
-            "$id": "#/definitions/urlLink",
             "title": "URL Link",
             "type": "object",
             "required": [
@@ -65,7 +63,6 @@
             }
         },
         "entrezLink": {
-            "$id": "#/definitions/entrezLink",
             "title": "Entrez Link",
             "type": "object",
             "required": [
@@ -137,7 +134,6 @@
             }
         },
         "runAttribute": {
-            "$id": "#/definitions/runAttribute",
             "type": "object",
             "title": "Run Attribute",
             "required": [
@@ -160,7 +156,6 @@
             }
         },
         "processingType": {
-            "$id": "#/definitions/processingType",
             "type": "object",
             "title": "Processing Type",
             "description": "Information about the processing type such as pipeline and sequencing directives.",
@@ -253,7 +248,6 @@
             }
         },
         "identifiers": {
-            "$id": "#/definitions/identifiers",
             "title": "Identifiers",
             "description": "Identifiers to be used in the International Nucleotide Sequence Database Collaboration (INSDC) namespace.",
             "type": "object",
@@ -306,7 +300,6 @@
             }
         },
         "reference": {
-            "$id": "#/definitions/reference",
             "additionalProperties": true,
             "type": "object",
             "properties": {
@@ -326,12 +319,11 @@
                     "title": "Center Namespace"
                 },
                 "identifiers": {
-                    "$ref": "#/definitions/identifiers"
+                    "$ref": "#/$defs/identifiers"
                 }
             }
         },
         "file": {
-            "$id": "#/definitions/file",
             "type": "object",
             "title": "File",
             "required": [
@@ -545,7 +537,7 @@
             "maxItems": 1,
             "type": "array",
             "items": {
-                "$ref": "#/definitions/reference"
+                "$ref": "#/$defs/reference"
             }
         },
         "spotDescriptor": {
@@ -763,14 +755,14 @@
         "processing": {
             "title": "Processing",
             "type": "object",
-            "$ref": "#/definitions/processingType"
+            "$ref": "#/$defs/processingType"
         },
         "files": {
             "type": "array",
             "title": "Files",
             "description": "Data files associated with the Run.",
             "items": {
-                "$ref": "#/definitions/file"
+                "$ref": "#/$defs/file"
             }
         },
         "runLinks": {
@@ -778,7 +770,7 @@
             "title": "Run Links",
             "description": "Links to resources related to this experiment or experiment set (publication, datasets, online databases). Used to encode URL links, Entrez links, and xref DB links. ",
             "items": {
-                "$ref": "#/definitions/Links"
+                "$ref": "#/$defs/Links"
             }
         },
         "runAttributes": {
@@ -786,7 +778,7 @@
             "title": "Run Attributes",
             "description": "Properties and attributes of the data set. These can be entered as free-form tag-value pairs. Submitters may be asked to follow a community established ontology when describing the work.",
             "items": {
-                "$ref": "#/definitions/runAttribute"
+                "$ref": "#/$defs/runAttribute"
             }
         }
     }

--- a/metadata_backend/helpers/schemas/ena_sample.json
+++ b/metadata_backend/helpers/schemas/ena_sample.json
@@ -1,23 +1,22 @@
 {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "Sample",
-    "definitions": {
+    "$defs": {
         "Links": {
-            "$id": "#/definitions/Links",
             "title": "Link Type",
             "oneOf": [
                 {
-                    "$ref": "#/definitions/xrefLink"
+                    "$ref": "#/$defs/xrefLink"
                 },
                 {
-                    "$ref": "#/definitions/urlLink"
+                    "$ref": "#/$defs/urlLink"
                 },
                 {
-                    "$ref": "#/definitions/entrezLink"
+                    "$ref": "#/$defs/entrezLink"
                 }
             ]
         },
         "xrefLink": {
-            "$id": "#/definitions/xrefLink",
             "title": "XRef Link",
             "type": "object",
             "required": [
@@ -43,7 +42,6 @@
             }
         },
         "urlLink": {
-            "$id": "#/definitions/urlLink",
             "title": "URL Link",
             "type": "object",
             "required": [
@@ -65,7 +63,6 @@
             }
         },
         "entrezLink": {
-            "$id": "#/definitions/entrezLink",
             "title": "Entrez Link",
             "type": "object",
             "required": [
@@ -137,7 +134,6 @@
             }
         },
         "sampleAttribute": {
-            "$id": "#/definitions/sampleAttribute",
             "type": "object",
             "title": "Sample Attribute",
             "required": [
@@ -244,7 +240,7 @@
             "title": "Sample Links",
             "description": "Links to resources related to this experiment or experiment set (publication, datasets, online databases). Used to encode URL links, Entrez links, and xref DB links. ",
             "items": {
-                "$ref": "#/definitions/Links"
+                "$ref": "#/$defs/Links"
             }
         },
         "sampleAttributes": {
@@ -252,7 +248,7 @@
             "title": "Sample Attributes",
             "description": "Properties and attributes of a Sample.  These can be entered as free-form tag-value pairs. For certain studies, submitters may be asked to follow a community established ontology when describing the work.",
             "items": {
-                "$ref": "#/definitions/sampleAttribute"
+                "$ref": "#/$defs/sampleAttribute"
             }
         }
     }

--- a/metadata_backend/helpers/schemas/ena_study.json
+++ b/metadata_backend/helpers/schemas/ena_study.json
@@ -1,23 +1,22 @@
 {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "Study",
-    "definitions": {
+    "$defs": {
         "Links": {
-            "$id": "#/definitions/Links",
             "title": "Link Type",
             "oneOf": [
                 {
-                    "$ref": "#/definitions/xrefLink"
+                    "$ref": "#/$defs/xrefLink"
                 },
                 {
-                    "$ref": "#/definitions/urlLink"
+                    "$ref": "#/$defs/urlLink"
                 },
                 {
-                    "$ref": "#/definitions/entrezLink"
+                    "$ref": "#/$defs/entrezLink"
                 }
             ]
         },
         "xrefLink": {
-            "$id": "#/definitions/xrefLink",
             "title": "XRef Link",
             "type": "object",
             "required": [
@@ -43,7 +42,6 @@
             }
         },
         "urlLink": {
-            "$id": "#/definitions/urlLink",
             "title": "URL Link",
             "type": "object",
             "required": [
@@ -65,7 +63,6 @@
             }
         },
         "entrezLink": {
-            "$id": "#/definitions/entrezLink",
             "title": "Entrez Link",
             "type": "object",
             "required": [
@@ -137,7 +134,6 @@
             }
         },
         "studyAttribute": {
-            "$id": "#/definitions/studyAttribute",
             "type": "object",
             "title": "Study Attribute",
             "required": [
@@ -160,7 +156,6 @@
             }
         },
         "studyType": {
-            "$id": "#/definitions/studyType",
             "title": "Study Type",
             "description": "The Study type presents a controlled vocabulary for expressing the overall purpose of the Study.",
             "type": "string",
@@ -205,7 +200,7 @@
                     "type": "string"
                 },
                 "studyType": {
-                    "$ref": "#/definitions/studyType"
+                    "$ref": "#/$defs/studyType"
                 },
                 "studyAbstract": {
                     "title": "Study Abstract",
@@ -230,7 +225,7 @@
             "title": "Study Links",
             "description": "Links to resources related to this experiment or experiment set (publication, datasets, online databases). Used to encode URL links, Entrez links, and xref DB links. ",
             "items": {
-                "$ref": "#/definitions/Links"
+                "$ref": "#/$defs/Links"
             }
         },
         "studyAttributes": {
@@ -238,7 +233,7 @@
             "title": "Study Attributes",
             "description": "Properties and attributes of the Study. These can be entered as free-form tag-value pairs. For certain studies, submitters may be asked to follow a community established ontology when describing the work.",
             "items": {
-                "$ref": "#/definitions/studyAttribute"
+                "$ref": "#/$defs/studyAttribute"
             }
         },
         "center": {

--- a/metadata_backend/helpers/schemas/submission.json
+++ b/metadata_backend/helpers/schemas/submission.json
@@ -1,6 +1,8 @@
 {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Submission that contains submitted metadata objects",
+    "title": "Submission",
     "type": "object",
-    "title": "Submission schema containing submitted metadata objects",
     "required": [
         "name",
         "description",

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -154,7 +154,7 @@ class ParserTestCase(unittest.TestCase):
         bp_dataset_xml = self.load_file_to_text("bpdataset", "template_dataset.xml")
         bp_dataset_json = self.xml_parser.parse("bpdataset", bp_dataset_xml)
         self.assertEqual("Dataset_QoRIPbAPlP", bp_dataset_json["alias"])
-        self.assertEqual("1", bp_dataset_json["attributes"]["attribute"][0]["value"])
+        self.assertEqual("1", bp_dataset_json["attributes"][0]["value"])
         self.assertEqual(list, type(bp_dataset_json["datasetType"]))
 
     def test_bp_sample_is_parsed(self):
@@ -167,8 +167,8 @@ class ParserTestCase(unittest.TestCase):
         self.assertEqual(10, len(bp_sample_json))
         self.assertEqual("BiologicalBeing_qLNZYjYjyZ", bp_sample_json[0]["biologicalBeing"]["alias"])
         self.assertEqual("BiologicalBeing_qLNZYjYjyZ", bp_sample_json[2]["specimen"]["extractedFrom"]["refname"])
-        self.assertEqual(65.0, bp_sample_json[2]["specimen"]["attributes"]["numericAttribute"]["value"])
-        self.assertEqual("sample_preparation", bp_sample_json[4]["block"]["attributes"]["attribute"]["tag"])
+        self.assertEqual(65.0, bp_sample_json[2]["specimen"]["attributes"][3]["value"])
+        self.assertEqual("sample_preparation", bp_sample_json[4]["block"]["attributes"][0]["tag"])
         self.assertEqual(2, len(bp_sample_json[7]["slide"]["attributes"]["attributeSet"]["attributeSet"]))
 
     def test_error_raised_when_schema_not_found(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38, flake8, isort, pylint, mypy, docs, black, bandit
+envlist = py38, flake8, isort, pylint, mypy, docs, black, bandit, jsonschema
 skipsdist = True
 
 [pytest]
@@ -71,6 +71,13 @@ deps =
 # Stop after first failure
 commands = py.test -x --cov=metadata_backend tests/unit/
 
+[testenv:jsonschema]
+skip_install = true
+deps =
+    pre-commit
+commands =
+    pre-commit run check-metaschema --all-files
+
 [gh-actions]
 python =
-    3.8: black, isort, flake8, mypy, bandit, docs, py38
+    3.8: black, isort, flake8, mypy, bandit, docs, jsonschema, py38


### PR DESCRIPTION
### Description
<!-- Please include a summary of the change or any information deemed important. -->


### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
- Fixes #581
- Follow-up from JSON schema validator change in #579 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (possibly, as the JSON schema changed) 

### Changes Made
<!-- List changes made. -->
- Update schemas to JSON Schema 2020-12
- Add validation pre-commit for JSON schemas
- Add validation step to GitHub actions (actually tox)
- Removed `$id` fields, as they [should be a resolvable `URI`](https://json-schema.org/understanding-json-schema/structuring.html#retrieval-uri), not `self`. Validation fails when they are not resolvable
- Fix BP `sampleAttribute` parsing and schema


### Testing
<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests
- [x] Schema validation with `tox` and `pre-commit`, also running with GitHub workflows

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
