### PR TITLE
update ENA schemas to v1.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored Mongo queries to return the value for a single field #591
 - There's more clear distinction between publishing to each integration: `datacite`, `metax`, and `rems` #591
 - Separated operator classes into their own files for better readability #625
+- updated ENA XML and JSON schemas to 1.16 #628
+  - XML to JSON parser had to be adjusted for `assemblyGraph`
 
 ### Removed
 

--- a/docs/dictionary/wordlist.txt
+++ b/docs/dictionary/wordlist.txt
@@ -39,6 +39,7 @@ apisauce
 aragonese
 arxiv
 assemblyannotation
+assemblygraph
 assignees
 async
 asyncio
@@ -231,6 +232,8 @@ filebase
 filename
 filepath
 filetype
+filteredvariation
+filteredvcf
 fixme
 flagdeleted
 flatfile
@@ -267,6 +270,7 @@ geolocationpolygon
 geolocations
 geoprofiles
 geosciences
+gfa
 gff
 gh
 github
@@ -420,8 +424,8 @@ mongo
 mongodb
 motu
 mpeg
-MQConsumer
-MQPublisher
+mqconsumer
+mqpublisher
 mre
 msll
 mypy
@@ -619,9 +623,11 @@ seqannot
 sequenceable
 sequenceannotation
 sequenceassembly
+sequenceconsensus
 sequenceflatfile
 sequencetype
 sequencevariation
+sequencevonsensus
 servicehandler
 sff
 sha

--- a/metadata_backend/helpers/parser.py
+++ b/metadata_backend/helpers/parser.py
@@ -125,13 +125,29 @@ class MetadataXMLConverter(XMLSchemaConverter):
                     children[key] = value
                 continue
 
-            if "assembly" in key:
-                if next(iter(value)) in {"standard", "custom"}:
-                    children[key] = next(iter(value.values()))
-                    if "accessionId" in children[key]:
-                        children[key]["accession"] = children[key].pop("accessionId")
+            if key in {"processedReads", "referenceAlignment", "sequenceAnnotation", "assemblyAnnotation"}:
+                if next(iter(value)) in {"assembly"}:
+                    if next(iter(value["assembly"])) in {"standard", "custom"}:
+                        value["assembly"] = next(iter(value["assembly"].values()))
+                        if "accessionId" in value["assembly"]:
+                            value["assembly"]["accession"] = value["assembly"].pop("accessionId")
+                children[key] = value
+                continue
+
+            if key == "assemblyGraph" and "assembly" in value:
+                attribs = value["assembly"]
+                attr_list = []
+                if isinstance(attribs, list):
+                    for d in attribs:
+                        for k, v in d.items():
+                            v["accession"] = v.pop("accessionId")
+                            attr_list.append(v)
                 else:
-                    children[key] = value
+                    v = next(iter(attribs.values()))
+                    v["accession"] = v.pop("accessionId")
+                    attr_list.append(v)
+
+                children[key] = attr_list
                 continue
 
             if key == "sequence":

--- a/metadata_backend/helpers/schemas/EGA.dac.xsd
+++ b/metadata_backend/helpers/schemas/EGA.dac.xsd
@@ -10,7 +10,6 @@
   ~ specific language governing permissions and limitations under the License.
   -->
 
-<!-- version:1.12.0 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:com="SRA.common">
 	<xs:import schemaLocation="SRA.common.xsd" namespace="SRA.common"/>
 

--- a/metadata_backend/helpers/schemas/EGA.dataset.xsd
+++ b/metadata_backend/helpers/schemas/EGA.dataset.xsd
@@ -10,7 +10,6 @@
   ~ specific language governing permissions and limitations under the License.
   -->
 
-<!-- version:1.12.0 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:com="SRA.common">
 	<xs:import schemaLocation="SRA.common.xsd" namespace="SRA.common"/>
 

