### PR TITLE
Don't generate mappings any more in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,6 @@ COPY --from=BUILD-FRONTEND /metadata-submitter-frontend/build \
 RUN pip install --upgrade pip pyyaml && \
     pip install -r /root/submitter/requirements.txt && \
     ./root/submitter/scripts/swagger/generate.sh && \
-    ./root/submitter/scripts/metax_mappings/fetch_refs.sh && \
     pip install /root/submitter
 
 #=======================

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -14,7 +14,6 @@ COPY metadata_backend/ ./metadata_backend
 COPY scripts ./scripts
 
 RUN pip install authlib requests  # required for mockauth (integration test)
-RUN ./scripts/metax_mappings/fetch_refs.sh
 RUN pip install .
 EXPOSE 5430
 


### PR DESCRIPTION
Metax mappings are part of the repository since #568, and the `Dockerfile` doesn't need to generate them.