### PR TITLE
Feature/token auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Run integration tests with pytest
   - run integration tests with `--nocleanup` option 
 - Support for LifeScience groups as a substitute to CSC projects #548
+- Support for `Bearer` tokens, opening use of the API without frontend. Tokens are validated from the configured `OIDC_URL`
+- Made [PKCE](https://oidcrp.readthedocs.io/en/latest/add_on/pkce.html) settings explicit in `oidcrp` client auth
+- Added [DPOP](https://oidcrp.readthedocs.io/en/latest/add_on/dpop.html) placeholder settings for when AAI support has been implemented
 
 ### Changed
 - schema loader now matches schema files by exact match with schema #481. This means that schema file naming in metadata_backend/helpers/schemas now have rules:
@@ -52,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - remove `datacite.json` to render the form from `folder["doiInfo"]`
   - we removed `namedtype` for `contributors` and `creators` we therefore allow `additionalProperties`
   - `subjectsSchema` is a given by frontend thus we allow via `additionalProperties`
+- Removed `OIDC_ENABLED` testing variable which can cause misconfiguration incidents
 
 - remove unused code related to change from user to project ownership caused by faulty rebase or rollback of certain features #579
 

--- a/docs/dictionary/wordlist.txt
+++ b/docs/dictionary/wordlist.txt
@@ -182,6 +182,7 @@ docstrings
 doi
 doiinfo
 dois
+dpop
 dt
 dzongkha
 ean
@@ -397,6 +398,7 @@ minitems
 minlength
 minmatch
 mirna
+misconfiguration
 miseq
 mkdir
 mnase
@@ -489,6 +491,7 @@ pgm
 phenome
 physicalobject
 pipesection
+pkce
 pmc
 pmid
 pointlatitude

--- a/docs/submitter.rst
+++ b/docs/submitter.rst
@@ -152,6 +152,11 @@ The REST API is structured as follows:
 - `Query Endpoints` used for data retrieval (``submissions``, ``objects``, ``users``) uses HTTP ``GET``;
 - `Management Endpoints` used for handling data updates and deletion, makes use of HTTP ``PUT``, ``PATCH`` and ``DELETE``.
 
+The REST API is protected and can be accessed in two ways:
+
+- Performing a successful login at frontend, which creates a session
+- Using a ``Bearer`` token, which is issued by ``OIDC_URL``
+
 .. important:: A logged in user can only perform operations on the data it has associated.
                The information for the current user can be retrieved at ``/v1/users/current`` (the user ID is ``current``), and
                any additional operations on other users are rejected.

--- a/metadata_backend/api/auth.py
+++ b/metadata_backend/api/auth.py
@@ -47,6 +47,25 @@ class AccessHandler:
                     "response_types": self.auth_method.split(" "),
                     "scope": self.scope.split(" "),
                 },
+                "add_ons": {
+                    # Re-activate this once we have implemented support on AAI side
+                    # "dpop": {
+                    #     "function": "oidcrp.oauth2.add_on.dpop.add_support",
+                    #     "kwargs": {
+                    #         "signing_algorithms": [
+                    #             "ES256",
+                    #             "ES512",
+                    #         ]
+                    #     },
+                    # },
+                    "pkce": {
+                        "function": "oidcrp.oauth2.add_on.pkce.add_support",
+                        "kwargs": {
+                            "code_challenge_length": 64,
+                            "code_challenge_method": "S256",
+                        },
+                    },
+                },
             },
         }
         self.rph = RPHandler(self.oidc_url, client_configs=self.oidc_conf)

--- a/metadata_backend/api/auth.py
+++ b/metadata_backend/api/auth.py
@@ -203,7 +203,7 @@ class AccessHandler:
             project_data = {
                 "projectId": project_id,  # internal ID
                 "projectNumber": project["project_name"],  # human friendly
-                "origin": project["origin"],  # where this project came from: [csc | lifescience]
+                "projectOrigin": project["project_origin"],  # where this project came from: [csc | lifescience]
             }
             new_project_ids.append(project_data)
 