--- a/metadata_backend/helpers/schemas/EGA.policy.xsd
+++ b/metadata_backend/helpers/schemas/EGA.policy.xsd
@@ -10,7 +10,6 @@
   ~ specific language governing permissions and limitations under the License.
   -->
 
-<!-- version:1.12.0 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:com="SRA.common">
 	<xs:import schemaLocation="SRA.common.xsd" namespace="SRA.common"/>
 

--- a/metadata_backend/helpers/schemas/ENA.assembly.xsd
+++ b/metadata_backend/helpers/schemas/ENA.assembly.xsd
@@ -10,7 +10,6 @@
   ~ specific language governing permissions and limitations under the License.
   -->
 
-<!-- version:1.12.0 -->
 <xs:schema xmlns:com="SRA.common" xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:import namespace="SRA.common" schemaLocation="SRA.common.xsd"/>
     <xs:complexType name="AssemblySetType">

--- a/metadata_backend/helpers/schemas/ENA.checklist.xsd
+++ b/metadata_backend/helpers/schemas/ENA.checklist.xsd
@@ -10,7 +10,6 @@
   ~ specific language governing permissions and limitations under the License.
   -->
 
-<!-- version:1.12.0 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:com="SRA.common">
     <xs:import schemaLocation="SRA.common.xsd" namespace="SRA.common"/>
 

--- a/metadata_backend/helpers/schemas/ENA.project.xsd
+++ b/metadata_backend/helpers/schemas/ENA.project.xsd
@@ -10,7 +10,6 @@
   ~ specific language governing permissions and limitations under the License.
   -->
 
-<!-- version:1.12.0 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:com="SRA.common">
     <xs:import schemaLocation="SRA.common.xsd" namespace="SRA.common"/>
     <xs:complexType name="OrganismType">

--- a/metadata_backend/helpers/schemas/SRA.analysis.xsd
+++ b/metadata_backend/helpers/schemas/SRA.analysis.xsd
@@ -10,7 +10,6 @@
   ~ specific language governing permissions and limitations under the License.
   -->
 
-<!-- version:1.12.0 -->
 <xs:schema xmlns:com="SRA.common" xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:import namespace="SRA.common" schemaLocation="SRA.common.xsd"/>
 
@@ -38,6 +37,7 @@
                     <xs:enumeration value="wig"/>
                     <xs:enumeration value="bed"/>
                     <xs:enumeration value="gff"/>
+                    <xs:enumeration value="gfa"/>
                     <xs:enumeration value="fasta"/>
                     <xs:enumeration value="fastq"/>
                     <xs:enumeration value="flatfile"/>
@@ -351,6 +351,15 @@
                                 <xs:element name="PATHOGEN_ANALYSIS"/>
                                 <xs:element name="COVID19_CONSENSUS"/>
                                 <xs:element name="COVID19_FILTERED_VCF"/>
+                                <xs:element name="PHYLOGENY_ANALYSIS"/>
+                                <xs:element name="ASSEMBLY_GRAPH">
+                                    <xs:complexType>
+                                        <xs:sequence>
+                                            <xs:element maxOccurs="unbounded" name="ASSEMBLY"
+                                                        type="com:ReferenceAssemblyType"></xs:element>
+                                        </xs:sequence>
+                                    </xs:complexType>
+                                </xs:element>
                                 <xs:element name="TRANSCRIPTOME_ASSEMBLY">
                                     <xs:complexType>
                                         <xs:sequence>
@@ -408,6 +417,8 @@
                                     </xs:complexType>
                                 </xs:element>
                                 <xs:element name="ASSEMBLY_ANNOTATION" type="com:ReferenceSequenceType"></xs:element>
+                                <xs:element name="SEQUENCE_CONSENSUS"/>
+                                <xs:element name="FILTERED_VARIATION"/>
                             </xs:choice>
                         </xs:complexType>
                     </xs:element>

--- a/metadata_backend/helpers/schemas/SRA.common.xsd
+++ b/metadata_backend/helpers/schemas/SRA.common.xsd
@@ -10,7 +10,6 @@
   ~ specific language governing permissions and limitations under the License.
   -->
 
