### PR TITLE
Automatically sort dictionary

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,6 +84,14 @@ repos:
 
   - repo: local
     hooks:
+    - id: sort
+      name: sort dictionary, remove unused and duplicates
+      entry: ./scripts/sort.sh
+      language: script
+      files: ^(docs|metadata_backend|.*md)
+      require_serial: true
+      pass_filenames: false
+
     - id: pylint
       name: pylint
       entry: pylint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
         - flake8-annotations
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.971
+    rev: v0.981
     hooks:
     - id: mypy
       args: [--ignore-missing-imports, metadata_backend/]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made [PKCE](https://oidcrp.readthedocs.io/en/latest/add_on/pkce.html) settings explicit in `oidcrp` client auth
 - Added [DPOP](https://oidcrp.readthedocs.io/en/latest/add_on/dpop.html) placeholder settings for when AAI support has been implemented
 - Add advanced health checks for Datacite, REMS and Metax and performance checks for API response #585
+- pre-commit check to sort and remove duplicates in the dictionary
 
 ### Changed
 - schema loader now matches schema files by exact match with schema #481. This means that schema file naming in metadata_backend/helpers/schemas now have rules:

--- a/docs/dictionary/wordlist.txt
+++ b/docs/dictionary/wordlist.txt
@@ -78,7 +78,6 @@ bislama
 bisulfite
 blastdbinfo
 bokmål
-bookchapter
 boolean
 breakpoint
 bugfix
@@ -106,10 +105,7 @@ cloneend
 codeql
 commonname
 complementsdatasetref
-computationalnotebook
 conf
-conferencepaper
-conferenceproceeding
 config
 configs
 conftest
@@ -145,7 +141,6 @@ daclinks
 dacref
 datacite
 datadescription
-datapaper
 dataset
 datasetattribute
 datasetattributes
@@ -308,7 +303,6 @@ imagetype
 ini
 insdc
 integrations
-interactiveresource
 interlingua
 interlingue
 inupiaq
@@ -318,7 +312,6 @@ ipython
 isni
 issn
 istc
-journalarticle
 js
 json
 jsoncontent
@@ -474,7 +467,6 @@ oromo
 oss
 ossetian
 otorhinolaryngology
-outputmanagementplan
 ownedby
 pacbio
 paleo
@@ -488,11 +480,8 @@ pcsubstance
 pdb
 pdbcls
 pdf
-peerreview
-perun
 pgm
 phenome
-physicalobject
 pipesection
 pkce
 pmc
@@ -648,9 +637,9 @@ subjectsschema
 submissionid
 submissionslice
 submissiontype
-submitter's
 submitterdemultiplexed
 submitterid
+submitter's
 submitters
 svg
 swati

--- a/scripts/sort.sh
+++ b/scripts/sort.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+file="docs/dictionary/wordlist.txt"
+
+# Sorts dictionary, converts to lower case, and remove duplicates
+sort "${file}" | tr "[:upper:]" "[:lower:]" | sort -u -o "${file}"
+
+# Remove unused words
+# Uses `ripgrep` to look for each word in the repository, and removes them with `sed` when no match is found
+if ! command -v rg > /dev/null 2>&1; then
+    echo "ripgrep not installed, skipping removing unused words"
+    exit 0
+fi
+
+while read -r line; do
+  if ! output="$(rg --hidden -g '!docs/dictionary' -i "${line}" .)" ; then
+    echo $line
+    sed -i "/${line}/d" "$file"
+  fi
+done <"${file}"


### PR DESCRIPTION
### Description
<!-- Please include a summary of the change or any information deemed important. -->
Sorting the dictionary is a boring task, so this is an automation for that.

Be sure you `pre-commit install` to benefit from `pre-commit` hooks.

### Changes Made

<!-- List changes made. -->
- sorts alphabetically
- removes duplicates
- convert to lowercase
- removes words that are not used any more (requires `ripgrep`)

**NB:** 

The feature for removing unused words from the dictionary requires [`ripgrep`](https://github.com/BurntSushi/ripgrep). I know it's not a standard tool, but it runs faster than the alternative for this case. If it's not available, the script will skip this step.