### PR TITLE
refactor publish action for deprecated syntax

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,8 @@ on:
     types: [published]
   push:
     branches: [master, develop]
+    tags:
+      - 'v*'
 
 jobs:
   push_to_registry:
@@ -13,30 +15,6 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
-
-      - name: Prepare
-        id: prep
-        run: |
-          DOCKER_IMAGE=cscfi/metadata-submitter
-          VERSION=edge
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/}
-            BRANCH=master
-          elif [[ $GITHUB_REF == refs/heads/* ]]; then
-            BRANCH=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
-            if [[ $BRANCH == master ]]; then
-              VERSION=latest
-              BRANCH=master
-            elif [[ $BRANCH == develop ]]; then
-              VERSION=stage
-              BRANCH=develop
-            fi
-          fi
-          echo "BUILD_BRANCH=$BRANCH" >> $GITHUB_ENV
-          TAGS="${DOCKER_IMAGE}:${VERSION}"
-          echo ::set-output name=version::${VERSION}
-          echo ::set-output name=tags::${TAGS}
-          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -48,18 +26,29 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: cscfi/metadata-submitter
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+      
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
           context: .
           file: ./Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.prep.outputs.tags }}
           build-args: |
             BRANCH=${{ env.BUILD_BRANCH }}
+          tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=registry,ref=cscfi/metadata-submitter:latest
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-to: type=inline
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.clone_url }}
-            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
             org.opencontainers.image.revision=${{ github.sha }}

--- a/metadata_backend/helpers/parser.py
+++ b/metadata_backend/helpers/parser.py
@@ -284,7 +284,7 @@ class MetadataXMLConverter(XMLSchemaConverter):
         self,
         data: ElementData,
         xsd_element: XsdElement,
-        xsd_type: XsdType = None,
+        xsd_type: Optional[XsdType] = None,
         level: int = 0,  # this is required for XMLSchemaConverter
     ) -> Union[Dict, List, str, None]:
         """Decode XML to JSON.

--- a/metadata_backend/services/service_handler.py
+++ b/metadata_backend/services/service_handler.py
@@ -50,9 +50,9 @@ class ServiceHandler(ABC):
     def __init__(
         self,
         base_url: URL,
-        auth: BasicAuth = None,
-        http_client_timeout: ClientTimeout = None,
-        http_client_headers: dict = None,
+        auth: Optional[BasicAuth] = None,
+        http_client_timeout: Optional[ClientTimeout] = None,
+        http_client_headers: Optional[dict] = None,
     ) -> None:
         """Create an instance with db_client and aiohttp client attached.
 
@@ -102,10 +102,10 @@ class ServiceHandler(ABC):
     async def _request(
         self,
         method: str = "GET",
-        url: URL = None,
+        url: Optional[URL] = None,
         path: str = "",
-        params: Union[str, dict] = None,
-        json_data: Union[Dict, List[Dict]] = None,
+        params: Optional[Union[str, dict]] = None,
+        json_data: Optional[Union[Dict, List[Dict]]] = None,
         timeout: int = 10,
     ) -> Union[dict, str]:
         """Request to service REST API.


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
refactor for deprecated syntax and streamline image.

Stage image was not used so we remove it, instead `develop` will be built as well as tags

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


### Changes Made

<!-- List changes made. -->
- there is some deprecated syntax in the action `set-output`
- fix optional parameters that have default `None`

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply


### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
some issues appeared, I assume `mypy` changed smth

```
mypy run-test: commands[0] | mypy --ignore-missing-imports metadata_backend/
metadata_backend/services/service_handler.py:53: error: Incompatible default for argument "auth" (default has type "None", argument has type "BasicAuth")  [assignment]
metadata_backend/services/service_handler.py:53: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
metadata_backend/services/service_handler.py:53: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
metadata_backend/services/service_handler.py:54: error: Incompatible default for argument "http_client_timeout" (default has type "None", argument has type "ClientTimeout")  [assignment]
metadata_backend/services/service_handler.py:54: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
metadata_backend/services/service_handler.py:54: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
metadata_backend/services/service_handler.py:55: error: Incompatible default for argument "http_client_headers" (default has type "None", argument has type "Dict[Any, Any]")  [assignment]
metadata_backend/services/service_handler.py:55: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
metadata_backend/services/service_handler.py:55: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
metadata_backend/services/service_handler.py:105: error: Incompatible default for argument "url" (default has type "None", argument has type "URL")  [assignment]
metadata_backend/services/service_handler.py:105: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
metadata_backend/services/service_handler.py:105: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
metadata_backend/services/service_handler.py:107: error: Incompatible default for argument "params" (default has type "None", argument has type "Union[str, Dict[Any, Any]]")  [assignment]
metadata_backend/services/service_handler.py:107: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
metadata_backend/services/service_handler.py:107: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
metadata_backend/services/service_handler.py:108: error: Incompatible default for argument "json_data" (default has type "None", argument has type "Union[Dict[Any, Any], List[Dict[Any, Any]]]")  [assignment]
metadata_backend/services/service_handler.py:108: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
metadata_backend/services/service_handler.py:108: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
metadata_backend/helpers/parser.py:283: error: Argument 3 of "element_decode" is incompatible with supertype "XMLSchemaConverter"; supertype defines the argument type as "Union[XsdSimpleType, XsdComplexType, None]"  [override]
metadata_backend/helpers/parser.py:283: note: This violates the Liskov substitution principle
metadata_backend/helpers/parser.py:283: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
metadata_backend/helpers/parser.py:287: error: Incompatible default for argument "xsd_type" (default has type "None", argument has type "XsdType")  [assignment]
metadata_backend/helpers/parser.py:287: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
metadata_backend/helpers/parser.py:287: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
Found 8 errors in 2 files (checked 48 source files)
```