-<!-- version:1.12.0 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:com="SRA.common"
     targetNamespace="SRA.common">
 

--- a/metadata_backend/helpers/schemas/SRA.experiment.xsd
+++ b/metadata_backend/helpers/schemas/SRA.experiment.xsd
@@ -10,7 +10,6 @@
   ~ specific language governing permissions and limitations under the License.
   -->
 
-<!-- version:1.12.0 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:com="SRA.common">
   <xs:import schemaLocation="SRA.common.xsd" namespace="SRA.common"/>
 

--- a/metadata_backend/helpers/schemas/SRA.receipt.xsd
+++ b/metadata_backend/helpers/schemas/SRA.receipt.xsd
@@ -10,7 +10,6 @@
   ~ specific language governing permissions and limitations under the License.
   -->
 
-<!-- version:1.12.0 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:complexType name="ID">
         <xs:sequence>

--- a/metadata_backend/helpers/schemas/SRA.run.xsd
+++ b/metadata_backend/helpers/schemas/SRA.run.xsd
@@ -10,7 +10,6 @@
   ~ specific language governing permissions and limitations under the License.
   -->
 
-<!-- version:1.12.0 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:com="SRA.common">
     <xs:import schemaLocation="SRA.common.xsd" namespace="SRA.common"/>
 

--- a/metadata_backend/helpers/schemas/SRA.sample.xsd
+++ b/metadata_backend/helpers/schemas/SRA.sample.xsd
@@ -10,7 +10,6 @@
   ~ specific language governing permissions and limitations under the License.
   -->
 
-<!-- version:1.12.0 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:com="SRA.common">
   <xs:import schemaLocation="SRA.common.xsd" namespace="SRA.common"/>
 

--- a/metadata_backend/helpers/schemas/SRA.study.xsd
+++ b/metadata_backend/helpers/schemas/SRA.study.xsd
@@ -10,7 +10,6 @@
   ~ specific language governing permissions and limitations under the License.
   -->
 
-<!-- version:1.12.0 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:com="SRA.common">
   <xs:import schemaLocation="SRA.common.xsd" namespace="SRA.common"/>
 

--- a/metadata_backend/helpers/schemas/SRA.submission.xsd
+++ b/metadata_backend/helpers/schemas/SRA.submission.xsd
@@ -10,7 +10,6 @@
   ~ specific language governing permissions and limitations under the License.
   -->
 
-<!-- version:1.12.0 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:com="SRA.common">
   <xs:import schemaLocation="SRA.common.xsd" namespace="SRA.common"/>
 

--- a/metadata_backend/helpers/schemas/ena_analysis.json
+++ b/metadata_backend/helpers/schemas/ena_analysis.json
@@ -133,6 +133,57 @@
                 }
             }
         },