@@ -289,7 +289,7 @@ class AccessHandler:
                 projects.append(
                     {
                         "project_name": csc_project,
-                        "origin": "csc",
+                        "project_origin": "csc",
                     }
                 )
         if "eduperson_entitlement" in userinfo:
@@ -299,7 +299,7 @@ class AccessHandler:
                     {
                         # remove the oidc client information, as it's not important to the user
                         "project_name": group.split("#")[0],
-                        "origin": "lifescience",
+                        "project_origin": "lifescience",
                     }
                 )
 

--- a/metadata_backend/api/auth.py
+++ b/metadata_backend/api/auth.py
@@ -114,68 +114,22 @@ class AccessHandler:
             LOG.error(f"OIDC Callback failed with: {e}")
             raise web.HTTPUnauthorized(reason="Invalid OIDC callback.")
 
-        # User data is read from AAI /userinfo and is used to create the user model in database
-        user_data: Dict[str, Union[str, List[Dict[str, str]]]] = {
-            "user_id": "",
-            "real_name": f"{session['userinfo']['given_name']} {session['userinfo']['family_name']}",
-            "projects": [],
-        }
-        if "CSCUserName" in session["userinfo"]:
-            user_data["user_id"] = session["userinfo"]["CSCUserName"]
-        elif "remoteUserIdentifier" in session["userinfo"]:
-            user_data["user_id"] = session["userinfo"]["remoteUserIdentifier"]
-        elif "sub" in session["userinfo"]:
-            user_data["user_id"] = session["userinfo"]["sub"]
-        else:
-            LOG.error(
-                "User was authenticated, but they are missing mandatory claim CSCUserName, remoteUserIdentifier or sub."
-            )
-            raise web.HTTPUnauthorized(
-                reason="Could not set user, missing claim CSCUserName, remoteUserIdentifier or sub."
-            )
-
-        # Handle projects, they come in different formats depending on the service used.
-        # Current project sources: CSC projects, LS AAI groups
-        projects: List[Dict[str, str]] = []
-        if "sdSubmitProjects" in session["userinfo"]:
-            # CSC projects come in format "project1 project2"
-            csc_projects = session["userinfo"]["sdSubmitProjects"].split(" ")
-            for csc_project in csc_projects:
-                projects.append(
-                    {
-                        "project_name": csc_project,
-                        "origin": "csc",
-                    }
-                )
-        if "eduperson_entitlement" in session["userinfo"]:
-            # LS AAI groups come in format ["group1", "group2"]
-            for group in session["userinfo"]["eduperson_entitlement"]:
-                projects.append(
-                    {
-                        # remove the oidc client information, as it's not important to the user
-                        "project_name": group.split("#")[0],
-                        "origin": "lifescience",
-                    }
-                )
-
-        if len(projects) == 0:
-            # No project group information received, abort, as metadata-submitter
-            # object hierarchy depends on a project group to act as owner for objects
-            raise web.HTTPUnauthorized(reason="User is not a member of any project.")
+        # Parse data from the userinfo endpoint to create user data containing username, real name and projects/groups
+        user_data: Dict[str, Union[List[Dict[str, str]], str]] = await self._create_user_data(session["userinfo"])
+        projects: List[Dict[str, str]] = await self._get_projects_from_userinfo(session["userinfo"])
 
         # Process project external IDs into the database and return accession IDs back to user_data
         user_data["projects"] = await self._process_projects(req, projects)
 
+        # Create session
         browser_session = await aiohttp_session.new_session(req)
         browser_session["at"] = time.time()
-
-        # Inject cookie to this request to let _set_user work as expected.
         browser_session["oidc_state"] = params["state"]
         browser_session["access_token"] = session["token"]
-
         await self._set_user(req, browser_session, user_data)
-        response = web.HTTPSeeOther(f"{self.redirect}/home")
 
+        # Create response
+        response = web.HTTPSeeOther(f"{self.redirect}/home")
         response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
         response.headers["Pragma"] = "no-Cache"
         response.headers["Expires"] = "0"
