### PR TITLE
add option to extend problem json error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,7 +73,7 @@ repos:
       files: docs/specification.yml
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.18.3
+    rev: 0.18.4
     hooks:
       - id: check-metaschema
         name: Validate schemas

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Added
 - `lastModified` to folder to keep track when a folder or the objects in a folder change and be able to filter via the `lastModified`
 - connection checking and `retry`-mechanism for calls to Metax-service in case of server and connection errors
@@ -43,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - File operator that does database operations for files #148
 - Mongo indexes for `file` schema #148
 - `/files` endpoint to retrieve files attached to a project #148 #627
+- option to add additional members to `application/problem+json` #642
 
 ### Changed
 - schema loader now matches schema files by exact match with schema #481. This means that schema file naming in metadata_backend/helpers/schemas now have rules:


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
add additional members to problem json response if the content type can be converted to dict
### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

related for #641 and required by some dev in #633 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)


### Changes Made

<!-- List changes made. -->

- update pre-commit dependencies, as packages were updated this month, so that we keep in sync
- add dict members to `application/problem+json` if that exist in the HTTP exception

all that needs to be added is:
```
text=ujson.dumps({"coolContent": [{"value": 1}, {"value": 2}]}),
content_type="application/json"
```

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Needs testing (start an issue or do a follow up PR about it)

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