+        "assembly": {
+            "type": "object",
+            "title": "Reference assembly details",
+            "oneOf": [
+                {
+                    "type": "object",
+                    "title": "Standard",
+                    "description": "A standard genome assembly.",
+                    "required": [
+                        "accession"
+                    ],
+                    "properties": {
+                        "refname": {
+                            "type": "string",
+                            "description": "A recognized name for the genome assembly.",
+                            "title": "Reference name"
+                        },
+                        "accession": {
+                            "type": "string",
+                            "description": "Accession.version with version being mandatory.",
+                            "title": "Accession.version"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "title": "Custom",
+                    "description": "Other genome assembly.",
+                    "required": [
+                        "description"
+                    ],
+                    "properties": {
+                        "label": {
+                            "type": "string",
+                            "title": "Label",
+                            "description": "Text label to display for the link."
+                        },
+                        "url": {
+                            "type": "string",
+                            "title": "URL",
+                            "description": "The internet service link (http(s), ftp) etc.",
+                            "pattern": "^(https?|ftp)://"
+                        },
+                        "description": {
+                            "type": "string",
+                            "title": "Description"
+                        }
+                    }
+                }
+            ]
+        },
         "analysisAttribute": {
             "type": "object",
             "title": "Analysis Attribute",
@@ -161,55 +212,7 @@
             "type": "object",
             "properties": {
                 "assembly": {
-                    "type": "object",
-                    "title": "Reference assembly details",
-                    "oneOf": [
-                        {
-                            "type": "object",
-                            "title": "Standard",
-                            "description": "A standard genome assembly.",
-                            "required": [
-                                "accession"
-                            ],
-                            "properties": {
-                                "refname": {
-                                    "type": "string",
-                                    "description": "A recognized name for the genome assembly.",
-                                    "title": "Reference name"
-                                },
-                                "accession": {
-                                    "type": "string",
-                                    "description": "Accession.version with version being mandatory.",
-                                    "title": "Accession.version"
-                                }
-                            }
-                        },
-                        {
-                            "type": "object",
-                            "title": "Custom",
-                            "description": "Other genome assembly.",
-                            "required": [
-                                "description"
-                            ],
-                            "properties": {
-                                "label": {
-                                    "type": "string",
-                                    "title": "Label",
-                                    "description": "Text label to display for the link."
-                                },
-                                "url": {
-                                    "type": "string",
-                                    "title": "URL",
-                                    "description": "The internet service link (http(s), ftp) etc.",
-                                    "pattern": "^(https?|ftp)://"
-                                },
-                                "description": {
-                                    "type": "string",
-                                    "title": "Description"
-                                }
-                            }
-                        }
-                    ]
+                    "$ref": "#/$defs/assembly"
                 },
                 "sequence": {
                     "type": "array",
@@ -346,6 +349,7 @@
                         "fastq",
                         "flatfile",
                         "gff",
+                        "gfa",
                         "info",
                         "Kallisto native",
                         "manifest",
@@ -511,55 +515,7 @@
                         }
                     },
                     "assembly": {
-                        "type": "object",
-                        "title": "Reference assembly details",
-                        "oneOf": [
-                            {
-                                "type": "object",
-                                "title": "Standard",
-                                "description": "A standard genome assembly.",
-                                "required": [
-                                    "accession"
-                                ],
-                                "properties": {
-                                    "refname": {
-                                        "type": "string",
-                                        "description": "A recognized name for the genome assembly.",
-                                        "title": "Reference name"
-                                    },
-                                    "accession": {
-                                        "type": "string",
-                                        "description": "Accession.version with version being mandatory.",
-                                        "title": "Accession.version"
-                                    }
-                                }
-                            },
-                            {
-                                "type": "object",
-                                "title": "Custom",
-                                "description": "Other genome assembly.",
-                                "required": [
-                                    "description"
-                                ],
-                                "properties": {
-                                    "label": {
-                                        "type": "string",
-                                        "title": "Label",
-                                        "description": "Text label to display for the link."
-                                    },
-                                    "url": {
-                                        "type": "string",
-                                        "title": "URL",
-                                        "description": "The internet service link (http(s), ftp) etc.",
-                                        "pattern": "^(https?|ftp)://"
-                                    },
-                                    "description": {
-                                        "type": "string",
-                                        "title": "Description"
-                                    }
-                                }
-                            }
-                        ]
+                        "$ref": "#/$defs/assembly"
                     },
                     "sequence": {
                         "type": "array",
@@ -856,6 +812,107 @@
                     "$ref": "#/$defs/sequenceType"
                 }
             }
+        },
+        "sequenceConsensus": {
+            "type": "object",
+            "title": "Sequence Consensus",
+            "required": [
+                "sequenceConsensus"
+            ],
+            "properties": {
+                "sequenceConsensus": {
+                    "type": "object",
+                    "title": "Sequence Consensus",
+                    "additionalProperties": true,
+                    "properties": {
+                        "description": {
+                            "type": "string",
+                            "title": "Sequence Consensus Description"
+                        }
+                    }
+                }
+            }
+        },
+        "filteredVariation": {
+            "type": "object",
+            "title": "Filtered Variation",
+            "required": [
+                "filteredVariation"
+            ],
+            "properties": {
+                "filteredVariation": {
+                    "type": "object",
+                    "title": "Filtered Variation",
+                    "additionalProperties": true,
+                    "properties": {
+                        "description": {
+                            "type": "string",
+                            "title": "Filtered Variation Description"
+                        }
+                    }
+                }
+            }
+        },
+        "covid19Consensus": {
+            "type": "object",
+            "title": "COVID19 Consensus",
+            "required": [
+                "covid19Consensus"
+            ],
+            "properties": {
+                "covid19Consensus": {
+                    "type": "object",
+                    "title": "COVID19 Consensus",
+                    "additionalProperties": true,
+                    "properties": {
+                        "description": {
+                            "type": "string",
+                            "title": "COVID19 Consensus Description"
+                        }
+                    }
+                }
+            }
+        },
+        "covid19FilteredVCF": {
+            "type": "object",
+            "title": "COVID19 Filtered VCF",
+            "required": [
+                "covid19FilteredVCF"
+            ],
+            "properties": {
+                "covid19FilteredVCF": {
+                    "type": "object",
+                    "title": "COVID19 Filtered VCF",
+                    "additionalProperties": true,
+                    "properties": {
+                        "description": {
+                            "type": "string",
+                            "title": "COVID19 Filtered VCF Description"
+                        }
+                    }
+                }
+            }
+        },
+        "assemblyGraph": {
+            "type": "object",
+            "title": "Assembly Graph",
+            "required": [
+                "assemblyGraph"
+            ],
+            "properties": {
+                "assemblyGraph": {
+                    "type": "array",
+                    "title": "Assembly Graph",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "assembly": {
+                                "$ref": "#/$defs/assembly"
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "type": "object",
@@ -911,6 +968,21 @@
                 },
                 {
                     "$ref": "#/$defs/assemblyAnnotation"
+                },
+                {
+                    "$ref": "#/$defs/sequenceConsensus"
+                },
+                {
+                    "$ref": "#/$defs/filteredVariation"
+                },
+                {
+                    "$ref": "#/$defs/covid19Consensus"
+                },
+                {
+                    "$ref": "#/$defs/covid19FilteredVCF"
+                },
+                {
+                    "$ref": "#/$defs/assemblyGraph"
                 }
             ]
         },

--- a/tests/integration/conf.py
+++ b/tests/integration/conf.py
@@ -20,6 +20,7 @@ test_fega_xml_files = [
     ("experiment", "sample_description.xml"),
     ("analysis", "ERZ266973.xml"),
     ("analysis", "processed_reads_analysis.xml"),
+    ("analysis", "assembly_graph_analysis.xml"),
     ("analysis", "reference_alignment_analysis.xml"),
     ("analysis", "reference_sequence_analysis.xml"),
     ("analysis", "sequence_assembly_analysis.xml"),

--- a/tests/test_files/analysis/assembly_graph_analysis.xml
+++ b/tests/test_files/analysis/assembly_graph_analysis.xml
@@ -1,0 +1,81 @@
+<ANALYSIS_SET>
+    <ANALYSIS alias="graph_X_PGGB">
+        <TITLE>Pangenome assembly graph X - generated using PGGB pipeline</TITLE>
+        <DESCRIPTION>Pangenome assembly graph X was generated …. Etc. …</DESCRIPTION>
+        <STUDY_REF accession="ERP123456"/>
+        <SAMPLE_REF accession="ERS123456"/>
+        <SAMPLE_REF accession="ERS123457"/>
+        <SAMPLE_REF accession="ERS123458"/>
+        <ANALYSIS_TYPE>
+            <ASSEMBLY_GRAPH>
+                <ASSEMBLY>
+                    <STANDARD accession="GCA_012345.1"/>
+                </ASSEMBLY>
+                <ASSEMBLY>
+                    <STANDARD accession="GCA_012346.1"/>
+                </ASSEMBLY>
+                <ASSEMBLY>
+                    <STANDARD accession="GCA_012347.1"/>
+                </ASSEMBLY>
+            </ASSEMBLY_GRAPH>
+        </ANALYSIS_TYPE>
+        <FILES>
+            <FILE filename="assembly_graph.gfa.gz" filetype="gfa" checksum_method="MD5"
+                  checksum="9f2976d079c10b111669b32590d1eb3e"/>
+        </FILES>
+        <ANALYSIS_ATTRIBUTES>
+            <ANALYSIS_ATTRIBUTE>
+                <TAG>pangenome name</TAG>
+                <VALUE>hprc-v1.0-mc-chm13-maxdel.10mb</VALUE>
+            </ANALYSIS_ATTRIBUTE>
+            <ANALYSIS_ATTRIBUTE>
+                <TAG>file format version</TAG>
+                <VALUE>GFAv1.1</VALUE>
+            </ANALYSIS_ATTRIBUTE>
+            <ANALYSIS_ATTRIBUTE>
+                <TAG>pipeline</TAG>
+                <VALUE>PGGB</VALUE>
+            </ANALYSIS_ATTRIBUTE>
+            <ANALYSIS_ATTRIBUTE>
+                <TAG>resolution</TAG>
+                <VALUE>base level</VALUE>
+            </ANALYSIS_ATTRIBUTE>
+            <ANALYSIS_ATTRIBUTE>
+                <TAG>number of nodes</TAG>
+                <VALUE>424643</VALUE>
+            </ANALYSIS_ATTRIBUTE>
+            <ANALYSIS_ATTRIBUTE>
+                <TAG>number of components</TAG>
+                <VALUE>25</VALUE>
+            </ANALYSIS_ATTRIBUTE>
+            <ANALYSIS_ATTRIBUTE>
+                <TAG>number of edges</TAG>
+                <VALUE>637628</VALUE>
+            </ANALYSIS_ATTRIBUTE>
+            <ANALYSIS_ATTRIBUTE>
+                <TAG>length (bp)</TAG>
+                <VALUE>3239764787</VALUE>
+            </ANALYSIS_ATTRIBUTE>
+            <ANALYSIS_ATTRIBUTE>
+                <TAG>total path length (bp)</TAG>
+                <VALUE>3239764787</VALUE>
+            </ANALYSIS_ATTRIBUTE>
+            <ANALYSIS_ATTRIBUTE>
+                <TAG>reference assembly</TAG>
+                <VALUE>GRCh38</VALUE>
+            </ANALYSIS_ATTRIBUTE>
+            <ANALYSIS_ATTRIBUTE>
+                <TAG>reference assembly</TAG>
+                <VALUE>ABCD123</VALUE>
+            </ANALYSIS_ATTRIBUTE>
+            <ANALYSIS_ATTRIBUTE>
+                <TAG>reference assembly</TAG>
+                <VALUE>ABCD234</VALUE>
+            </ANALYSIS_ATTRIBUTE>
+            <ANALYSIS_ATTRIBUTE>
+                <TAG>reference based</TAG>
+                <VALUE>true</VALUE>
+            </ANALYSIS_ATTRIBUTE>
+        </ANALYSIS_ATTRIBUTES>
+    </ANALYSIS>
+</ANALYSIS_SET>


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
include changes from:
- https://github.com/enasequence/schema/pull/29
- https://github.com/enasequence/schema/pull/27

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->
- [x] Update schemas
### Changes Made

<!-- List changes made. -->
- update ENA xsd schemas with upstream, also `ena_analysis.json`
- analysis has the most changes (new file type) and new analysis types
- removed version numbers from xsd files (as done in ENA upstream files)
- refreshed wordlist
- added `assembly_graph_analysis.xml` to test the new schema additions
  - adjusted JSON parser to an interpretation mentioned in https://github.com/CSCfi/metadata-submitter/pull/628#issuecomment-1292345525

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