@@ -235,7 +189,7 @@ class AccessHandler:
         req: Request,
         browser_session: aiohttp_session.Session,
         user_data: Dict[str, Union[List[Dict[str, str]], str]],
-    ) -> None:
+    ) -> str:
         """Set user in current session and return user id based on result of create_user.
 
         :raises: HTTPBadRequest in could not get user info from AAI OIDC
@@ -264,3 +218,69 @@ class AccessHandler:
             user_id = await operator.update_user(user_id, update_operation)
 
         browser_session["user_info"] = user_id
+        return user_id
+
+    async def _create_user_data(self, userinfo: Dict) -> Dict[str, Union[List[Dict[str, str]], str]]:
+        """Parse user profile data from userinfo endpoint response.
+
+        :param userinfo: dict from userinfo containing user profile
+        :returns: parsed user profile data containing username and real name
+        """
+        # User data is read from AAI /userinfo and is used to create the user model in database
+        user_data: Dict[str, Union[List[Dict[str, str]], str]] = {
+            "user_id": "",
+            "real_name": f"{userinfo['given_name']} {userinfo['family_name']}",
+            "projects": [],
+        }
+        if "CSCUserName" in userinfo:
+            user_data["user_id"] = userinfo["CSCUserName"]
+        elif "remoteUserIdentifier" in userinfo:
+            user_data["user_id"] = userinfo["remoteUserIdentifier"]
+        elif "sub" in userinfo:
+            user_data["user_id"] = userinfo["sub"]
+        else:
+            LOG.error(
+                "User was authenticated, but they are missing mandatory claim CSCUserName, remoteUserIdentifier or sub."
+            )
+            raise web.HTTPUnauthorized(
+                reason="Could not set user, missing claim CSCUserName, remoteUserIdentifier or sub."
+            )
+
+        return user_data
+
+    async def _get_projects_from_userinfo(self, userinfo: Dict) -> List[Dict[str, str]]:
+        """Parse projects and groups from userinfo endpoint response.
+
+        :param userinfo: dict from userinfo containing user profile
+        :returns: parsed projects and groups and their origins
+        """
+        # Handle projects, they come in different formats depending on the service used.
+        # Current project sources: CSC projects, LS AAI groups
+        projects: List[Dict[str, str]] = []
+        if "sdSubmitProjects" in userinfo:
+            # CSC projects come in format "project1 project2"
+            csc_projects = userinfo["sdSubmitProjects"].split(" ")
+            for csc_project in csc_projects:
+                projects.append(
+                    {
+                        "project_name": csc_project,
+                        "origin": "csc",
+                    }
+                )
+        if "eduperson_entitlement" in userinfo:
+            # LS AAI groups come in format ["group1", "group2"]
+            for group in userinfo["eduperson_entitlement"]:
+                projects.append(
+                    {
+                        # remove the oidc client information, as it's not important to the user
+                        "project_name": group.split("#")[0],
+                        "origin": "lifescience",
+                    }
+                )
+
+        if len(projects) == 0:
+            # No project group information received, abort, as metadata-submitter
+            # object hierarchy depends on a project group to act as owner for objects
+            raise web.HTTPUnauthorized(reason="User is not a member of any project.")
+
+        return projects

--- a/metadata_backend/conf/conf.py
+++ b/metadata_backend/conf/conf.py
@@ -143,9 +143,6 @@ swagger_static_path = Path(__file__).parent.parent / "swagger" / "index.html"
 
 
 # 5) Set up configurations for AAI server
-OIDC_ENABLED = False
-if "OIDC_URL" in os.environ and bool(os.getenv("OIDC_URL")):
-    OIDC_ENABLED = True
 
 aai_config = {
     "client_id": os.getenv("AAI_CLIENT_ID", "public"),

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -41,12 +41,12 @@ async def login(sess, sub, given, family):
         LOG.debug("Doing mock user login")
 
 
-async def get_user_data(sess):
+async def get_user_data(sess, headers={}):
     """Get current logged in user's data model.
 
     :param sess: HTTP session in which request call is made
     """
-    async with sess.get(f"{users_url}/current") as resp:
+    async with sess.get(f"{users_url}/current", headers=headers) as resp:
         LOG.debug("Get userdata")
         ans = await resp.json()
         assert resp.status == 200, f"HTTP Status code error {resp.status} {ans}"

--- a/tests/integration/mock_auth.py
+++ b/tests/integration/mock_auth.py
@@ -214,6 +214,18 @@ async def oidc_config(request: web.Request) -> web.Response:
         ],
         "userinfo_encryption_enc_values_supported": ["A128CBC-HS256"],
         "userinfo_signing_alg_values_supported": ["RS256", "RS384", "RS512", "HS256", "HS384", "HS512", "ES256"],
+        "dpop_signing_alg_values_supported": [
+            "none",
+            "RS256",
+            "RS384",
+            "RS512",
+            "HS256",
+            "HS384",
+            "HS512",
+            "ES256",
+            "ES384",
+            "ES512",
+        ],
         "request_object_signing_alg_values_supported": [
             "none",
             "RS256",

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -40,6 +40,17 @@ LOG.setLevel(logging.DEBUG)
 class TestUsers:
     """Test user operations."""
 
+    async def test_token_auth(self):
+        """Test token auth."""
+        async with aiohttp.ClientSession() as sess:
+            headers = {"Authorization": "Bearer test"}
+            user_data = await get_user_data(sess, headers=headers)
+            assert user_data["name"] == "Mock Family"
+            assert user_data["projects"][0]["projectNumber"] == "1000"
+            assert user_data["projects"][0]["origin"] == "csc"
+            assert user_data["projects"][5]["projectNumber"] == "test_namespace:test_root:group3"
+            assert user_data["projects"][5]["origin"] == "lifescience"
+
     async def test_multiple_user_submissions(self, client_logged_in):
         """Test different users can create a submission."""
         async with aiohttp.ClientSession() as sess:

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -47,9 +47,9 @@ class TestUsers:
             user_data = await get_user_data(sess, headers=headers)
             assert user_data["name"] == "Mock Family"
             assert user_data["projects"][0]["projectNumber"] == "1000"
-            assert user_data["projects"][0]["origin"] == "csc"
+            assert user_data["projects"][0]["projectOrigin"] == "csc"
             assert user_data["projects"][5]["projectNumber"] == "test_namespace:test_root:group3"
-            assert user_data["projects"][5]["origin"] == "lifescience"
+            assert user_data["projects"][5]["projectOrigin"] == "lifescience"
 
     async def test_multiple_user_submissions(self, client_logged_in):
         """Test different users can create a submission."""

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -329,9 +329,9 @@ class AccessHandlerPassTestCase(IsolatedAsyncioTestCase):
         userinfo = {"sdSubmitProjects": "1000", "eduperson_entitlement": ["group"]}
         projects = await AccessHandler._get_projects_from_userinfo(self, userinfo)
         assert projects[0]["project_name"] == "1000"
-        assert projects[0]["origin"] == "csc"
+        assert projects[0]["project_origin"] == "csc"
         assert projects[1]["project_name"] == "group"
-        assert projects[1]["origin"] == "lifescience"
+        assert projects[1]["project_origin"] == "lifescience"
 
     async def test_get_projects_from_userinfo_fail(self):
         """Test that no projects raises an error."""


### PR DESCRIPTION
### Description
Adds support for using the REST API with `Bearer` tokens issued by the configured `OIDC_URL`.

### Related issues
Closes #468 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### Changes Made

<!-- List changes made. -->

- refactored some `callback()` code in `auth.py` into functions, so that they can be re-used in the middleware
- added new case to middleware which checks for the existence of a `Bearer` token, and if one exists, it validates it at the configured `OIDC_URL` and gets back the user profile, which is used to create the user context for the duration of the request
- removed `OIDC_ENABLED` testing variable which can cause misconfiguration incidents
- set PKCE for `oidcrp` auth to be explicit
- added placeholder `DPOP` for when AAI support is ready

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests
- [x] Integration Tests
- [x] Manual Testing

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
