### PR TITLE
Rename `submission.dac` to `submission.rems`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - New rems service handler
   - New rems mock api service for integration tests
   - New API endpoint `/v1/rems` for the frontend to retrieve DAC and Policies
-  - Submission now can have a new field, `dac`, with `workflowId`, `organizationId`, and `licenses` (array of int)
-  - Published datasets have a new field `dac` with `workflowId`, `organizationId`, `resourceId`, and `catalogueItemId`
+  - Submission now can have a new field, `dac` (changed to `rems` in #648), with `workflowId`, `organizationId`, and `licenses` (array of int)
+  - Published datasets have a new field `dac` (changed to `rems` in #648) with `workflowId`, `organizationId`, `resourceId`, and `catalogueItemId`
 - Pylint static checks
 - Added mapping for languages between the submitter and Metax-service #514
 - Added mapping for subjects from submission doi info to Metax field_of_science #556
@@ -83,6 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor `xml_object.py` -> `object_xml.py` #627
 - Refactor operators to use a common base class called `BaseOperator` #627
 - XML validation errors now compile all the failing elements into same error message and include the line number in the error reason #630
+- Changed the submission object's `dac` field to `rems` and its subsequent endpoints similarly #648
 
 ### Removed
 

--- a/docs/specification.yml
+++ b/docs/specification.yml
@@ -1361,11 +1361,11 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/405MethodNotAllowed"
-  /v1/submissions/{submissionId}/dac:
+  /v1/submissions/{submissionId}/rems:
     put:
       tags:
         - Manage
-      summary: Update DAC for the submission with a specified submission ID.
+      summary: Update REMS (DAC) for the submission with a specified submission ID.
       parameters:
         - name: submissionId
           in: path
@@ -1377,7 +1377,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/DAC"
+              $ref: "#/components/schemas/REMS_DAC"
       responses:
         200:
           description: OK
@@ -2842,7 +2842,7 @@ components:
             type: object
           type: array
           uniqueItems: true
-    DAC:
+    REMS_DAC:
       type: object
       required:
         - workflowId

--- a/metadata_backend/api/handlers/publish.py
+++ b/metadata_backend/api/handlers/publish.py
@@ -401,9 +401,9 @@ class PublishSubmissionAPIHandler(RESTAPIIntegrationHandler):
                 }
                 rems_datasets.append(rems_ds)
 
-        org_id = submission["dac"]["organizationId"]
-        licenses = submission["dac"]["licenses"]
-        workflow_id = submission["dac"]["workflowId"]
+        org_id = submission["rems"]["organizationId"]
+        licenses = submission["rems"]["licenses"]
+        workflow_id = submission["rems"]["workflowId"]
         for ds in rems_datasets:
             resource_id = await self.rems_handler.create_resource(
                 doi=ds["doi"], organization_id=org_id, licenses=licenses
@@ -418,13 +418,13 @@ class PublishSubmissionAPIHandler(RESTAPIIntegrationHandler):
             # Add rems URL to metax dataset description
             rems_url = self.rems_handler.application_url(catalogue_id)
             if "metaxIdentifier" in ds:
-                new_description = ds["description"] + f"\n\nDAC: {rems_url}"
+                new_description = ds["description"] + f"\n\nREMS DAC: {rems_url}"
                 await self.metax_handler.update_draft_dataset_description(ds["metaxIdentifier"], new_description)
             await obj_op.update_metadata_object(
                 ds["schema"],
                 ds["accession_id"],
                 {
-                    "dac": {
+                    "rems": {
                         "url": rems_url,
                         "workflowId": workflow_id,
                         "organizationId": org_id,
@@ -473,8 +473,8 @@ class PublishSubmissionAPIHandler(RESTAPIIntegrationHandler):
                 raise web.HTTPBadRequest(reason=reason)
             schemas_in_submission.add(schema)
             # TO_DO: Can only be enabled after we have unified the DAC from EGA and REMS
-            # if "dac" in workflow.required_schemas and "dac" not in submission:
-            #     raise web.HTTPBadRequest(reason=f"Submission '{accession_id}' must have DAC.")
+            # if "dac" in workflow.required_schemas and "rems" not in submission:
+            #     raise web.HTTPBadRequest(reason=f"Submission '{accession_id}' must have rems.")
         if not has_study:
             raise web.HTTPBadRequest(reason=f"Submission '{submission_id}' must have a study.")
 

--- a/metadata_backend/api/handlers/restapi.py
+++ b/metadata_backend/api/handlers/restapi.py
@@ -336,12 +336,12 @@ class RESTAPIIntegrationHandler(RESTAPIHandler):
 
         return _doi_data["fullDOI"]
 
-    async def check_dac_ok(self, submission: dict) -> bool:
-        """Check that DAC in object is ok."""
-        if "dac" not in submission:
-            raise web.HTTPBadRequest(reason="DAC is missing.")
+    async def check_rems_ok(self, submission: dict) -> bool:
+        """Check that REMS DAC in object is ok."""
+        if "rems" not in submission:
+            raise web.HTTPBadRequest(reason="REMS field is missing.")
 
-        dac = submission["dac"]
+        dac = submission["rems"]
 
         if "workflowId" in dac and "organizationId" in dac and "licenses" in dac:
             await self.rems_handler.validate_workflow_licenses(
@@ -349,7 +349,7 @@ class RESTAPIIntegrationHandler(RESTAPIHandler):
             )
         else:
             raise web.HTTPBadRequest(
-                reason="DAC is missing one or more of the required fields: "
+                reason="REMS DAC is missing one or more of the required fields: "
                 "'workflowId', 'organizationId', or 'licenses'."
             )
 

--- a/metadata_backend/api/handlers/submission.py
+++ b/metadata_backend/api/handlers/submission.py
@@ -294,9 +294,9 @@ class SubmissionAPIHandler(RESTAPIIntegrationHandler):
 
         if req.path.endswith("doi"):
             schema = "doiInfo"
-        elif req.path.endswith("dac"):
-            schema = "dac"
-            await self.check_dac_ok({"dac": data})
+        elif req.path.endswith("rems"):
+            schema = "rems"
+            await self.check_rems_ok({"rems": data})
         else:
             raise web.HTTPNotFound(reason=f"'{req.path}' does not exist")
 

--- a/metadata_backend/helpers/schemas/submission.json
+++ b/metadata_backend/helpers/schemas/submission.json
@@ -1162,7 +1162,7 @@
             },
             "uniqueItems": true
         },
-        "dac": {
+        "rems": {
             "type": "object",
             "title": "REMS DAC for datasets",
             "required": [

--- a/metadata_backend/server.py
+++ b/metadata_backend/server.py
@@ -139,7 +139,7 @@ async def init(
         web.get("/submissions/{submissionId}/files", _submission.get_submission_files),
         web.post("/submissions/{submissionId}/files", _submission.add_submission_files),
         web.put("/submissions/{submissionId}/doi", _submission.put_submission_path),
-        web.put("/submissions/{submissionId}/dac", _submission.put_submission_path),
+        web.put("/submissions/{submissionId}/rems", _submission.put_submission_path),
         web.patch("/submissions/{submissionId}", _submission.patch_submission),
         web.delete("/submissions/{submissionId}", _submission.delete_submission),
         # publish submissions

--- a/tests/http/publication_minimal.http
+++ b/tests/http/publication_minimal.http
@@ -68,7 +68,7 @@ PUT {{backend_url}}/v1/submissions/{{submission_id}}/doi
 < ../test_files/doi/test_doi.json
 
 ### Update DAC in submission
-PUT {{backend_url}}/v1/submissions/{{submission_id}}/dac
+PUT {{backend_url}}/v1/submissions/{{submission_id}}/rems
 
 < ../test_files/dac/dac_rems.json
 

--- a/tests/http/publication_rems.http
+++ b/tests/http/publication_rems.http
@@ -78,7 +78,7 @@ PUT {{backend_url}}/v1/submissions/{{submission_id}}/doi
 < ../test_files/doi/test_doi.json
 
 ### Update DAC in submission
-PUT {{backend_url}}/v1/submissions/{{submission_id}}/dac
+PUT {{backend_url}}/v1/submissions/{{submission_id}}/rems
 
 < ../test_files/dac/dac_rems.json
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -532,18 +532,18 @@ async def put_submission_doi(sess, submission_id, data):
         return ans["submissionId"]
 
 
-async def put_submission_dac(sess, submission_id, data):
-    """Put DAC into submission within session, returns submissionId.
+async def put_submission_rems(sess, submission_id, data):
+    """Put REMS (DAC) into submission within session, returns submissionId.
 
     :param sess: HTTP session in which request call is made
     :param submission_id: id of the submission
-    :param data: dac data used to update the submission
+    :param data: REMS data used to update the submission
     :returns: Submission id for the submission inserted to database
     """
-    async with sess.put(f"{submissions_url}/{submission_id}/dac", data=data) as resp:
+    async with sess.put(f"{submissions_url}/{submission_id}/rems", data=data) as resp:
         ans = await resp.json()
         assert resp.status == 200, f"HTTP Status code error {resp.status} {ans}"
-        LOG.debug(f"Adding DAC to submission {ans['submissionId']}")
+        LOG.debug(f"Adding REMS DAC to submission {ans['submissionId']}")
         return ans["submissionId"]
 
 

--- a/tests/integration/test_bigpicture.py
+++ b/tests/integration/test_bigpicture.py
@@ -7,8 +7,8 @@ from tests.integration.helpers import (
     post_object,
     post_object_json,
     publish_submission,
-    put_submission_dac,
     put_submission_doi,
+    put_submission_rems,
 )
 
 
@@ -30,8 +30,8 @@ class TestBigPicture:
         doi_data_raw = await create_request_json_data("doi", "test_doi.json")
         await put_submission_doi(client_logged_in, submission_bigpicture, doi_data_raw)
 
-        dac_data = await create_request_json_data("dac", "dac_rems.json")
-        await put_submission_dac(client_logged_in, submission_bigpicture, dac_data)
+        rems_data = await create_request_json_data("dac", "dac_rems.json")
+        await put_submission_rems(client_logged_in, submission_bigpicture, rems_data)
 
         await publish_submission(client_logged_in, submission_bigpicture)
 

--- a/tests/integration/test_metax.py
+++ b/tests/integration/test_metax.py
@@ -12,8 +12,8 @@ from tests.integration.helpers import (
     publish_submission,
     put_object_json,
     put_object_xml,
-    put_submission_dac,
     put_submission_doi,
+    put_submission_rems,
 )
 
 LOG = logging.getLogger(__name__)
@@ -39,8 +39,8 @@ async def test_metax_id_created(client_logged_in, submission_fega):
 
     doi_data_raw = await create_request_json_data("doi", "test_doi.json")
     await put_submission_doi(client_logged_in, submission_fega, doi_data_raw)
-    # dac_data = await create_request_json_data("dac", "dac_rems.json")
-    # await put_submission_dac(client_logged_in, submission_fega, dac_data)
+    # rems_data = await create_request_json_data("dac", "dac_rems.json")
+    # await put_submission_rems(client_logged_in, submission_fega, rems_data)
     await post_object_json(client_logged_in, "run", submission_fega, "ERR000076.json")
     await publish_submission(client_logged_in, submission_fega)
 
@@ -190,8 +190,8 @@ async def test_metax_publish_dataset(client_logged_in, submission_fega):
     # Add DOI and publish the submission
     doi_data_raw = await create_request_json_data("doi", "test_doi.json")
     await put_submission_doi(client_logged_in, submission_fega, doi_data_raw)
-    dac_data = await create_request_json_data("dac", "dac_rems.json")
-    await put_submission_dac(client_logged_in, submission_fega, dac_data)
+    rems_data = await create_request_json_data("dac", "dac_rems.json")
+    await put_submission_rems(client_logged_in, submission_fega, rems_data)
     await post_object_json(client_logged_in, "run", submission_fega, "ERR000076.json")
     await publish_submission(client_logged_in, submission_fega)
 
@@ -286,8 +286,8 @@ async def test_metax_publish_dataset(client_logged_in, submission_fega):
 #         # Add DOI and publish the submission
 #         doi_data_raw = await create_request_json_data("doi", "test_doi.json")
 #         await put_submission_doi(client_logged_in, submission_fega, doi_data_raw)
-#         dac_data = await create_request_json_data("dac", "dac_rems.json")
-#         await put_submission_dac(client_logged_in, submission_fega, dac_data)
+#         rems_data = await create_request_json_data("dac", "dac_rems.json")
+#         await put_submission_rems(client_logged_in, submission_fega, rems_data)
 #         await publish_submission(client_logged_in, submission_fega)
 #
 #         for schema, accession_id in objects:

--- a/tests/integration/test_publications.py
+++ b/tests/integration/test_publications.py
@@ -6,8 +6,8 @@ from tests.integration.helpers import (
     create_request_json_data,
     post_object_json,
     publish_submission,
-    put_submission_dac,
     put_submission_doi,
+    put_submission_rems,
 )
 
 LOG = logging.getLogger(__name__)
@@ -26,8 +26,8 @@ class TestMinimalJsonPublication:
         await post_object_json(client_logged_in, "study", submission_fega, "SRP000539.json")
         doi_data_raw = await create_request_json_data("doi", "test_doi.json")
         await put_submission_doi(client_logged_in, submission_fega, doi_data_raw)
-        dac_data = await create_request_json_data("dac", "dac_rems.json")
-        await put_submission_dac(client_logged_in, submission_fega, dac_data)
+        rems_data = await create_request_json_data("dac", "dac_rems.json")
+        await put_submission_rems(client_logged_in, submission_fega, rems_data)
 
         await publish_submission(client_logged_in, submission_fega)
 
@@ -54,8 +54,8 @@ class TestMinimalJsonPublicationRems:
         doi_data_raw = await create_request_json_data("doi", "test_doi.json")
         await put_submission_doi(client_logged_in, submission_fega, doi_data_raw)
 
-        dac_data = await create_request_json_data("dac", "dac_rems.json")
-        await put_submission_dac(client_logged_in, submission_fega, dac_data)
+        rems_data = await create_request_json_data("dac", "dac_rems.json")
+        await put_submission_rems(client_logged_in, submission_fega, rems_data)
 
         await publish_submission(client_logged_in, submission_fega)
 
@@ -69,8 +69,8 @@ class TestMinimalJsonPublicationRems:
             LOG.debug(f"Checking that dataset {ds_id} in submission {submission_fega} has rems data")
             res = await resp.json()
             assert res["accessionId"] == ds_id, "expected dataset id does not match"
-            assert "dac" in res
-            assert res["dac"]["workflowId"] == 1
-            assert res["dac"]["organizationId"] == "CSC"
-            assert "resourceId" in res["dac"]
-            assert "catalogueId" in res["dac"]
+            assert "rems" in res, "expected rems field not found in dataset"
+            assert res["rems"]["workflowId"] == 1, "expected workflowId does not match"
+            assert res["rems"]["organizationId"] == "CSC", "expected organizationId does not match"
+            assert "resourceId" in res["rems"], "expected resourceId not found in rems field"
+            assert "catalogueId" in res["rems"], "expected catalogueId not found in rems field"

--- a/tests/integration/test_submissions.py
+++ b/tests/integration/test_submissions.py
@@ -27,8 +27,8 @@ from tests.integration.helpers import (
     post_object_json,
     post_submission,
     publish_submission,
-    put_submission_dac,
     put_submission_doi,
+    put_submission_rems,
     submissions_url,
 )
 
@@ -307,8 +307,8 @@ class TestSubmissionOperations:
 
         ds_2 = await post_object(client_logged_in, "dataset", submission_fega, "dataset_put.xml")
 
-        dac_data = await create_request_json_data("dac", "dac_rems.json")
-        await put_submission_dac(client_logged_in, submission_fega, dac_data)
+        rems_data = await create_request_json_data("dac", "dac_rems.json")
+        await put_submission_rems(client_logged_in, submission_fega, rems_data)
 
         await post_object_json(client_logged_in, "run", submission_fega, "ERR000076.json")
 
@@ -329,6 +329,7 @@ class TestSubmissionOperations:
             assert "extraInfo" in res.keys()
             assert res["drafts"] == [], "there are drafts in submission, expected empty"
             assert len(res["metadataObjects"]) == 5, "submission metadataObjects content mismatch"
+            assert "rems" in res.keys(), "submission does not have rems dac data"
 
         # Check that submission info and its objects cannot be updated and that publishing it again fails
         async with client_logged_in.patch(
@@ -355,8 +356,8 @@ class TestSubmissionOperations:
         async with client_logged_in.put(f"{submissions_url}/{submission_fega}/doi", data=doi_data_raw) as resp:
             LOG.debug("Trying to replace submission doi")
             assert resp.status == 405, f"HTTP Status code error {resp.status} {ans}"
-        async with client_logged_in.put(f"{submissions_url}/{submission_fega}/dac", data=dac_data) as resp:
-            LOG.debug("Trying to replace submission dac")
+        async with client_logged_in.put(f"{submissions_url}/{submission_fega}/rems", data=rems_data) as resp:
+            LOG.debug("Trying to replace submission rems")
             assert resp.status == 405, f"HTTP Status code error {resp.status} {ans}"
 
         # Check new drafts or objects cannot be added under published submission
@@ -568,8 +569,8 @@ class TestSubmissionPagination:
             await post_object_json(client_logged_in, "study", submission_fega, "SRP000539.json")
             doi_data_raw = await create_request_json_data("doi", "test_doi.json")
             await put_submission_doi(client_logged_in, submission_fega, doi_data_raw)
-            dac_data = await create_request_json_data("dac", "dac_rems.json")
-            await put_submission_dac(client_logged_in, submission_fega, dac_data)
+            rems_data = await create_request_json_data("dac", "dac_rems.json")
+            await put_submission_rems(client_logged_in, submission_fega, rems_data)
             await publish_submission(client_logged_in, submission_fega)
 
         # Test default values

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -29,8 +29,8 @@ from tests.integration.helpers import (
     post_submission,
     post_template_json,
     publish_submission,
-    put_submission_dac,
     put_submission_doi,
+    put_submission_rems,
 )
 
 LOG = logging.getLogger(__name__)
@@ -135,8 +135,8 @@ class TestUsers:
         doi_data_raw = await create_request_json_data("doi", "test_doi.json")
         await put_submission_doi(client_logged_in, publish_submission_id, doi_data_raw)
 
-        dac_data = await create_request_json_data("dac", "dac_rems.json")
-        await put_submission_dac(client_logged_in, publish_submission_id, dac_data)
+        rems_data = await create_request_json_data("dac", "dac_rems.json")
+        await put_submission_rems(client_logged_in, publish_submission_id, rems_data)
 
         # add a study and dataset for publishing a submission
         await post_object_json(client_logged_in, "study", publish_submission_id, "SRP000539.json")


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
Separated this task from the other tasks given in #588 for less chaotic reviewing. So this just refactors the naming scheme of the `dac` field in the `submission` object to `rems`.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
Partially fixes #588 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Breaking change (probably for front-end, considering the endpoint name is altered)

### Changes Made

<!-- List changes made. -->
- change the `submission` schema
- change the PUT endpoint name to `/v1/submission/rems`
- modify existing integration tests
- edit openapi specs

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Integration Tests

