### PR TITLE
add healthcheck for connecting services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,7 @@ MONGO_SSL_CA=/tls/cacert
 MONGO_SSL_CLIENT_CERT_KEY=/tls/combined
 
 # doi
-DOI_API=http://mockdoi:8001/dois
+DOI_API=http://mockdoi:8001
 DOI_PREFIX=10.xxxx
 DOI_USER=user
 DOI_KEY=key

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for `Bearer` tokens, opening use of the API without frontend. Tokens are validated from the configured `OIDC_URL`
 - Made [PKCE](https://oidcrp.readthedocs.io/en/latest/add_on/pkce.html) settings explicit in `oidcrp` client auth
 - Added [DPOP](https://oidcrp.readthedocs.io/en/latest/add_on/dpop.html) placeholder settings for when AAI support has been implemented
+- Add advanced health checks for Datacite, REMS and Metax and performance checks for API response #585
 
 ### Changed
 - schema loader now matches schema files by exact match with schema #481. This means that schema file naming in metadata_backend/helpers/schemas now have rules:

--- a/metadata_backend/api/health.py
+++ b/metadata_backend/api/health.py
@@ -8,12 +8,30 @@ from aiohttp.web import Request, Response
 from motor.motor_asyncio import AsyncIOMotorClient
 from pymongo.errors import ConnectionFailure
 
+from metadata_backend.api.auth import AAIServiceHandler
+
 from ..conf.conf import url
 from ..helpers.logger import LOG
+from ..services.datacite_service_handler import DataciteServiceHandler
+from ..services.metax_service_handler import MetaxServiceHandler
+from ..services.rems_service_handler import RemsServiceHandler
 
 
 class HealthHandler:
     """Handler for health check."""
+
+    def __init__(
+        self,
+        metax_handler: MetaxServiceHandler,
+        datacite_handler: DataciteServiceHandler,
+        rems_handler: RemsServiceHandler,
+        aai_handler: AAIServiceHandler,
+    ) -> None:
+        """Endpoints should have access to metax and datacite services."""
+        self.metax_handler = metax_handler
+        self.datacite_handler = datacite_handler
+        self.rems_handler = rems_handler
+        self.aai_handler = aai_handler
 
     async def get_health_status(self, _: Request) -> Response:
         """Check health status of the application and return a JSON object portraying the status.
@@ -30,9 +48,27 @@ class HealthHandler:
             services["database"] = {"status": "Ok"} if conn < 1000 else {"status": "Degraded"}
         else:
             services["database"] = {"status": "Down"}
+
+        # Determine the status of loaded services
+
+        services["datacite"] = await self.datacite_handler._healtcheck()
+        services["rems"] = await self.rems_handler._healtcheck()
+        services["metax"] = await self.metax_handler._healtcheck()
+        services["aai"] = await self.aai_handler._healtcheck()
+
+        full_status["status"] = "Ok"
+
         # General service status
-        full_status["status"] = "Ok" if services["database"]["status"] == "Ok" else "Partially down"
+
+        for service in services.values():
+            if service["status"] in ["Down", "Error"]:
+                full_status["status"] = "Partially down"
+                break
+            if service["status"] == "Degraded":
+                full_status["status"] = "Degraded"
+
         full_status["services"] = services
+
         LOG.info("Health status collected.")
 
         return web.Response(

--- a/metadata_backend/server.py
+++ b/metadata_backend/server.py
@@ -10,7 +10,7 @@ import uvloop
 from aiohttp import web
 from cryptography.fernet import Fernet
 
-from .api.auth import AccessHandler
+from .api.auth import AAIServiceHandler, AccessHandler
 from .api.handlers.object import ObjectAPIHandler
 from .api.handlers.rems_proxy import RemsAPIHandler
 from .api.handlers.restapi import RESTAPIHandler
@@ -67,6 +67,7 @@ async def init(
     metax_handler = MetaxServiceHandler()
     datacite_handler = DataciteServiceHandler()
     rems_handler = RemsServiceHandler()
+    aai_handler = AAIServiceHandler()
 
     async def close_http_clients(_: web.Application) -> None:
         """Close http client session."""
@@ -150,7 +151,12 @@ async def init(
     ]
     server.add_routes(aai_routes)
     LOG.info("AAI routes loaded")
-    _health = HealthHandler()
+    _health = HealthHandler(
+        metax_handler=metax_handler,
+        datacite_handler=datacite_handler,
+        rems_handler=rems_handler,
+        aai_handler=aai_handler,
+    )
     health_routes = [
         web.get("/health", _health.get_health_status),
     ]

--- a/metadata_backend/services/service_handler.py
+++ b/metadata_backend/services/service_handler.py
@@ -2,6 +2,7 @@
 
 It provides a http client with optional basic auth, and requests that retry automatically and come with error handling
 """
+from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Union
 
 from aiohttp import BasicAuth, ClientSession, ClientTimeout
@@ -37,7 +38,7 @@ class ServiceClientError(HTTPError):
         HTTPError.__init__(self, **kwargs)
 
 
-class ServiceHandler:
+class ServiceHandler(ABC):
     """General service class handler to have similar implementation between services.
 
     Classes inheriting should set the service_name and base_url
@@ -98,6 +99,10 @@ class ServiceHandler:
         """Override in subclass and return formatted error message."""
         return error
 
+    @abstractmethod
+    async def _healtcheck(self) -> Dict:
+        """Override in subclass and return formatted status message."""
+
     @retry(total_tries=5)
     async def _request(
         self,
@@ -115,7 +120,7 @@ class ServiceHandler:
         :param path: When requesting to self.base_url, provide only the path (shortcut).
         :param params: URL parameters, must be url encoded
         :param json_data: Dict with request data
-        :param timeout: Request timeout
+        :param timeout: Request timeout in seconds
         :returns: Response body parsed as JSON
         """
         if not self.enabled:

--- a/tests/integration/conf.py
+++ b/tests/integration/conf.py
@@ -65,7 +65,7 @@ publish_url = f"{base_url}{API_PREFIX}/publish"
 schemas_url = f"{base_url}{API_PREFIX}/schemas"
 metax_url = f"{os.getenv('METAX_URL', 'http://localhost:8002')}"
 metax_api = f"{metax_url}/rest/v2/datasets"
-datacite_url = f"{os.getenv('DOI_API', 'http://localhost:8001/dois')}"
+datacite_url = f"{os.getenv('DOI_API', 'http://localhost:8001')}"
 auth = aiohttp.BasicAuth(os.getenv("METAX_USER", "sd"), os.getenv("METAX_PASS", "test"))
 # to form direct contact to db with eg create_submission()
 DATABASE = os.getenv("MONGO_DATABASE", "default")

--- a/tests/integration/mock_doi_api.py
+++ b/tests/integration/mock_doi_api.py
@@ -171,9 +171,15 @@ async def delete(req: web.Request) -> web.Response:
     return web.json_response(status=204)
 
 
+async def heartbeat(req: web.Request) -> web.Response:
+    """DOI heartbeat endpoint."""
+    return web.Response(status=200, text="OK")
+
+
 async def init() -> web.Application:
     """Start server."""
     app = web.Application()
+    app.router.add_get("/heartbeat", heartbeat)
     app.router.add_get("/dois/{id:.*}", get)
     app.router.add_post("/dois", create)
     app.router.add_put("/dois/{id:.*}", update)

--- a/tests/integration/mock_metax_api.py
+++ b/tests/integration/mock_metax_api.py
@@ -41,7 +41,18 @@ async def get_root(req: web.Request) -> web.Response:
     :params req: HTTP request with data for Metax dataset
     :return: HTTPNoContent
     """
+    if req.method == "HEAD":
+        return web.HTTPOk(body=None)
     return web.HTTPNoContent()
+
+
+async def ping_pong(req: web.Request) -> web.Response:
+    """Mock endpoint for testing server responds.
+
+    :params req: HTTP request with data for Metax dataset
+    :return: HTTPNoContent
+    """
+    return web.HTTPOk(body="pong")
 
 
 async def get_dataset(req: web.Request) -> web.Response:
@@ -369,7 +380,8 @@ async def init() -> web.Application:
     """Start server."""
     app = web.Application()
     api_routes = [
-        web.get("/", get_root),
+        web.get("/", get_root, allow_head=True),
+        web.get("/watchman/ping/", ping_pong),
         web.post("/rest/v2/datasets", post_dataset),
         web.put("/rest/v2/datasets/{metax_id}", update_dataset),
         web.delete("/rest/v2/datasets/{metax_id}", delete_dataset),

--- a/tests/integration/mock_rems_api.py
+++ b/tests/integration/mock_rems_api.py
@@ -301,9 +301,21 @@ async def post_catalogue_item(request: web.Request) -> web.Response:
     return web.json_response(data={"success": True, "id": catalogue_id})
 
 
+async def get_health(request: web.Request) -> web.Response:
+    """REMS create health status."""
+    healthy_response = {
+        "healthy": True,
+        "version": {"version": "v2.29-0-g16fbe58a7", "revision": "testing"},
+        "latest-event": "2022-09-22T00:04:08.554Z",
+    }
+
+    return web.json_response(data=healthy_response)
+
+
 async def init() -> web.Application:
     """Start server."""
     app = web.Application()
+    app.router.add_get("/api/health", get_health)
     app.router.add_get("/api/workflows", get_workflows)
     app.router.add_get("/api/workflows/{workflow_id}", get_workflow)
     app.router.add_get("/api/licenses", get_licenses)

--- a/tests/integration/test_bigpicture.py
+++ b/tests/integration/test_bigpicture.py
@@ -48,12 +48,12 @@ class TestBigPicture:
         submission_id = await publish_submission(client_logged_in, submission_id)
 
         # check that datacite has references between datasets and study
-        async with client_logged_in.get(f"{datacite_url}/{bpdataset['doi']}") as datacite_resp:
+        async with client_logged_in.get(f"{datacite_url}/dois/{bpdataset['doi']}") as datacite_resp:
             assert datacite_resp.status == 200, f"HTTP Status code error, got {datacite_resp.status}"
             datacite_res = await datacite_resp.json()
             bpdataset = datacite_res
 
-        async with client_logged_in.get(f"{datacite_url}/{study['doi']}") as datacite_resp:
+        async with client_logged_in.get(f"{datacite_url}/dois/{study['doi']}") as datacite_resp:
             assert datacite_resp.status == 200, f"HTTP Status code error, got {datacite_resp.status}"
             datacite_res = await datacite_resp.json()
             study = datacite_res

--- a/tests/integration/test_submissions.py
+++ b/tests/integration/test_submissions.py
@@ -323,15 +323,15 @@ class TestSubmissionOperations:
             assert len(res["metadataObjects"]) == 4, "submission metadataObjects content mismatch"
 
         # check that datacite has references between datasets and study
-        async with client_logged_in.get(f"{datacite_url}/{ds_1['doi']}") as datacite_resp:
+        async with client_logged_in.get(f"{datacite_url}/dois/{ds_1['doi']}") as datacite_resp:
             assert datacite_resp.status == 200, f"HTTP Status code error, got {datacite_resp.status}"
             datacite_res = await datacite_resp.json()
             ds_1 = datacite_res
-        async with client_logged_in.get(f"{datacite_url}/{ds_2['doi']}") as datacite_resp:
+        async with client_logged_in.get(f"{datacite_url}/dois/{ds_2['doi']}") as datacite_resp:
             assert datacite_resp.status == 200, f"HTTP Status code error, got {datacite_resp.status}"
             datacite_res = await datacite_resp.json()
             ds_2 = datacite_res
-        async with client_logged_in.get(f"{datacite_url}/{study['doi']}") as datacite_resp:
+        async with client_logged_in.get(f"{datacite_url}/dois/{study['doi']}") as datacite_resp:
             assert datacite_resp.status == 200, f"HTTP Status code error, got {datacite_resp.status}"
             datacite_res = await datacite_resp.json()
             study = datacite_res

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -40,7 +40,7 @@ LOG.setLevel(logging.DEBUG)
 class TestUsers:
     """Test user operations."""
 
-    async def test_token_auth(self):
+    async def test_token_auth(self, client_logged_in):
         """Test token auth."""
         async with aiohttp.ClientSession() as sess:
             headers = {"Authorization": "Bearer test"}

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -17,7 +17,16 @@ class HealthTestCase(AioHTTPTestCase):
 
     async def setUpAsync(self):
         """Configure values and patches for testing."""
-        self.health_status = {"services": {"database": {"status": "Ok"}}, "status": "Ok"}
+        self.health_status = {
+            "services": {
+                "database": {"status": "Ok"},
+                "datacite": {"status": "Down"},
+                "metax": {"status": "Down"},
+                "rems": {"status": "Down"},
+                "aai": {"status": "Error"},
+            },
+            "status": "Partially down",
+        }
 
         class_motorclient = "metadata_backend.api.health.AsyncIOMotorClient"
         motorclient_config = {"server_info.side_effect": self.fake_asynciomotorclient_server_info}


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->

- datacite has a heartbeat endpoint that responds with `200` or `500`
- rems has a health endpoint with details about the status of the installation
- metax does not currently have any health endpoint so we do a HEAD request to base URL

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
Close #572

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

<!-- List changes made. -->
* make the `DOI_API` URL default to base DOI URL instead of the ending with `/dois` 
* add datacite, rems and metax health checks in the API response also based on performance indicators (API timed reponses)
* modify mock datacite, rems and metax endpoints to answer for healthchecks


### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests
- [x] Integration Tests

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
